### PR TITLE
fix(chart): expose ORY_BROWSER_URL to frontend, drop NEXT_PUBLIC_ORY_SDK_URL

### DIFF
--- a/charts/agentarea/config.yaml
+++ b/charts/agentarea/config.yaml
@@ -72,7 +72,7 @@ groups:
       API_URL: '{{ include "agentarea.backend.url" . }}'
       ORY_ADMIN_URL: '{{ include "agentarea.kratosAdminUrl" . }}'
       ORY_SDK_URL: '{{ include "agentarea.kratosPublicUrl" . }}'
-      NEXT_PUBLIC_ORY_SDK_URL: '{{ include "agentarea.kratosPublicBrowserUrl" . }}'
+      ORY_BROWSER_URL: '{{ include "agentarea.kratosPublicBrowserUrl" . }}'
       METRICS_ENABLED: '{{ .Values.global.monitoring.prometheus.enabled }}'
       HEALTH_CHECK_ENABLED: '{{ .Values.global.monitoring.health.enabled }}'
 

--- a/charts/agentarea/templates/configs/frontend.env.tpl
+++ b/charts/agentarea/templates/configs/frontend.env.tpl
@@ -9,7 +9,7 @@ NODE_ENV: "production"
 API_URL: "{{ include "agentarea.backend.url" . }}"
 ORY_ADMIN_URL: "{{ include "agentarea.kratosAdminUrl" . }}"
 ORY_SDK_URL: "{{ include "agentarea.kratosPublicUrl" . }}"
-NEXT_PUBLIC_ORY_SDK_URL: "{{ include "agentarea.kratosPublicBrowserUrl" . }}"
+ORY_BROWSER_URL: "{{ include "agentarea.kratosPublicBrowserUrl" . }}"
 METRICS_ENABLED: "{{ .Values.global.monitoring.prometheus.enabled }}"
 HEALTH_CHECK_ENABLED: "{{ .Values.global.monitoring.health.enabled }}"
 {{- end }}
@@ -40,11 +40,11 @@ HEALTH_CHECK_ENABLED: "{{ .Values.global.monitoring.health.enabled }}"
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-frontend
       key: ORY_SDK_URL
-- name: NEXT_PUBLIC_ORY_SDK_URL
+- name: ORY_BROWSER_URL
   valueFrom:
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-frontend
-      key: NEXT_PUBLIC_ORY_SDK_URL
+      key: ORY_BROWSER_URL
 - name: METRICS_ENABLED
   valueFrom:
     configMapKeyRef:


### PR DESCRIPTION
## Summary

- Frontend SSR renders `ui.action`/flow URLs from `ORY_SDK_URL` (cluster-local), which leaks internal hostnames to the browser. The webapp already has a fix (`src/lib/auth/browser-config.ts` + `rewriteFlowForBrowser` + `window.__ENV__.CLIENT_ORY_SDK_URL` injection in `src/app/layout.tsx`), but it only activates when `ORY_BROWSER_URL` is set — which the chart never exposed.
- Swap `NEXT_PUBLIC_ORY_SDK_URL` → `ORY_BROWSER_URL` in `charts/agentarea/config.yaml` and regenerate `frontend.env.tpl`. `NEXT_PUBLIC_*` is build-time only in Next.js; since we build a single image used across environments, rendering it via configMap had no effect at runtime. `ORY_BROWSER_URL` is the var the code actually reads.

## Test plan

- [ ] `helm template` renders `ORY_BROWSER_URL` in frontend configMap and container env (verified locally: `ORY_BROWSER_URL` points to `kratos.urls.publicBrowser`, `ORY_SDK_URL` stays cluster-local).
- [ ] CI passes.
- [ ] After staging deploy: open `/auth/login` in a browser, confirm `<form action=...>` points to the public Kratos hostname (`kratos-staging.tailfdd2bf.ts.net`), not the cluster-local service.