### PR TITLE
ci(release): build-once, promote-on-tag Docker release flow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -137,7 +137,6 @@ jobs:
         with:
           images: ${{ steps.image.outputs.images }}
           tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=${{ steps.version.outputs.version }}-{{sha}}
           flavor: |
             latest=false

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -126,8 +126,14 @@ jobs:
           - [ ] Verify all package versions are updated correctly
           - [ ] Add release notes to CHANGELOG (if applicable)
           - [ ] If chart configs changed, bump chart version independently
-          - [ ] Merge this PR to trigger automated build and publish
+          - [ ] Merge this PR — ci.yml will build `<version>-<sha>` Docker images
+          - [ ] After ci.yml is green, run `./scripts/release.sh` locally to tag the release
 
-          **Note:** Merging this PR will automatically trigger the release pipeline to build Docker images, publish Helm charts, and create a Git tag.
+          **Note:** Merging this PR does **not** automatically publish the release.
+          It only bumps versions and triggers ci.yml to build `<version>-<sha>`
+          Docker images. To publish the release (retag images as `<version>`,
+          create git tag and GitHub Release), run `./scripts/release.sh` from
+          your local checkout of main after the PR is merged and ci.yml is green.
+          The release-publish workflow also publishes the Helm chart.
           EOF
           )"

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,108 +1,82 @@
 name: Publish Release
 
+# Triggered by push of a semver tag `vX.Y.Z`.
+# Does NOT rebuild images. Retags existing `<version>-<sha>` artifacts (pushed by
+# ci.yml on merge to main) with immutable semver tags `<version>`, `<maj.min>`,
+# `<maj>`, and the mutable `latest`. Then creates a GitHub Release.
+#
+# Preconditions (enforced by scripts/release.sh and re-checked here):
+#   - Tag name is `vX.Y.Z` (semver)
+#   - VERSION file at tag commit == X.Y.Z
+#   - ci.yml has produced images `agentarea-<component>:X.Y.Z-<short_sha>` on DockerHub
+
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
 
 jobs:
-  check-release:
+  verify:
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/') &&
-      contains(github.event.pull_request.labels.*.name, 'release')
     outputs:
-      is_release: ${{ steps.check.outputs.is_release }}
-      version: ${{ steps.extract-version.outputs.version }}
-    steps:
-      - name: Check release conditions
-        id: check
-        run: echo "is_release=true" >> $GITHUB_OUTPUT
-
-      - uses: actions/checkout@v4
-        with:
-          ref: main  # Ensure we're on merged main
-
-      - name: Read version from VERSION file
-        id: extract-version
-        run: |
-          VERSION=$(cat VERSION | tr -d '[:space:]')
-          VERSION_TAG="v${VERSION}"
-          echo "version=${VERSION_TAG}" >> $GITHUB_OUTPUT
-          echo "app_version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Releasing version: ${VERSION_TAG}"
-
-      - name: Verify version synchronization
-        run: |
-          bash scripts/verify-version-sync.sh
-
-  create-tag:
-    runs-on: ubuntu-latest
-    needs: check-release
-    if: needs.check-release.outputs.is_release == 'true'
-    permissions:
-      contents: write
+      version: ${{ steps.parse.outputs.version }}
+      major: ${{ steps.parse.outputs.major }}
+      major_minor: ${{ steps.parse.outputs.major_minor }}
+      short_sha: ${{ steps.parse.outputs.short_sha }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Create and push tag
+      - name: Parse tag and verify VERSION sync
+        id: parse
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ needs.check-release.outputs.version }}" -m "Release ${{ needs.check-release.outputs.version }}"
-          git push origin "${{ needs.check-release.outputs.version }}"
+          set -euo pipefail
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG_NAME#v}"
 
-      - name: Create GitHub Release
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: '${{ needs.check-release.outputs.version }}',
-              name: 'Release ${{ needs.check-release.outputs.version }}',
-              body: 'Release ${{ needs.check-release.outputs.version }}\n\nSee [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.',
-              draft: false,
-              prerelease: false
-            });
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag $TAG_NAME does not match vX.Y.Z semver"
+            exit 1
+          fi
 
-  build-and-push:
+          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          if [ "$FILE_VERSION" != "$VERSION" ]; then
+            echo "::error::VERSION file ($FILE_VERSION) does not match tag ($VERSION)"
+            exit 1
+          fi
+
+          bash scripts/verify-version-sync.sh
+
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+          {
+            echo "version=$VERSION"
+            echo "major=$MAJOR"
+            echo "major_minor=$MAJOR.$MINOR"
+            echo "short_sha=$SHORT_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+  retag:
     runs-on: ubuntu-latest
-    needs: [check-release, create-tag]
-    if: needs.check-release.outputs.is_release == 'true'
-    permissions:
-      packages: write
+    needs: verify
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - name: api
-            context: agentarea-platform
-            file: agentarea-platform/apps/api/Dockerfile
-          - name: worker
-            context: agentarea-platform
-            file: agentarea-platform/apps/worker/Dockerfile
-          - name: frontend
-            context: agentarea-webapp
-            file: agentarea-webapp/Dockerfile
-          - name: bootstrap
-            context: .
-            file: agentarea-bootstrap/Dockerfile
-          - name: mcp-manager
-            context: agentarea-mcp-manager
-            file: agentarea-mcp-manager/Dockerfile
-          - name: mcp-runner
-            context: agentarea-mcp-manager
-            file: agentarea-mcp-manager/Dockerfile.runner
-
+        component:
+          - api
+          - worker
+          - frontend
+          - bootstrap
+          - mcp-manager
+          - mcp-runner
+          - events
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -112,60 +86,75 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Log in to Private Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.DOCKER_REGISTRY_MIRROR }}
-          username: ${{ secrets.DOCKER_REGISTRY_MIRROR_USERNAME }}
-          password: ${{ secrets.DOCKER_REGISTRY_MIRROR_PASSWORD }}
-
-      - name: Get commit SHA
-        id: sha
+      - name: Wait for source image
+        env:
+          IMAGE: agentarea/agentarea-${{ matrix.component }}
+          SRC_TAG: ${{ needs.verify.outputs.version }}-${{ needs.verify.outputs.short_sha }}
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          # ci.yml may still be building the same commit; retry up to 15 minutes.
+          for i in $(seq 1 30); do
+            if docker buildx imagetools inspect "${IMAGE}:${SRC_TAG}" >/dev/null 2>&1; then
+              echo "Source image ${IMAGE}:${SRC_TAG} available"
+              exit 0
+            fi
+            echo "Attempt $i/30: ${IMAGE}:${SRC_TAG} not yet available, sleeping 30s..."
+            sleep 30
+          done
+          echo "::error::Source image ${IMAGE}:${SRC_TAG} not found after 15 minutes. Did ci.yml succeed for this commit?"
+          exit 1
 
