### PR TITLE
fix(mcp-runner): bump Dockerfile.runner to golang:1.25-alpine

### DIFF
--- a/agentarea-mcp-manager/Dockerfile.runner
+++ b/agentarea-mcp-manager/Dockerfile.runner
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Dockerfile.runner pinned `golang:1.24-alpine` but `agentarea-mcp-manager/go.mod` requires `go 1.25.0`, breaking the `docker-agentarea-mcp-runner / build-and-push` CI job (`go: go.mod requires go >= 1.25.0 (running go 1.24.13)`).
- Other Dockerfiles in the same module (`Dockerfile`, `Dockerfile.dev`, `Dockerfile.sandbox`) already use `golang:1.25-alpine`; this brings the runner image in line.

## Test plan
- [ ] CI `docker-agentarea-mcp-runner / build-and-push` succeeds on this branch
- [ ] Resulting `agentarea/mcp-runner` image lands in registry on merge to main