### PR TITLE
fix(openapi): sort PinnedTarget.__slots__ to satisfy RUF023

### DIFF
--- a/agentarea-platform/libs/openapi/agentarea_openapi/application/service.py
+++ b/agentarea-platform/libs/openapi/agentarea_openapi/application/service.py
@@ -92,9 +92,7 @@ async def fetch_and_parse_spec(
     # We connect to a pinned IP (anti-DNS-rebinding) but the TLS cert is issued
     # for the original hostname — pass sni_hostname so SNI + cert validation use
     # the original host instead of the IP we connect to.
-    extensions = (
-        {"sni_hostname": target.original_host} if target.original_host else None
-    )
+    extensions = {"sni_hostname": target.original_host} if target.original_host else None
 
     async with httpx.AsyncClient(
         timeout=30, headers=request_headers, follow_redirects=False, verify=True

--- a/agentarea-platform/libs/openapi/agentarea_openapi/application/url_validator.py
+++ b/agentarea-platform/libs/openapi/agentarea_openapi/application/url_validator.py
@@ -78,7 +78,7 @@ class PinnedTarget:
     of the path.
     """
 
-    __slots__ = ("scheme", "host", "port", "path", "raw_query", "original_host")
+    __slots__ = ("host", "original_host", "path", "port", "raw_query", "scheme")
 
     def __init__(
         self,

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -5084,7 +5084,7 @@ export interface components {
         ProviderConfigCreate: {
             /**
              * Api Key
-             * @description Secret API key for the provider. Stored encrypted in the secret manager; never returned in responses.
+             * @description Secret API key for the provider. Stored encrypted in the secret manager; never returned in responses. May be empty for proxies that accept keyless traffic — the backend suppresses the Authorization header when this is empty.
              */
             api_key: string;
             /**


### PR DESCRIPTION
CI/CD Pipeline failed on main (run 25101687716): ruff RUF023 — `PinnedTarget.__slots__` not sorted in `url_validator.py:81`. This sorts the tuple and applies a ruff-format reflow in `service.py`.

Verified locally with `uv run ruff check .` and `uv run ruff format --check .` — both pass.