-      - name: Extract version components
-        id: version-parts
+      - name: Retag to release tags
+        env:
+          IMAGE: agentarea/agentarea-${{ matrix.component }}
+          SRC_TAG: ${{ needs.verify.outputs.version }}-${{ needs.verify.outputs.short_sha }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          MAJOR_MINOR: ${{ needs.verify.outputs.major_minor }}
+          MAJOR: ${{ needs.verify.outputs.major }}
         run: |
-          VERSION="${{ needs.check-release.outputs.version }}"
-          # Remove 'v' prefix if present
-          VERSION="${VERSION#v}"
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${VERSION}" \
+            --tag "${IMAGE}:${MAJOR_MINOR}" \
+            --tag "${IMAGE}:${MAJOR}" \
+            --tag "${IMAGE}:latest" \
+            "${IMAGE}:${SRC_TAG}"
 
-          # Extract major, minor, patch
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3 | cut -d- -f1)
+          echo "Retagged ${IMAGE}:${SRC_TAG} -> ${VERSION}, ${MAJOR_MINOR}, ${MAJOR}, latest"
 
-          echo "major=${MAJOR}" >> $GITHUB_OUTPUT
-          echo "minor=${MINOR}" >> $GITHUB_OUTPUT
-          echo "patch=${PATCH}" >> $GITHUB_OUTPUT
-          echo "version_clean=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_OUTPUT
-          echo "major_minor=${MAJOR}.${MINOR}" >> $GITHUB_OUTPUT
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
+  release:
+    runs-on: ubuntu-latest
+    needs: [verify, retag]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
         with:
-          images: |
-            agentarea/agentarea-${{ matrix.name }}
-            ${{ secrets.DOCKER_REGISTRY_MIRROR }}/agentarea/agentarea-${{ matrix.name }}
-          tags: |
-            type=raw,value=${{ steps.version-parts.outputs.version_clean }}-${{ steps.sha.outputs.short_sha }}
-            type=raw,value=${{ steps.version-parts.outputs.version_clean }}
-            type=raw,value=${{ steps.version-parts.outputs.major_minor }}-${{ steps.sha.outputs.short_sha }}
-            type=raw,value=${{ steps.version-parts.outputs.major_minor }}
-            type=raw,value=${{ steps.version-parts.outputs.major }}-${{ steps.sha.outputs.short_sha }}
-            type=raw,value=${{ steps.version-parts.outputs.major }}
-            type=raw,value=latest
+          fetch-depth: 0
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=agentarea/agentarea-${{ matrix.name }}:buildcache
-          cache-to: type=registry,ref=agentarea/agentarea-${{ matrix.name }}:buildcache,mode=max
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(git describe --tags --abbrev=0 --match='v*' "${TAG}^" 2>/dev/null || echo "")
+
+          NOTES_FILE=$(mktemp)
+          if [ -n "$PREV_TAG" ]; then
+            {
+              echo "## Changes since $PREV_TAG"
+              echo ""
+              git log "${PREV_TAG}..${TAG}" --pretty=format:'- %s (%an)' --no-merges
+            } > "$NOTES_FILE"
+          else
+            {
+              echo "## Changes"
+              echo ""
+              git log "${TAG}" --pretty=format:'- %s (%an)' --no-merges | head -n 50
+            } > "$NOTES_FILE"
+          fi
+
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --notes-file "$NOTES_FILE"

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,402 +1,256 @@
-# Version Management
+# Versioning and Releases
 
-AgentArea uses a **VERSION-first architecture** for application versioning with **independent chart versioning** for Helm charts.
+AgentArea uses a **build-once / promote-on-tag** release model:
+
+- **ci.yml** builds immutable per-commit Docker images on every merge to `main`.
+- **release-publish.yaml** never rebuilds. On a semver git tag (`vX.Y.Z`), it **retags** an already-built image with the stable release tags and creates the GitHub Release.
+- **release-helm.yml** publishes the Helm chart on the same tag push.
+
+A local script, `scripts/release.sh`, validates pre-conditions and pushes the tag.
 
 ## Version Architecture
 
 ```
-VERSION file (0.0.3) - Single source of truth for application version
-    ├─> Git tags (v0.0.3)
-    ├─> Docker images (0.0.3-abc1234, 0.0.3, 0.0, 0, latest)
-    ├─> Python packages (version = "0.0.3" in pyproject.toml)
-    ├─> Node packages (version: "0.0.3" in package.json)
-    └─> Helm chart appVersion ("0.0.3")
+VERSION file (0.0.8) — single source of truth for application version
+    ├─> Git tags              (v0.0.8)
+    ├─> Docker images         (0.0.8-abc1234, 0.0.8, 0.0, 0, latest)
+    ├─> Python packages       (pyproject.toml version)
+    ├─> Node packages         (package.json version)
+    ├─> Go constants          (mcp-manager, event-service main.go)
+    └─> Helm appVersion       (charts/agentarea/Chart.yaml appVersion)
 
-Chart.yaml version (0.0.1) - Independent chart version
-    └─> Helm chart packages (0.0.1)
+Chart.yaml version (0.0.1) — independent chart version
+    └─> Helm chart packages   (bumped by release-helm.yml on tag push)
 ```
 
-## Key Concepts
-
 ### Application Version (VERSION file)
-- **Location**: `VERSION` file at project root
-- **Purpose**: Tracks the version of the application code (API, worker, frontend, etc.)
-- **Managed by**: `scripts/bump-version.py` (custom Python script)
-- **Synchronized to**: All pyproject.toml files, package.json, Chart.yaml appVersion, .bumpversion.yaml
 
-### Chart Version (Chart.yaml)
-- **Location**: `charts/agentarea/Chart.yaml` (`version` field)
-- **Purpose**: Tracks the version of the Helm chart configuration
-- **Managed by**: Manual edits to Chart.yaml
-- **Independent**: Does NOT follow application version
+- **Location:** `VERSION` at repo root.
+- **Purpose:** Single source of truth for the application's version.
+- **Managed by:** `scripts/bump-version.py` via the `Prepare Release` workflow.
+- **Propagated to:** all `pyproject.toml`, `package.json`, `Chart.yaml` appVersion, `.bumpversion.yaml`, Go `const version` in `agentarea-mcp-manager` and `agentarea-event-service`.
 
