### PR TITLE
fix(ui): widen provider config form layout

### DIFF
--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/create/components/ProviderConfigFormWrapper.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/create/components/ProviderConfigFormWrapper.tsx
@@ -40,7 +40,7 @@ export default async function ProviderConfigFormWrapper({
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl">
+    <div className="mx-auto w-full">
       <ProviderConfigForm
         preselectedProviderId={preselectedProviderId}
         isEdit={isEdit}

--- a/agentarea-webapp/src/components/ProviderConfigForm/ProviderConfigForm.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/ProviderConfigForm.tsx
@@ -508,7 +508,7 @@ export default function ProviderConfigForm({
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
-      <div className={cn("mx-auto", isClear ? "max-w-xl" : "max-w-4xl")}>
+      <div className={cn("mx-auto", "max-w-4xl")}>
         <div
           className={cn(
             "grid grid-cols-1 form-content",


### PR DESCRIPTION
## Summary
- Remove double `max-w` constraint on provider config form wrapper and form itself
- Form now consistently uses `max-w-4xl` regardless of `isClear` mode, giving the enriched model table (costs, capabilities, token columns) room to render properly

## Test plan
- [ ] Open provider config create page — form should be wider
- [ ] Open provider config edit page — same wider layout
- [ ] Model table columns (Context, Max Output, Input $/1M, Output $/1M, Capabilities) should not be cramped