### PR TITLE
fix(chart): point eventService at published agentarea-events image

### DIFF
--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -246,7 +246,7 @@ The following table lists configurable parameters of the chart and their default
 | worker.waitForDependencies | bool | `false` |  |
 | eventService.enabled | bool | `true` |  |
 | eventService.replicaCount | int | `1` |  |
-| eventService.image.repository | string | `"agentarea/agentarea-event-service"` |  |
+| eventService.image.repository | string | `"agentarea/agentarea-events"` |  |
 | eventService.image.tag | string | `"latest"` |  |
 | eventService.image.pullPolicy | string | `""` |  |
 | eventService.port | int | `8002` |  |

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -429,7 +429,7 @@ eventService:
   enabled: true
   replicaCount: 1
   image:
-    repository: agentarea/agentarea-event-service
+    repository: agentarea/agentarea-events
     tag: "latest"
     pullPolicy: ""  # Overrides global.image.pullPolicy if set
   # Service port


### PR DESCRIPTION
## Summary

- CI publishes the event-service container as `agentarea/agentarea-events` (`.github/workflows/ci.yml:637` passes `component: events`, which `docker-build-push.yml:92,103` expands to `agentarea/agentarea-$component`).
- The chart referenced `agentarea/agentarea-event-service`, which has never been pushed (DockerHub returns 404). Event-service pods hit `ImagePullBackOff`, so no Ready endpoints exist and the service appears undiscoverable.
- Aligns `values.yaml` (and mirrored `README.md` row) with the image CI actually publishes.

## Known follow-ups (not in this PR)

- No `Service` template exists for event-service — add `templates/agentarea-event-service/service.yaml` + `eventService.service.{type,port}` in values.
- `cmd/server/main.go` never starts an HTTP server, but `deployment.yaml` declares HTTP liveness/readiness probes on `:8002/health`. Either add a `/health` HTTP server or switch probes to `exec`/`tcpSocket`.

## Test plan

- [ ] `helm template` renders `image: "agentarea/agentarea-events:latest"` for the event-service deployment.
- [ ] Deploy to staging and confirm event-service pod reaches Running (image pull succeeds).
- [ ] Confirm `latest` tag exists on DockerHub for `agentarea/agentarea-events` (verified — 9 tags, most recent 2026-04-16).