-### Why Independent Chart Versioning?
+### Chart Version (Chart.yaml `version`)
 
-Chart versions should be bumped independently when:
-- Chart templates change (new resources, configuration options)
-- Chart dependencies update (PostgreSQL, Redis versions)
-- Chart values.yaml structure changes
-- Chart installation/upgrade logic changes
-
-Chart versions should NOT be bumped when:
-- Only application code changes (API, worker, frontend)
-- Docker image versions update
-- Application version changes
+- **Location:** `charts/agentarea/Chart.yaml` `version` field.
+- **Bumped automatically** by `release-helm.yml` on every `v*` tag push (patch by default; manual dispatch lets you choose patch/minor/major).
+- Independent of application version. **Do not edit manually.**
 
 ## Docker Image Tags
 
-AgentArea uses a **GitLab-inspired tagging strategy** that combines semantic versioning with commit SHA tracking for full traceability.
+### What gets pushed when
 
-### Stable Releases
+| Event | Workflow | Tags pushed for each of 7 components |
+|---|---|---|
+| Merge to `main` | `ci.yml` → `docker-build-push.yml` | `<version>-<sha>` (e.g. `0.0.8-a8eaf7b`) — immutable |
+| Git tag push `vX.Y.Z` | `release-publish.yaml` | `<version>`, `<maj.min>`, `<maj>`, `latest` — all pointing to the **same digest** as `<version>-<sha>` (retag, no rebuild) |
 
-When a release is published (e.g., `v0.0.3`), Docker images are tagged with:
+### Tag semantics
 
-- `0.0.3-abc1234` - **Immutable**: Specific version + commit SHA (recommended for production)
-- `0.0.3` - **Mutable**: Specific patch version
-- `0.0-abc1234` - **Rolling with SHA**: Latest patch in 0.0.x series with commit SHA
-- `0.0` - **Rolling minor**: Always points to latest patch in 0.0.x series
-- `0-abc1234` - **Rolling with SHA**: Latest minor in 0.x.x series with commit SHA
-- `0` - **Rolling major**: Always points to latest minor in 0.x.x series
-- `latest` - **Latest stable**: Always points to most recent stable release
+- `0.0.8-a8eaf7b` — **Immutable per-commit.** Built once by ci.yml. Safe to pin in prod.
+- `0.0.8` — **Immutable semver.** Created once by release-publish on tag `v0.0.8`. Points to the same digest as the `<version>-<sha>` of that commit. **Never overwritten.**
+- `0.0` — **Rolling minor.** Moves forward to the latest `0.0.x` release.
+- `0` — **Rolling major.** Moves forward to the latest `0.x.y` release.
+- `latest` — Always points to the most recent release.
 
-### Pre-Release Tags (Docker Only)
+### Tag usage guidelines
 
-Pre-release tags are applied at the Docker image level, NOT in the application version:
+| Use case | Tag | Why |
+|---|---|---|
+| Production pin | `0.0.8-a8eaf7b` | Fully traceable, guaranteed not to change |
+| Production (auto patch) | `0.0` | Gets patch-level fixes automatically |
+| Staging | `0.0.8-<latest-main-sha>` | Test unreleased main builds |
+| "Show me the latest" | `latest` | Most recent release |
 
-- Application version stays stable: `0.0.3`
-- Docker tags for RC testing: `0.0.3-rc.1`, `0.0.3-rc.2`, `0.0.3-rc.1-abc1234`
-- Docker tags for beta: `0.0.3-beta.1`, `0.0.3-beta.1-abc1234`
+### Components
 
-**Note:** The VERSION file and all package versions always contain stable versions only (e.g., `0.0.3`). Pre-release identifiers are added as Docker image tags for deployment testing purposes.
+Seven Docker images are published:
 
-### Main Branch Builds
+`api`, `worker`, `frontend`, `bootstrap`, `mcp-manager`, `mcp-runner`, `events`
 
-Commits to the `main` branch automatically build and tag images as:
+### Registry
 
-- `0.0.3-abc1234` - Current version from VERSION file + commit SHA
-- `0.0.3` - Current version from VERSION file (mutable)
-
-Note: `dev`, `commit-*`, and branch-based tags have been removed in favor of version+SHA tags.
-
-### Tag Usage Guidelines
-
-| Use Case | Recommended Tag | Why |
-|----------|----------------|-----|
-| **Production** | `0.0.3-abc1234` | Immutable, fully traceable, guaranteed not to change |
-| **Production (rolling)** | `0.0` | Always get latest patch fixes in 0.0.x |
-| **Staging** | `0.0.4-rc.1` | Test release candidates before production |
-| **Development** | `0` | Bleeding edge, always latest version |
-| **Pinned version** | `0.0.3` | Specific patch, but may be rebuilt |
-
-### Examples
-
-```yaml
-# Production deployment (Helm values.yaml)
-# Pin to exact version+SHA for immutability
-image:
-  repository: agentarea/agentarea-api
-  tag: "0.0.3-abc1234"
-
-# Production with automatic patch updates
-# Get security fixes automatically
-image:
-  repository: agentarea/agentarea-api
-  tag: "0.0"
-
-# Staging/Testing with release candidate
-image:
-  repository: agentarea/agentarea-api
-  tag: "0.0.4-rc.1"
-
-# Development with latest version
-image:
-  repository: agentarea/agentarea-api
-  tag: "0"
-```
-
-### Docker Registries
-
-All images are pushed to:
-- **Docker Hub**: `agentarea/agentarea-{component}`
-- **Private Registry**: Configured via GitHub secrets (for releases and main branch builds)
-
-Components: `api`, `worker`, `frontend`, `bootstrap`, `mcp-manager`
+All images go to Docker Hub: `agentarea/agentarea-<component>`.
 
 ## Release Process
 
-### 1. Prepare Release (Bump Application Version)
+### 1. Prepare Release (bump VERSION)
 
-Trigger the `Prepare Release` workflow with desired bump type:
+Via GitHub UI: **Actions → "Prepare Release" → Run workflow** → select `patch`/`minor`/`major`.
 
-```bash
-# Via GitHub UI: Actions → Prepare Release → Run workflow
-# Select release type: patch, minor, or major
-```
+The `release-prepare.yaml` workflow:
+1. Runs CI validation (lints, tests, build).
+2. Runs `scripts/bump-version.py <type>` — bumps VERSION and propagates to all version files.
+3. Creates branch `release/vX.Y.Z` and opens a PR labelled `release`.
 
