### PR TITLE
Jamakase/kratos browser url

### DIFF
--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -330,6 +330,7 @@ The following table lists configurable parameters of the chart and their default
 | kratos.image.repository | string | `"oryd/kratos"` |  |
 | kratos.image.tag | string | `"v1.3.1"` |  |
 | kratos.urls.public | string | `""` |  |
+| kratos.urls.publicBrowser | string | `""` |  |
 | kratos.urls.admin | string | `""` |  |
 | kratos.database.name | string | `"kratos"` |  |
 | kratos.configMapOverrideName | string | `""` |  |

--- a/charts/agentarea/config.yaml
+++ b/charts/agentarea/config.yaml
@@ -68,7 +68,7 @@ groups:
       API_URL: '{{ include "agentarea.backend.url" . }}'
       ORY_ADMIN_URL: '{{ include "agentarea.kratosAdminUrl" . }}'
       ORY_SDK_URL: '{{ include "agentarea.kratosPublicUrl" . }}'
-      NEXT_PUBLIC_ORY_SDK_URL: '{{ include "agentarea.kratosPublicUrl" . }}'
+      NEXT_PUBLIC_ORY_SDK_URL: '{{ include "agentarea.kratosPublicBrowserUrl" . }}'
       METRICS_ENABLED: '{{ .Values.global.monitoring.prometheus.enabled }}'
       HEALTH_CHECK_ENABLED: '{{ .Values.global.monitoring.health.enabled }}'
 

--- a/charts/agentarea/templates/_helpers.tpl
+++ b/charts/agentarea/templates/_helpers.tpl
@@ -87,6 +87,13 @@ Kratos Public URL
 {{- end -}}
 
 {{/*
+Kratos Public Browser URL (for client-side JS, falls back to kratosPublicUrl)
+*/}}
+{{- define "agentarea.kratosPublicBrowserUrl" -}}
+{{- .Values.kratos.urls.publicBrowser | default (include "agentarea.kratosPublicUrl" .) | trimSuffix "/" -}}
+{{- end -}}
+
+{{/*
 Kratos Admin URL
 */}}
 {{- define "agentarea.kratosAdminUrl" -}}

--- a/charts/agentarea/templates/configs/frontend.env.tpl
+++ b/charts/agentarea/templates/configs/frontend.env.tpl
@@ -9,7 +9,7 @@ NODE_ENV: "production"
 API_URL: "{{ include "agentarea.backend.url" . }}"
 ORY_ADMIN_URL: "{{ include "agentarea.kratosAdminUrl" . }}"
 ORY_SDK_URL: "{{ include "agentarea.kratosPublicUrl" . }}"
-NEXT_PUBLIC_ORY_SDK_URL: "{{ include "agentarea.kratosPublicUrl" . }}"
+NEXT_PUBLIC_ORY_SDK_URL: "{{ include "agentarea.kratosPublicBrowserUrl" . }}"
 METRICS_ENABLED: "{{ .Values.global.monitoring.prometheus.enabled }}"
 HEALTH_CHECK_ENABLED: "{{ .Values.global.monitoring.health.enabled }}"
 {{- end }}

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -620,6 +620,7 @@ kratos:
   # If not set, these default to internal Kubernetes service DNS names
   urls:
     public: "" # e.g. https://auth.example.com
+    publicBrowser: "" # Browser-facing URL, defaults to public. Set when pods can't resolve the public domain (e.g. Tailscale)
     admin: ""  # e.g. http://kratos-admin.internal
   
   database:


### PR DESCRIPTION
This pull request updates how the frontend receives the public URL for Ory Kratos, allowing for a browser-facing URL to be specified separately from the internal service URL. This is particularly useful in environments where pods cannot resolve the public domain, such as when using Tailscale. The changes add support for a new `publicBrowser` URL value and update relevant templates to use it.

Kratos Public Browser URL support:

* Added `publicBrowser` field to `kratos.urls` in `values.yaml`, allowing specification of a browser-facing URL for Ory Kratos.
* Introduced the `agentarea.kratosPublicBrowserUrl` helper template, which falls back to `kratosPublicUrl` if `publicBrowser` is not set.

Frontend environment configuration updates:

* Updated `NEXT_PUBLIC_ORY_SDK_URL` in `frontend.env.tpl` and `config.yaml` to use the new `kratosPublicBrowserUrl` helper, ensuring the frontend receives the correct browser-accessible URL. [[1]](diffhunk://#diff-1eb2240216bde2493696beede92e786bd2ab456a4c2cb1b11e90e86304ef1209L12-R12) [[2]](diffhunk://#diff-2cd18bb27a0026cb151ec645370269e657539cceddf419ee5ae375b995c1cfe7L71-R71)