### PR TITLE
fix(api): resolve Alembic multiple heads migration failure

### DIFF
--- a/agentarea-platform/apps/api/alembic/versions/58940c431605_merge_latest_heads.py
+++ b/agentarea-platform/apps/api/alembic/versions/58940c431605_merge_latest_heads.py
@@ -1,0 +1,29 @@
+"""merge latest heads
+
+Revision ID: 58940c431605
+Revises: 010_add_a2ui_enabled, gg2_add_wallet_fk_cascades, jj1_docker_url_nullable
+Create Date: 2026-04-01 11:12:27.259186
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "58940c431605"
+down_revision: str | None = (
+    "010_add_a2ui_enabled",
+    "gg2_add_wallet_fk_cascades",
+    "jj1_docker_url_nullable",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- add a new Alembic merge revision to unify active migration heads
- resolve migration startup failure: "The script directory has multiple heads"
- keep existing migration history intact (no revision rewrites)

## Details
This PR adds 58940c431605_merge_latest_heads.py under apps/api/alembic/versions.
The merge revision joins:
- 010_add_a2ui_enabled
- gg2_add_wallet_fk_cascades
- jj1_docker_url_nullable

After this change, alembic heads reports a single head.

## Validation
- Ran alembic heads and confirmed one head remains.