-**Release Types:**
-- **patch**: Bug fixes (0.0.3 → 0.0.4)
-- **minor**: New features (0.0.3 → 0.1.0)
-- **major**: Breaking changes (0.0.3 → 1.0.0)
+**Release types:**
+- `patch` — bug fixes (0.0.8 → 0.0.9)
+- `minor` — new features, backward compatible (0.0.8 → 0.1.0)
+- `major` — breaking changes (0.0.8 → 1.0.0)
 
-**Note:** Application versions are always stable. For release candidate testing, use the same application version with Docker-specific RC tags (e.g., Docker tag `0.0.3-rc.1` with application version `0.0.3`).
+### 2. Review and merge the release PR
 
-This workflow:
-1. ✅ Verifies all versions are synchronized
-2. ⬆️ Runs `scripts/bump-version.py` with selected type
-3. 📝 Updates VERSION file and propagates to all package files
-4. 🎯 Syncs Chart.yaml `appVersion` (NOT `version`)
-5. ✅ Verifies synchronization after bump
-6. 📋 Creates release PR (e.g., `release/v0.0.4`)
+- Verify all version files updated.
+- Add release notes to `CHANGELOG.md` if you keep one.
+- Merge. The merge to `main` triggers `ci.yml`, which builds and pushes `0.0.9-<sha>` for all 7 components.
 
-**Note:** We use a custom Python script instead of `bumpversion` tool. Configuration is in `.bumpversion.yaml` (modern YAML format).
+**Merging the PR does not publish the release.** It only bumps versions and builds images.
 
-### 2. Review Release PR
+### 3. Publish the release with `scripts/release.sh`
 
-- Review changes in PR
-- Verify all version files updated correctly
-- **If chart configuration changed**: Manually bump chart version in `charts/agentarea/Chart.yaml`
-- Optionally add release notes to CHANGELOG
-
-### 3. Merge Release PR
-
-On merge to main:
-1. 🏷️ `release-publish` workflow creates git tag (e.g., `v0.0.4`)
-2. 🐳 Builds and pushes Docker images with version tag
-3. 📦 Tag push triggers `release-helm-oci` workflow
-4. 🚀 Helm chart published to GHCR
-
-### Dev/Test Releases (Helm Chart)
-
-For testing Helm charts without a full release:
+Once `ci.yml` is green on the release PR merge commit:
 
 ```bash
-# Via GitHub UI: Actions → Release Helm Chart to GHCR → Run workflow (manual dispatch)
+git checkout main
+git pull
+./scripts/release.sh
 ```
 
-This creates a dev version like:
-- Chart version: `0.0.1-dev.abc1234`
-- App version: `0.0.3-dev.abc1234`
+The script performs these checks before creating the tag:
 
-Dev versions can be redeployed (unlike official releases).
+1. Working tree is clean.
+2. On `main` (or confirms override).
+3. Local `main` is up-to-date with `origin/main`.
+4. `VERSION` contains a valid semver; tag `v<version>` doesn't already exist locally or on origin.
+5. `scripts/verify-version-sync.sh` passes (all version files agree).
+6. `ci.yml` is green on HEAD (via `gh` CLI).
+7. All 7 `agentarea-<component>:<version>-<sha>` images exist on Docker Hub.
+8. Shows a summary with commit list since the previous tag.
+9. Asks `y/N` confirmation.
+10. Creates an annotated tag `v<version>` and pushes it to origin.
 
-## Version Verification
-
-CI automatically verifies version synchronization on every push and PR:
+**Flags:**
 
 ```bash
-# Run locally to check:
-./scripts/verify-version-sync.sh
+./scripts/release.sh --dry-run        # run checks only, no tag/push
+./scripts/release.sh --skip-ci        # skip ci.yml green check (hotfixes)
+./scripts/release.sh --skip-images    # skip Docker Hub existence check
 ```
 
-This verifies:
-- ✅ .bumpversion.yaml current_version matches VERSION
-- ✅ All pyproject.toml files match VERSION
-- ✅ package.json matches VERSION
-- ✅ Chart.yaml appVersion matches VERSION
-- ℹ️ Chart.yaml version is NOT checked (independent)
+### 4. Automated: retag + GitHub Release + Helm chart
 
-## Manual Version Changes
+The tag push triggers two workflows in parallel:
 
-### Bump Application Version Locally
+**`release-publish.yaml`:**
+1. Validates tag matches VERSION on the tagged commit.
+2. For each of 7 components, waits for `<version>-<sha>` to appear in Docker Hub (retries up to 15 min if `ci.yml` is still running).
+3. Uses `docker buildx imagetools create` to add tags `<version>`, `<maj.min>`, `<maj>`, `latest` to the existing image. **No rebuild.** Same digest.
+4. Creates a GitHub Release with auto-generated notes from `git log <prev-tag>..HEAD`.
 
-⚠️ **Not recommended** - use the `Prepare Release` workflow instead.
+**`release-helm.yml`:**
+1. Bumps chart `version` (patch by default).
+2. Packages the chart and publishes to the `agentarea/helm-charts` repo.
 
-If you must bump locally:
+## TL;DR Release Checklist
 
-```bash
-# 1. Ensure versions are synchronized
-./scripts/verify-version-sync.sh
-
-# 2. Bump version (patch/minor/major)
-python3 scripts/bump-version.py patch  # or minor, or major
-
-# 3. Verify synchronization
-./scripts/verify-version-sync.sh
+```
+1. Actions → "Prepare Release" → patch/minor/major → run
+2. Review + merge the release PR
+3. Wait for ci.yml green
+4. Locally:  git pull && ./scripts/release.sh
+5. Confirm prompt → tag pushed → GitHub Release + Docker retag + Helm chart publish happen automatically
 ```
 
-The `bump-version.py` script automatically:
-- Updates VERSION file
-- Updates all pyproject.toml files
-- Updates package.json
-- Updates Chart.yaml appVersion
-- Updates .bumpversion.cfg
+## Key Invariants
 
-### Bump Chart Version Independently
+- `<version>` (bare semver) is **published exactly once**, via retag. It is never overwritten.
+- `<version>-<sha>` is built by `ci.yml` on every merge to main. Immutable per-commit.
+- `<version>-<sha>` and `<version>` on the release commit share the **same digest** — they are the exact same image under different tags.
+- `VERSION` always contains a stable semver (no `-rc`, `-beta`). Pre-release testing uses `<version>-<sha>` directly.
+- Chart `version` is owned by `release-helm.yml`; do not edit it manually.
 
-When chart configuration changes:
+## Why This Model
 
-```bash
-# 1. Edit charts/agentarea/Chart.yaml
-# Update the 'version' field (e.g., 0.0.1 -> 0.0.2)
+**Problem (before):** `ci.yml` pushed both `<version>` and `<version>-<sha>` on every merge to main. The bare `<version>` tag was overwritten on every merge, breaking immutability (prod and staging could both run `0.0.8` but be different images) and making rollback unreliable.
 
