### PR TITLE
fix(mcp): advertise correct API_BASE_URL and /mcp resource in prod

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
@@ -34,7 +34,8 @@ async def oauth_protected_resource_metadata() -> JSONResponse:
     api_base = settings.app.API_BASE_URL.rstrip("/")
     return JSONResponse(
         content={
-            "resource": api_base,
+            # MCP spec: canonical URI of the MCP server endpoint, not the API root.
+            "resource": f"{api_base}/mcp",
             # Using ourselves as the AS URL so clients resolve
             # /.well-known/oauth-authorization-server against us (not Hydra directly).
             "authorization_servers": [api_base],

--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -107,6 +107,7 @@ The following table lists configurable parameters of the chart and their default
 | global.temporal.worker.maxConcurrentSessionExecutions | int | `1000` |  |
 | global.api.host | string | `"0.0.0.0"` |  |
 | global.api.port | int | `8000` |  |
+| global.api.publicUrl | string | `""` |  |
 | global.api.auth.enabled | bool | `false` |  |
 | global.api.auth.headerName | string | `""` |  |
 | global.api.auth.headerValue | string | `""` |  |

--- a/charts/agentarea/config.yaml
+++ b/charts/agentarea/config.yaml
@@ -83,6 +83,7 @@ groups:
       MCP_CLIENT_TIMEOUT: '30'
       API_HOST: '{{ .Values.global.api.host }}'
       API_PORT: '{{ .Values.global.api.port }}'
+      API_BASE_URL: '{{ include "agentarea.backend.apiUrl" . }}'
       API_AUTH_ENABLED: '{{ .Values.global.api.auth.enabled }}'
       API_RATE_LIMIT_ENABLED: '{{ .Values.global.api.rateLimit.enabled }}'
       API_RATE_LIMIT_REQUESTS_PER_MINUTE: '{{ .Values.global.api.rateLimit.requestsPerMinute }}'

--- a/charts/agentarea/templates/_service-discovery.tpl
+++ b/charts/agentarea/templates/_service-discovery.tpl
@@ -54,6 +54,25 @@ http://{{ include "agentarea.fullname" . }}-backend:{{ .Values.backend.service.p
 {{- end -}}
 
 {{/*
+Backend public API URL helper.
+Resolution order:
+  1. .Values.global.api.publicUrl (explicit override, e.g. https://api.example.com)
+  2. https://{{ ingress.hosts.backend.host }} when ingress is enabled and host is set
+  3. Internal ClusterIP service URL (agentarea.backend.url)
+Used for OAuth protected-resource metadata and any env var that must advertise
+the externally reachable API URL (API_BASE_URL).
+*/}}
+{{- define "agentarea.backend.apiUrl" -}}
+{{- if .Values.global.api.publicUrl -}}
+{{ .Values.global.api.publicUrl }}
+{{- else if and .Values.ingress.enabled .Values.ingress.hosts.backend.host -}}
+https://{{ .Values.ingress.hosts.backend.host }}
+{{- else -}}
+{{ include "agentarea.backend.url" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Frontend service URL helper
 */}}
 {{- define "agentarea.frontend.url" -}}

--- a/charts/agentarea/templates/configs/backend.env.tpl
+++ b/charts/agentarea/templates/configs/backend.env.tpl
@@ -10,6 +10,7 @@ MCP_MANAGER_URL: "http://{{ include "agentarea.fullname" . }}-mcp-manager:{{ .Va
 MCP_CLIENT_TIMEOUT: "30"
 API_HOST: "{{ .Values.global.api.host }}"
 API_PORT: "{{ .Values.global.api.port }}"
+API_BASE_URL: "{{ include "agentarea.backend.apiUrl" . }}"
 API_AUTH_ENABLED: "{{ .Values.global.api.auth.enabled }}"
 API_RATE_LIMIT_ENABLED: "{{ .Values.global.api.rateLimit.enabled }}"
 API_RATE_LIMIT_REQUESTS_PER_MINUTE: "{{ .Values.global.api.rateLimit.requestsPerMinute }}"
@@ -53,6 +54,11 @@ KRATOS_AUDIENCE: "{{ .Values.kratos.jwt.audience }}"
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-backend
       key: API_PORT
+- name: API_BASE_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "agentarea.fullname" . }}-env-backend
+      key: API_BASE_URL
 - name: API_AUTH_ENABLED
   valueFrom:
     configMapKeyRef:

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -121,6 +121,12 @@ global:
     # API server settings
     host: "0.0.0.0"
     port: 8000
+    # Public base URL of the backend API (e.g. https://api.example.com).
+    # Advertised in OAuth protected-resource metadata and the MCP
+    # WWW-Authenticate header. If empty, derived from
+    # ingress.hosts.backend.host when ingress is enabled, otherwise falls
+    # back to the internal ClusterIP service URL.
+    publicUrl: ""
     # Authentication
     auth:
       enabled: false


### PR DESCRIPTION
## Summary

- Fixes MCP client rejection in prod: `Protected resource http://localhost:8000 does not match expected https://api.agentarea.ai/mcp`.
- Adds Helm plumbing so `API_BASE_URL` is set from ingress / explicit `publicUrl` instead of the Python default `http://localhost:8000`.
- Fixes the RFC 9728 `resource` field to return the canonical MCP endpoint (`{api_base}/mcp`) per the MCP auth spec. The AS `issuer` stays at the API root.

## Changes

**Helm:**
- New helper `agentarea.backend.apiUrl` in `_service-discovery.tpl` — resolves `global.api.publicUrl` → `https://{ingress.hosts.backend.host}` → internal ClusterIP URL.
- `global.api.publicUrl: ""` added in `values.yaml` for explicit override.
- `API_BASE_URL` added to `config.yaml` backend group; `backend.env.tpl` regenerated.

**Backend:**
- `/.well-known/oauth-protected-resource` now returns `"resource": "{api_base}/mcp"`.

## Configuration

Prod is expected to set one of:
- `global.api.publicUrl: https://api.agentarea.ai`, or
- `ingress.enabled: true` + `ingress.hosts.backend.host: api.agentarea.ai`.

Local/dev falls back to the internal service URL — no action needed.

## Test plan

- [x] `helm template` with ingress enabled → `API_BASE_URL: https://api.agentarea.ai`
- [x] `helm template` with `global.api.publicUrl` override → uses override
- [x] `helm template` default → `http://test-agentarea-backend:8000`
- [x] Regenerated `backend.env.tpl` contains `API_BASE_URL` in both configVars and envs blocks
- [ ] Deploy to staging, hit `/.well-known/oauth-protected-resource`, confirm `resource` ends in `/mcp` and MCP client handshake passes