### PR TITLE
ci(helm): add valkey repo for chart dependency build

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Add repositories
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add valkey https://valkey.io/valkey-helm/
           helm repo update
 
       - name: Build chart dependencies


### PR DESCRIPTION
## Summary
- `Release Helm Chart` workflow (run [24529441606](https://github.com/agentarea/agentarea/actions/runs/24529441606)) failed on `v0.0.10`: `helm dependency build` couldn't resolve `https://valkey.io/valkey-helm/`.
- Workflow was adding the unused `bitnami` repo; `charts/agentarea/Chart.yaml` only depends on `valkey`.
- Replaces the bitnami `helm repo add` with valkey so dependency resolution succeeds.

## Test plan
- [x] Locally reproduced the failure against Chart.yaml + Chart.lock with helm 3.17.3.
- [x] With the valkey repo added, `helm dependency build charts/agentarea` downloads `valkey-0.9.3.tgz` cleanly.
- [ ] Re-run `Release Helm Chart` (workflow_dispatch) on main once merged; confirm `Build chart dependencies` step succeeds.