-# 2. Commit the change
-git add charts/agentarea/Chart.yaml
-git commit -m "chore(chart): bump chart version to 0.0.2"
-```
+**Fix:** `ci.yml` pushes only `<version>-<sha>`. Promotion to the stable `<version>` tag happens exactly once, via retag, when someone pushes a semver git tag. The image is never rebuilt — semver tag and dev tag are bit-identical.
 
-Chart version should follow semantic versioning:
-- **MAJOR**: Incompatible changes (breaking upgrades)
-- **MINOR**: New features (backwards-compatible)
-- **PATCH**: Bug fixes, small improvements
+## Verification
 
-## Helper Scripts
-
-### `scripts/bump-version.py`
-
-Bump application version across all files:
-
-```bash
-python3 scripts/bump-version.py patch   # 0.0.3 → 0.0.4
-python3 scripts/bump-version.py minor   # 0.0.3 → 0.1.0
-python3 scripts/bump-version.py major   # 0.0.3 → 1.0.0
-```
-
-This script:
-- Updates VERSION file with new version
-- Propagates to all pyproject.toml files
-- Updates package.json
-- Updates Chart.yaml appVersion
-- Updates .bumpversion.yaml
-- Used by the "Prepare Release" workflow
-
-### `scripts/get-version.sh`
-
-Read VERSION file in various formats:
-
-```bash
-./scripts/get-version.sh           # Returns: 0.0.3
-./scripts/get-version.sh --tag     # Returns: v0.0.3
-./scripts/get-version.sh --dev     # Returns: 0.0.3-dev.abc1234
-```
-
-### `scripts/verify-version-sync.sh`
-
-Verify all app versions are synchronized:
+Manual CI check anyone can run:
 
 ```bash
 ./scripts/verify-version-sync.sh
-# ✅ All versions synchronized to 0.0.3
 ```
 
-### `scripts/sync-versions.py`
+Verifies:
+- `.bumpversion.yaml` `current_version` matches VERSION
+- All `pyproject.toml` files match VERSION
+- `package.json` matches VERSION
+- `Chart.yaml` appVersion matches VERSION
+- Go `const version` matches VERSION (mcp-manager, event-service)
+- Chart `version` is **not** checked (intentionally independent)
 
-Emergency synchronization script (syncs to VERSION file):
-
-```bash
-python3 scripts/sync-versions.py
-# ✅ All versions synchronized to 0.0.3
-```
-
-Use this for emergency recovery when versions are out of sync.
-
-### `scripts/update-appversion.py`
-
-Sync Chart.yaml appVersion to VERSION file:
-
-```bash
-python3 scripts/update-appversion.py
-# ✅ Updated Chart appVersion to 0.0.3 (chart version unchanged)
-```
-
-Called automatically by bump-version.py.
+CI runs this on every push and PR via the `version-check` job in `ci.yml`.
 
 ## Troubleshooting
 
-### Versions Out of Sync
+### Versions out of sync
 
-**Symptom**: CI fails with "version mismatch" error
+`verify-version-sync.sh` or `ci.yml` fails with a mismatch.
 
-**Solution**:
 ```bash
-# Check current state
-./scripts/verify-version-sync.sh
-
-# Use sync script to fix
-python3 scripts/sync-versions.py
-
-# Verify fix
-./scripts/verify-version-sync.sh
+./scripts/verify-version-sync.sh     # see what's wrong
+python3 scripts/sync-versions.py     # force-sync everything to VERSION
+./scripts/verify-version-sync.sh     # confirm fixed
 ```
 
-### Git Tag Doesn't Match VERSION
+### `release.sh` says "tag already exists on origin"
 
-**Symptom**: Tag says v0.0.X but VERSION file says 0.0.Y
+Someone (or a prior run) already pushed `v<version>`. If you need to re-release the same version:
 
-**Solution**:
 ```bash
-# Delete wrong tag
-git tag -d v0.0.X
-git push origin :refs/tags/v0.0.X
+# Delete local + remote tag (destructive!)
+git tag -d v0.0.9
+git push origin :refs/tags/v0.0.9
 
-# Create correct tag
-git tag -a v$(cat VERSION) -m "Release v$(cat VERSION)"
-git push origin v$(cat VERSION)
+# Re-run
+./scripts/release.sh
 ```
 
-### Chart appVersion Not Synchronized
+Prefer bumping VERSION to a new patch instead of re-using a tag.
 
-**Symptom**: Chart.yaml appVersion doesn't match VERSION file
+### `release.sh` says images are missing in Docker Hub
 
-**Solution**:
+`ci.yml` hasn't finished building the release commit yet, or some component's build failed.
+
 ```bash
-# Sync appVersion to VERSION file
-python3 scripts/update-appversion.py
+# Check ci.yml status
+gh run list --workflow=ci.yml --commit $(git rev-parse HEAD)
 
-# Verify
-grep appVersion charts/agentarea/Chart.yaml
-cat VERSION
+# If still running: wait. If failed: fix, merge a new commit, re-run release.sh.
+# release-publish.yaml also retries up to 15 min, so in practice you can tag anyway.
 ```
 
-### Helm Dev Release Shows 0.0.0-dev
+### Helm dev release needs testing before a full release
 
-**Symptom**: Manual Helm chart release creates `0.0.0-dev.<sha>` instead of expected version
+Use manual dispatch on `release-helm.yml` via the Actions UI. That path is not covered by `release.sh`.
 
-**Cause**: This was the old behavior when workflow read from git tags
+### Hotfix on an older release
 
-**Solution**: This should no longer happen after the workflow update. The workflow now:
-- Reads chart version from Chart.yaml
-- Reads app version from VERSION file
-- Creates `<chart-version>-dev.<sha>` for dev releases
+```bash
+# Branch from the old tag
+git checkout -b hotfix/v0.0.8-fix v0.0.8
 
-If still happening, ensure you're using the updated `.github/workflows/release-helm-oci.yml`.
+# Fix the issue, bump VERSION to 0.0.9 (or whatever), commit
+python3 scripts/bump-version.py patch
+git commit -am "fix: critical bug, bump to 0.0.9"
 
