### PR TITLE
fix: sync Go version constants in bump-version script

### DIFF
--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -108,6 +108,25 @@ def main():
     except subprocess.CalledProcessError as e:
         print(f"⚠️  Warning: Failed to update Chart.yaml appVersion: {e.stderr}")
 
+    # Update Go version constants
+    go_version_files = [
+        root_dir / 'agentarea-mcp-manager' / 'cmd' / 'mcp-manager' / 'main.go',
+        root_dir / 'agentarea-event-service' / 'cmd' / 'server' / 'main.go',
+    ]
+
+    for go_file in go_version_files:
+        if go_file.exists():
+            content = go_file.read_text()
+            updated = re.sub(
+                r'const version = "[^"]*"',
+                f'const version = "{new_version}"',
+                content
+            )
+
+            if updated != content:
+                go_file.write_text(updated)
+                print(f"✅ Updated {go_file.relative_to(root_dir)}")
+
     print(f"\n✅ All versions bumped to {new_version}")
 
 if __name__ == '__main__':

--- a/scripts/verify-version-sync.sh
+++ b/scripts/verify-version-sync.sh
@@ -56,10 +56,12 @@ GO_VERSION_FILES=(
 for file in "${GO_VERSION_FILES[@]}"; do
   if [ -f "$file" ]; then
     GO_VERSION=$(grep 'const version = ' "$file" | sed 's/const version = "\(.*\)"/\1/')
+    REL_PATH=$(realpath --relative-to="$PROJECT_ROOT" "$file" 2>/dev/null || echo "$file")
     if [ "$GO_VERSION" != "$EXPECTED_VERSION" ]; then
-      REL_PATH=$(realpath --relative-to="$PROJECT_ROOT" "$file" 2>/dev/null || echo "$file")
       echo "❌ $REL_PATH: $GO_VERSION (expected: $EXPECTED_VERSION)"
       ERRORS=$((ERRORS + 1))
+    else
+      echo "✅ $REL_PATH: $GO_VERSION"
     fi
   fi
 done


### PR DESCRIPTION
## Summary

- `scripts/bump-version.py` was updating pyproject.toml / package.json / Chart.yaml / .bumpversion.yaml but **skipping the two Go version constants** (`agentarea-mcp-manager/cmd/mcp-manager/main.go` and `agentarea-event-service/cmd/server/main.go`).
- The new post-bump `verify-version-sync.sh` check (added in #125) correctly flagged the drift, causing the last `prepare-and-bump` run to fail with Go files still at 0.0.8 while VERSION was bumped to 0.0.9.
- `.bumpversion.yaml` already lists these Go files, and the emergency `sync-versions.py` script already handled them — only the primary `bump-version.py` was missing the logic.
- Also tidied `verify-version-sync.sh` to emit a success line for passing Go files (consistent with every other check in that script).

## Test plan

- [x] Ran `python3 scripts/bump-version.py patch` locally against a 0.0.8 tree — both Go constants bumped to 0.0.9
- [x] Ran `bash scripts/verify-version-sync.sh` after the bump — all five targets report synced
- [ ] Re-run the "Prepare Release" workflow to confirm the `prepare-and-bump` job passes end-to-end