### PR TITLE
fix: pin release.sh short SHA to 7 chars

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,7 +123,9 @@ ok "Tag $TAG available"
 
 # ─── CI status ────────────────────────────────────────────────────────
 HEAD_SHA=$(git rev-parse HEAD)
-SHORT_SHA=$(git rev-parse --short HEAD)
+# Must be 7 chars to match docker/metadata-action's {{sha}} (docker-build-push.yml).
+# Local git may auto-widen --short beyond 7, so pin the length explicitly.
+SHORT_SHA=$(git rev-parse --short=7 HEAD)
 
 if $SKIP_CI; then
   warn "Skipping ci.yml status check (--skip-ci)"


### PR DESCRIPTION
## Summary
- docker/metadata-action `{{sha}}` in `docker-build-push.yml` produces a **7-char** short SHA (e.g. `0.0.10-421c9bb`), but `release.sh` used `git rev-parse --short HEAD` which auto-widens to 8 chars on developer machines (git `core.abbrev=auto`).
- Result: the DockerHub image-existence check hunted for tags that never exist (`0.0.10-421c9bbd` vs the real `0.0.10-421c9bb`) and reported all 7 images missing on a working release.
- Pin `--short=7` so local checks match CI-published tags.

## Test plan
- [x] `git rev-parse --short=7 HEAD` → `421c9bb` (matches DockerHub)
- [x] `docker buildx imagetools inspect agentarea/agentarea-{api,worker,frontend,bootstrap,mcp-manager,mcp-runner,events}:0.0.10-421c9bb` all resolve
- [ ] Re-run `./scripts/release.sh --dry-run` locally and confirm all 7 images report `[✓]`