-## Version History Example
-
-```
-Application Versions (from VERSION file):
-v0.0.1 → v0.0.2 → v0.0.3 → v0.0.4
-(Every app release bumps this)
-
-Chart Versions (from Chart.yaml):
-0.0.1 → 0.0.2 → 0.0.3
-(Only bumped when chart config changes)
-
-Example timeline:
-- v0.0.1 app released with chart 0.0.1
-- v0.0.2 app released with chart 0.0.1 (no chart changes)
-- v0.0.3 app released with chart 0.0.2 (chart had dependency update)
-- v0.0.4 app released with chart 0.0.2 (no chart changes)
+# Open a PR to a hotfix branch (not main, if main has moved on), merge it
+# After ci.yml builds images on the hotfix branch, run:
+./scripts/release.sh --skip-ci    # skip if ci.yml rules don't cover hotfix branches
 ```
 
-## Best Practices
+## Related Files
 
-1. ✅ **Always use the release workflow** for version bumps (not manual edits)
-2. ✅ **Verify synchronization** before and after version changes
-3. ✅ **Bump chart version** when chart configuration changes
-4. ✅ **Use dev releases** for testing Helm charts
-5. ❌ **Don't manually edit version files** (except Chart.yaml version)
-6. ❌ **Don't commit unsynchronized versions**
-7. ❌ **Don't skip version verification** in release PRs
-
-## Questions?
-
-- How do I bump the application version? → Use "Prepare Release" workflow
-- How do I bump the chart version? → Manually edit Chart.yaml
-- How do I test Helm chart changes? → Use manual dispatch of "Release Helm Chart to GHCR"
-- Why are versions out of sync? → Run `verify-version-sync.sh` to diagnose
-- Can I bump versions manually? → Not recommended, use workflows
-
-For more details, see:
-- `.bumpversion.cfg` - Application version configuration
-- `charts/agentarea/Chart.yaml` - Chart version and metadata
-- `.github/workflows/` - Release automation workflows
+- `VERSION` — source of truth
+- `scripts/bump-version.py` — bumps VERSION + all consumers
+- `scripts/release.sh` — pre-flight + tag push
+- `scripts/verify-version-sync.sh` — consistency check
+- `scripts/sync-versions.py` — emergency resync
+- `scripts/update-appversion.py` — sync Chart.yaml appVersion to VERSION
+- `scripts/bump-chart-version.py` — chart version bumper (used by release-helm.yml)
+- `.github/workflows/release-prepare.yaml` — opens release PR
+- `.github/workflows/ci.yml` → `docker-build-push.yml` — builds `<version>-<sha>` on main
+- `.github/workflows/release-publish.yaml` — retags on tag push, creates GitHub Release
+- `.github/workflows/release-helm.yml` — publishes Helm chart on tag push

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -282,36 +282,15 @@ agentarea/
 
 ## 🚀 Release Process
 
