### PR TITLE
Use AWS CLI for RustFS bucket initialization

### DIFF
--- a/charts/agentarea/templates/rustfs/rustfs.yaml
+++ b/charts/agentarea/templates/rustfs/rustfs.yaml
@@ -135,24 +135,26 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: mc
-          image: "minio/mc:latest"
+        - name: s3-client
+          image: "amazon/aws-cli:2.17.51"
           command:
             - sh
             - -c
             - |
-              mc alias set local http://{{ .Release.Name }}-rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY"
-              mc mb -p local/{{ .Values.rustfs.defaultBuckets }} || true
+              aws configure set default.s3.addressing_style path
+              aws s3 mb s3://{{ .Values.rustfs.defaultBuckets }} --endpoint-url http://{{ .Release.Name }}-rustfs:9000 || true
           env:
-            - name: RUSTFS_ACCESS_KEY
+            - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.secrets.rustfs }}
                   key: root-user
-            - name: RUSTFS_SECRET_KEY
+            - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.secrets.rustfs }}
                   key: root-password
+            - name: AWS_DEFAULT_REGION
+              value: "us-east-1"
 {{- end }}
 {{- end }}

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -43,7 +43,7 @@ global:
     postgresql: "agentarea-postgresql-secret"
     # Redis credentials
     redis: "agentarea-redis-secret"
-    # MinIO/S3 credentials
+    # RustFS/S3 credentials
     rustfs: "agentarea-rustfs-secret"
     # Application secrets (JWT, encryption keys)
     application: "agentarea-app-secrets"
@@ -666,8 +666,8 @@ rustfs:
   persistence:
     enabled: true
     size: 10Gi
-  # Probes are overridable. The rustfs image doesn't implement MinIO's
-  # /minio/health/live path (returns 403), so defaults use TCP probes.
+  # Probes are overridable. The rustfs image doesn't expose an HTTP health path
+  # by default (returns 403), so defaults use TCP probes.
   # Override to httpGet if your image version exposes a working health path.
   readinessProbe:
     tcpSocket:


### PR DESCRIPTION
## Summary
- replace the RustFS bucket init hook client from `minio/mc` to pinned `amazon/aws-cli:2.17.51`
- use S3-compatible AWS env vars and path-style addressing against the in-cluster RustFS endpoint
- update values comments to describe RustFS health behavior directly

## Verification
- `helm lint charts/agentarea`
- `helm lint charts/agentarea -f charts/agentarea/values-minikube.yaml`
- `helm template agentarea charts/agentarea --namespace agentarea` and parsed 51 YAML documents
- `git diff --check`

## Not Tested
- live Helm install against a Kubernetes cluster