-### Versioning
+We follow [Semantic Versioning](https://semver.org/). Releases use a
+**build-once / promote-on-tag** model:
 
-We follow [Semantic Versioning](https://semver.org/):
-- **MAJOR**: Breaking changes
-- **MINOR**: New features (backward compatible)
-- **PATCH**: Bug fixes (backward compatible)
+1. **Actions → "Prepare Release"** (patch/minor/major) — opens a release PR that bumps `VERSION`.
+2. Review and merge the PR. `ci.yml` builds immutable `<version>-<sha>` Docker images.
+3. Locally: `./scripts/release.sh` — runs pre-flight checks, creates and pushes `vX.Y.Z` tag.
+4. The tag push triggers retag of the pre-built images to `<version>`, `<maj.min>`, `<maj>`, `latest`, creates the GitHub Release, and publishes the Helm chart. **No rebuild.**
 
-### Release Checklist
-
-<Steps>
-  <Step title="Version Bump">
-    Update version numbers in relevant files and create a new tag
-  </Step>
-  
-  <Step title="Changelog Update">
-    Document all changes in CHANGELOG.md with proper categorization
-  </Step>
-  
-  <Step title="Testing">
-    Run comprehensive test suite and manual testing
-  </Step>
-  
-  <Step title="Documentation">
-    Update documentation and API references
-  </Step>
-  
-  <Step title="Release">
-    Create GitHub release with detailed release notes
-  </Step>
-</Steps>
+See [VERSIONING.md](./VERSIONING.md) for the full process, tag semantics, invariants, and troubleshooting.
 
 ## 🤝 Community Guidelines
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,6 +90,7 @@
         "icon": "users",
         "pages": [
           "contributing",
+          "VERSIONING",
           "community",
           "roadmap",
           "changelog"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -108,6 +108,25 @@ def main():
     except subprocess.CalledProcessError as e:
         print(f"⚠️  Warning: Failed to update Chart.yaml appVersion: {e.stderr}")
 
+    # Update Go version constants
+    go_version_files = [
+        root_dir / 'agentarea-mcp-manager' / 'cmd' / 'mcp-manager' / 'main.go',
+        root_dir / 'agentarea-event-service' / 'cmd' / 'server' / 'main.go',
+    ]
+
+    for go_file in go_version_files:
+        if go_file.exists():
+            content = go_file.read_text()
+            updated = re.sub(
+                r'const version = "[^"]*"',
+                f'const version = "{new_version}"',
+                content
+            )
+
+            if updated != content:
+                go_file.write_text(updated)
+                print(f"✅ Updated {go_file.relative_to(root_dir)}")
+
     print(f"\n✅ All versions bumped to {new_version}")
 
 if __name__ == '__main__':

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# release.sh - Validate state and push a semver tag for the current HEAD.
+#
+# The tag push triggers .github/workflows/release-publish.yaml, which retags
+# the existing `<version>-<sha>` Docker images (built by ci.yml on merge to
+# main) with `<version>`, `<maj.min>`, `<maj>`, and `latest`, then creates a
+# GitHub Release. Nothing is rebuilt.
+#
+# Usage:
+#   ./scripts/release.sh                  # tag HEAD with version from VERSION
+#   ./scripts/release.sh --dry-run        # checks only, no tag/push
+#   ./scripts/release.sh --skip-ci        # skip ci.yml success check
+#   ./scripts/release.sh --skip-images    # skip DockerHub existence check
+#   ./scripts/release.sh --help
+
+set -euo pipefail
+
+RED=$'\e[31m'
+GREEN=$'\e[32m'
+YELLOW=$'\e[33m'
+BLUE=$'\e[34m'
+BOLD=$'\e[1m'
+RESET=$'\e[0m'
+
+DRY_RUN=false
+SKIP_CI=false
+SKIP_IMAGES=false
+
+usage() {
+  cat <<EOF
+Usage: $0 [--dry-run] [--skip-ci] [--skip-images] [-h|--help]
+
+Validate repository state and push a semver tag (vX.Y.Z) for the current HEAD.
+The version comes from the VERSION file. Downstream workflow retags pre-built
+Docker images and creates a GitHub Release.
+
+Options:
+  --dry-run        Run all checks but do not create/push the tag
+  --skip-ci        Skip the ci.yml "green on HEAD" check
+  --skip-images    Skip the DockerHub image-existence check
+  -h, --help       Show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)     DRY_RUN=true; shift ;;
+    --skip-ci)     SKIP_CI=true; shift ;;
+    --skip-images) SKIP_IMAGES=true; shift ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+info() { printf '%s[•]%s %s\n' "$BLUE"   "$RESET" "$*"; }
+ok()   { printf '%s[✓]%s %s\n' "$GREEN"  "$RESET" "$*"; }
+warn() { printf '%s[!]%s %s\n' "$YELLOW" "$RESET" "$*"; }
+err()  { printf '%s[✗]%s %s\n' "$RED"    "$RESET" "$*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# ─── Git state ────────────────────────────────────────────────────────
+info "Checking local git state..."
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  die "Working tree is dirty. Commit or stash changes first."
+fi
+ok "Working tree clean"
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
+if [ "$BRANCH" != "main" ]; then
+  warn "Current branch is '$BRANCH' (not 'main')."
+  read -r -p "Continue anyway? [y/N] " ans
+  case "${ans:-}" in y|Y|yes) ;; *) die "Aborted." ;; esac
+else
+  ok "On branch main"
+fi
+
+info "Fetching from origin (including tags)..."
+git fetch --quiet --tags origin main
+
+if [ "$BRANCH" = "main" ]; then
+  LOCAL=$(git rev-parse HEAD)
+  REMOTE=$(git rev-parse origin/main)
+  if [ "$LOCAL" != "$REMOTE" ]; then
+    BEHIND=$(git rev-list --count "$LOCAL..$REMOTE")
+    AHEAD=$(git rev-list --count "$REMOTE..$LOCAL")
+    [ "$BEHIND" -gt 0 ] && die "Local main is $BEHIND commit(s) behind origin/main. Pull first."
+    [ "$AHEAD"  -gt 0 ] && die "Local main is $AHEAD commit(s) ahead of origin/main. Push first."
+  fi
+  ok "Up-to-date with origin/main"
+fi
+
+# ─── Version ──────────────────────────────────────────────────────────
+info "Reading VERSION..."
+[ -f VERSION ] || die "VERSION file not found in $PROJECT_ROOT"
+VERSION=$(tr -d '[:space:]' < VERSION)
+echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  || die "VERSION content '$VERSION' is not semver X.Y.Z"
+TAG="v$VERSION"
+ok "Version: $VERSION → tag $TAG"
+
+info "Verifying version sync across all files..."
+if ! bash scripts/verify-version-sync.sh >/dev/null 2>&1; then
+  err "verify-version-sync.sh failed. Run it directly for details:"
+  err "  bash scripts/verify-version-sync.sh"
+  exit 1
+fi
+ok "All version files synchronized"
+
+# ─── Tag uniqueness ───────────────────────────────────────────────────
+info "Checking tag $TAG does not exist..."
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  die "Tag $TAG already exists locally. Delete it or bump VERSION."
+fi
+if git ls-remote --tags origin "$TAG" | grep -q "refs/tags/$TAG$"; then
+  die "Tag $TAG already exists on origin. Bump VERSION for a new release."
+fi
+ok "Tag $TAG available"
+
+# ─── CI status ────────────────────────────────────────────────────────
+HEAD_SHA=$(git rev-parse HEAD)
+SHORT_SHA=$(git rev-parse --short HEAD)
+
+if $SKIP_CI; then
+  warn "Skipping ci.yml status check (--skip-ci)"
+elif ! command -v gh >/dev/null 2>&1; then
+  warn "gh CLI not installed; skipping ci.yml status check."
+else
+  info "Checking ci.yml status for $SHORT_SHA..."
+  STATUS=$(gh run list \
+    --workflow=ci.yml \
+    --commit "$HEAD_SHA" \
+    --limit 1 \
+    --json status,conclusion \
+    --jq '.[0] | "\(.status)/\(.conclusion)"' 2>/dev/null || echo "none")
+  case "$STATUS" in
+    "completed/success")
+      ok "ci.yml green on $SHORT_SHA" ;;
+    "completed/"*)
+      die "ci.yml on $SHORT_SHA finished non-successfully ($STATUS). Fix before releasing." ;;
+    "in_progress/"*|"queued/"*|"pending/"*)
+      warn "ci.yml still running on $SHORT_SHA ($STATUS). release-publish will wait (up to 15 min)." ;;
+    "none"|""|"null/null")
+      warn "No ci.yml run found for $SHORT_SHA yet." ;;
+    *)
+      warn "Unexpected ci.yml status: $STATUS" ;;
+  esac
+fi
+
+# ─── DockerHub images ─────────────────────────────────────────────────
+COMPONENTS=(api worker frontend bootstrap mcp-manager mcp-runner events)
+
+if $SKIP_IMAGES; then
+  warn "Skipping DockerHub image check (--skip-images)"
+elif ! command -v docker >/dev/null 2>&1; then
+  warn "docker CLI not installed; skipping image-existence check."
+else
+  info "Checking DockerHub images agentarea/agentarea-*:$VERSION-$SHORT_SHA..."
+  MISSING=()
+  for c in "${COMPONENTS[@]}"; do
+    IMG="agentarea/agentarea-$c:$VERSION-$SHORT_SHA"
+    if docker buildx imagetools inspect "$IMG" >/dev/null 2>&1; then
+      ok "  $IMG"
+    else
+      MISSING+=("$IMG")
+    fi
+  done
+  if [ ${#MISSING[@]} -gt 0 ]; then
+    warn "Missing images (${#MISSING[@]}/${#COMPONENTS[@]}):"
+    for m in "${MISSING[@]}"; do warn "    $m"; done
+    warn "They may still be building; release-publish retries for 15 min."
+  fi
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────
+PREV_TAG=$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo "")
+COMMIT_SUBJECT=$(git log -1 --pretty=%s)
+
+echo
+printf '%s═══ Release Summary ═══%s\n' "$BOLD" "$RESET"
+printf '  Tag:       %s\n' "$TAG"
+printf '  Commit:    %s %s\n' "$SHORT_SHA" "$COMMIT_SUBJECT"
+if [ -n "$PREV_TAG" ]; then
+  COMMIT_COUNT=$(git rev-list --count "$PREV_TAG..HEAD")
+  printf '  Previous:  %s (%s commits ago)\n' "$PREV_TAG" "$COMMIT_COUNT"
+fi
+echo
+if [ -n "$PREV_TAG" ]; then
+  printf '%sCommits since %s:%s\n' "$BOLD" "$PREV_TAG" "$RESET"
+  git log "$PREV_TAG..HEAD" --pretty=format:'  - %s (%an)' --no-merges
+  echo
+fi
+echo
+
+if $DRY_RUN; then
+  ok "--dry-run: exiting before tag push."
+  exit 0
+fi
+
+read -r -p "Create and push tag $TAG? [y/N] " ans
+case "${ans:-}" in y|Y|yes) ;; *) die "Aborted." ;; esac
+
+# ─── Tag and push ─────────────────────────────────────────────────────
+info "Creating annotated tag $TAG..."
+git tag -a "$TAG" -m "Release $TAG"
+
+info "Pushing tag to origin..."
+git push origin "refs/tags/$TAG"
+
+REPO=$(git remote get-url origin | sed -E 's#.*github\.com[:/]([^/]+/[^/.]+?)(\.git)?$#\1#')
+echo
+ok "Tag $TAG pushed."
+printf '  Workflow: https://github.com/%s/actions/workflows/release-publish.yaml\n' "$REPO"
+printf '  Release:  https://github.com/%s/releases/tag/%s\n' "$REPO" "$TAG"

--- a/scripts/verify-version-sync.sh
+++ b/scripts/verify-version-sync.sh
@@ -56,10 +56,12 @@ GO_VERSION_FILES=(
 for file in "${GO_VERSION_FILES[@]}"; do
   if [ -f "$file" ]; then
     GO_VERSION=$(grep 'const version = ' "$file" | sed 's/const version = "\(.*\)"/\1/')
+    REL_PATH=$(realpath --relative-to="$PROJECT_ROOT" "$file" 2>/dev/null || echo "$file")
     if [ "$GO_VERSION" != "$EXPECTED_VERSION" ]; then
-      REL_PATH=$(realpath --relative-to="$PROJECT_ROOT" "$file" 2>/dev/null || echo "$file")
       echo "❌ $REL_PATH: $GO_VERSION (expected: $EXPECTED_VERSION)"
       ERRORS=$((ERRORS + 1))
+    else
+      echo "✅ $REL_PATH: $GO_VERSION"
     fi
   fi
 done


### PR DESCRIPTION
## Summary

Fixes the semver-tag-overwrite bug and switches the release flow to **build-once / promote-on-tag**. No more rebuilds on release: `<version>` is published exactly once, via retag, sharing the same digest as `<version>-<sha>`.

## The problem

- `ci.yml` pushed both `<version>` and `<version>-<sha>` on every merge to main — the bare `<version>` tag (e.g. `agentarea/agentarea-api:0.0.8`) was overwritten on every merge. Prod and staging could both run `0.0.8` but be different images. Rollback was unreliable.
- `release-publish.yaml` rebuilt all images on release-PR merge, racing with `ci.yml` on the same commit.

## The fix

| File | Change |
|---|---|
| `.github/workflows/docker-build-push.yml` | Removed bare `<version>` tag. Main merges push only immutable `<version>-<sha>`. |
| `.github/workflows/release-publish.yaml` | Rewritten. Triggers on `push: tags: [v*]`. Retags existing images via `docker buildx imagetools create` — no rebuild, same digest. Retries up to 15 min if `ci.yml` still building. Auto-generates GitHub Release notes from `git log`. |
| `.github/workflows/release-prepare.yaml` | PR body updated — merging the release PR no longer auto-publishes. Publishing happens via `./scripts/release.sh`. |
| `scripts/release.sh` (new, +x) | Pre-flight: clean tree → main up-to-date → `VERSION` sync → tag uniqueness → `ci.yml` green on HEAD → all 7 images present on Docker Hub → summary with commits since last tag → confirmation → `git tag` + push. Flags: `--dry-run`, `--skip-ci`, `--skip-images`. |
| `docs/VERSIONING.md` | Rewritten to match the new model. Tag semantics, invariants, full release walkthrough, troubleshooting. |
| `docs/contributing.md` | Release section condensed to a 4-step summary linking to `VERSIONING.md`. |
| `docs/docs.json` | `VERSIONING` added to the Community nav group. |
| `scripts/bump-version.py` (from prior commit `a8eaf7b4`) | Syncs Go `const version` in `agentarea-mcp-manager` and `agentarea-event-service`, which all-7-components release now relies on. |

## New release flow

```
1. Actions -> Prepare Release (patch/minor/major) -> opens release PR
2. Review + merge release PR -> ci.yml builds <version>-<sha> for 7 components
3. Wait for ci.yml green
4. Locally:  git pull && ./scripts/release.sh  -> pre-flight checks + git tag push
5. Auto:     release-publish.yaml retags (no rebuild) + GitHub Release
             release-helm.yml publishes Helm chart
```

## Invariants enforced

- `<version>` (bare semver) is published **exactly once** via retag. Never overwritten.
- `<version>-<sha>` is built by `ci.yml` on every main merge. Immutable per-commit.
- Release tag and dev tag on the release commit share the **same digest** — bit-identical image under different tags.
- `release.sh` refuses to tag if: working tree dirty, branch not up-to-date, `VERSION` not in sync, tag already used, `ci.yml` not green, or release images missing from Docker Hub.

## Test plan

- [ ] YAML + shell syntax validated locally (`python3 -m yaml` + `bash -n`).
- [ ] Run `./scripts/release.sh --dry-run` on the merged branch — confirm all checks pass and no tag is pushed.
- [ ] First real release after merge: trigger `Prepare Release (patch)` -> merge -> wait for `ci.yml` green -> `./scripts/release.sh` -> verify:
  - [ ] Tag `vX.Y.Z` appears on GitHub.
  - [ ] `release-publish.yaml` runs, retags 7 components, creates GitHub Release.
  - [ ] `docker buildx imagetools inspect agentarea/agentarea-api:X.Y.Z` and `:X.Y.Z-<sha>` show the **same digest**.
  - [ ] `release-helm.yml` publishes the chart.