### PR TITLE
Fix image pull secrets for private registry workloads

### DIFF
--- a/agentarea-mcp-manager/internal/backends/kubernetes_resources.go
+++ b/agentarea-mcp-manager/internal/backends/kubernetes_resources.go
@@ -233,14 +233,14 @@ func (k *KubernetesBackend) createDeployment(ctx context.Context, instanceName s
 
 	container.VolumeMounts = volumeMounts
 
-		// Determine runtime class based on trust level
+	// Determine runtime class based on trust level
 	runtimeClassName := k.k8sConfig.RuntimeClass
-	
+
 	// If instance specifies a runtime class, use it
 	if spec.RuntimeClass != "" {
 		runtimeClassName = spec.RuntimeClass
 	}
-	
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("mcp-%s", instanceName),
@@ -267,6 +267,9 @@ func (k *KubernetesBackend) createDeployment(ctx context.Context, instanceName s
 						},
 						Containers: []corev1.Container{container},
 						Volumes:    k.createVolumes(spec),
+					}
+					if k.k8sConfig.PodServiceAccountName != "" {
+						spec.ServiceAccountName = k.k8sConfig.PodServiceAccountName
 					}
 					// Only set RuntimeClassName if it's not empty
 					if runtimeClassName != "" {
@@ -432,7 +435,7 @@ func (k *KubernetesBackend) createHTTPRoute(ctx context.Context, instanceName st
 	}
 
 	pathPrefix := fmt.Sprintf("/mcp/%s", instanceName)
-	
+
 	// Determine gateway namespace
 	gatewayNs := k.k8sConfig.GatewayNamespace
 	if gatewayNs == "" {
@@ -445,8 +448,8 @@ func (k *KubernetesBackend) createHTTPRoute(ctx context.Context, instanceName st
 			Namespace: k.k8sConfig.Namespace,
 			Labels:    k.getCommonLabels(instanceName),
 			Annotations: map[string]string{
-				"agentarea.io/instance-id":  spec.InstanceID,
-				"agentarea.io/workspace-id": spec.WorkspaceID,
+				"agentarea.io/instance-id":   spec.InstanceID,
+				"agentarea.io/workspace-id":  spec.WorkspaceID,
 				"agentarea.io/auth-required": "true",
 			},
 		},

--- a/agentarea-mcp-manager/internal/config/config.go
+++ b/agentarea-mcp-manager/internal/config/config.go
@@ -41,8 +41,8 @@ type Config struct {
 
 // FeaturesConfig holds feature flag configuration
 type FeaturesConfig struct {
-	Enabled  []string                       `json:"enabled"`
-	Variants map[string]map[string]string   `json:"variants"`
+	Enabled  []string                     `json:"enabled"`
+	Variants map[string]map[string]string `json:"variants"`
 }
 
 // ServerConfig holds HTTP server configuration
@@ -177,6 +177,7 @@ func loadKubernetesConfig() KubernetesConfig {
 	config.Enabled = getEnvBool("KUBERNETES_ENABLED", config.Enabled)
 	config.Namespace = getEnv("KUBERNETES_NAMESPACE", config.Namespace)
 	config.RuntimeClass = getEnv("KUBERNETES_RUNTIME_CLASS", config.RuntimeClass)
+	config.PodServiceAccountName = getEnv("KUBERNETES_POD_SERVICE_ACCOUNT_NAME", config.PodServiceAccountName)
 	config.ImagePullPolicy = getEnv("K8S_IMAGE_PULL_POLICY", config.ImagePullPolicy)
 	config.GatewayName = getEnv("KUBERNETES_GATEWAY_NAME", config.GatewayName)
 	config.GatewayNamespace = getEnv("KUBERNETES_GATEWAY_NAMESPACE", config.GatewayNamespace)

--- a/agentarea-mcp-manager/internal/config/config_test.go
+++ b/agentarea-mcp-manager/internal/config/config_test.go
@@ -1,0 +1,13 @@
+package config
+
+import "testing"
+
+func TestLoadKubernetesConfigPodServiceAccountName(t *testing.T) {
+	t.Setenv("KUBERNETES_POD_SERVICE_ACCOUNT_NAME", "agentarea-mcp-runtime")
+
+	cfg := loadKubernetesConfig()
+
+	if cfg.PodServiceAccountName != "agentarea-mcp-runtime" {
+		t.Fatalf("PodServiceAccountName = %q, want %q", cfg.PodServiceAccountName, "agentarea-mcp-runtime")
+	}
+}

--- a/agentarea-mcp-manager/internal/config/kubernetes.go
+++ b/agentarea-mcp-manager/internal/config/kubernetes.go
@@ -14,6 +14,9 @@ type KubernetesConfig struct {
 	// Runtime configuration
 	RuntimeClass string `json:"runtime_class"`
 
+	// Service account to use for MCP server pods created by the Kubernetes backend.
+	PodServiceAccountName string `json:"pod_service_account_name"`
+
 	// Image pull policy (IfNotPresent, Always, Never). Defaults to IfNotPresent
 	// which is safe for k3d/local dev; production clusters should set Always.
 	ImagePullPolicy string `json:"image_pull_policy"`
@@ -130,12 +133,13 @@ type CertManagerConfig struct {
 // DefaultKubernetesConfig returns default Kubernetes configuration
 func DefaultKubernetesConfig() KubernetesConfig {
 	return KubernetesConfig{
-		Enabled:         false,
-		Namespace:       "agentarea",
-		Domain:          "mcp.local",
-		IngressClass:    "nginx",
-		StorageClass:    "standard",
-		ImagePullPolicy: "IfNotPresent",
+		Enabled:               false,
+		Namespace:             "agentarea",
+		Domain:                "mcp.local",
+		IngressClass:          "nginx",
+		StorageClass:          "standard",
+		ImagePullPolicy:       "IfNotPresent",
+		PodServiceAccountName: "",
 
 		DefaultRequests: ResourceRequirements{
 			CPU:    "100m",

--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -284,6 +284,9 @@ The following table lists configurable parameters of the chart and their default
 | mcpManager.gateway.name | string | `"envoy-gateway"` |  |
 | mcpManager.gateway.namespace | string | `"envoy-gateway-system"` |  |
 | mcpManager.runtimeClass | string | `""` |  |
+| mcpManager.runtime.serviceAccount.create | bool | `true` |  |
+| mcpManager.runtime.serviceAccount.name | string | `""` |  |
+| mcpManager.runtime.imagePullSecrets | list | `[]` |  |
 | mcpManager.securityContext | object | `{}` |  |
 | mcpManager.features.enabled[0] | string | `"gateway_api"` |  |
 | mcpManager.features.enabled[1] | string | `"state_reconciler"` |  |

--- a/charts/agentarea/config.yaml
+++ b/charts/agentarea/config.yaml
@@ -115,6 +115,7 @@ groups:
       KUBERNETES_GATEWAY_NAME: '{{ .Values.mcpManager.gateway.name | default "envoy-gateway" }}'
       KUBERNETES_GATEWAY_NAMESPACE: '{{ .Values.mcpManager.gateway.namespace | default "envoy-gateway-system" }}'
       KUBERNETES_RUNTIME_CLASS: '{{ .Values.mcpManager.runtimeClass | default "" }}'
+      KUBERNETES_POD_SERVICE_ACCOUNT_NAME: '{{ include "agentarea.mcpRuntimeServiceAccountName" . }}'
       KUBERNETES_SECURITY_RUN_AS_NON_ROOT: 'true'
       KUBERNETES_SECURITY_READ_ONLY_ROOT_FS: 'true'
       KUBERNETES_DEFAULT_CPU_REQUEST: '100m'

--- a/charts/agentarea/templates/_helpers.tpl
+++ b/charts/agentarea/templates/_helpers.tpl
@@ -73,6 +73,33 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Render global image pull secrets for pod specs.
+*/}}
+{{- define "agentarea.imagePullSecrets" -}}
+{{- with .Values.global.image.pullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render MCP runtime image pull secrets for runtime pod service account.
+*/}}
+{{- define "agentarea.mcpRuntimeImagePullSecrets" -}}
+{{- with .Values.mcpManager.runtime.imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the MCP runtime service account.
+*/}}
+{{- define "agentarea.mcpRuntimeServiceAccountName" -}}
+{{- default (printf "%s-mcp-runtime" (include "agentarea.fullname" .)) .Values.mcpManager.runtime.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Frontend URL
 */}}
 {{- define "agentarea.frontendUrl" -}}

--- a/charts/agentarea/templates/agentarea-backend/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-backend/deployment.yaml
@@ -49,10 +49,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.backend.extraInitContainers }}
       initContainers:
         {{- toYaml .Values.backend.extraInitContainers | nindent 8 }}

--- a/charts/agentarea/templates/agentarea-event-service/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-event-service/deployment.yaml
@@ -49,10 +49,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: event-service
           image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.eventService.image.repository }}:{{ default .Chart.AppVersion .Values.eventService.image.tag }}"

--- a/charts/agentarea/templates/agentarea-frontend/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-frontend/deployment.yaml
@@ -49,10 +49,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: frontend
           image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.frontend.image.repository }}:{{ default .Chart.AppVersion .Values.frontend.image.tag }}"

--- a/charts/agentarea/templates/agentarea-mcp-manager/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-mcp-manager/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: mcp-manager
     spec:
       serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: mcp-manager
           image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.mcpManager.image.repository }}:{{ default .Chart.AppVersion .Values.mcpManager.image.tag }}"

--- a/charts/agentarea/templates/agentarea-temporal/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-temporal/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: temporal
     spec:
       serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: temporal
           image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.temporal.image.repository }}:{{ default .Chart.AppVersion .Values.temporal.image.tag }}"
@@ -100,6 +101,7 @@ spec:
         app.kubernetes.io/component: temporal-ui
     spec:
       serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: temporal-ui
           image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.temporalUi.image.repository }}:{{ default .Chart.AppVersion .Values.temporalUi.image.tag }}"

--- a/charts/agentarea/templates/agentarea-worker/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-worker/deployment.yaml
@@ -49,10 +49,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.worker.extraInitContainers }}
       initContainers:
       {{- toYaml .Values.server.extraInitContainers | nindent 8 }}

--- a/charts/agentarea/templates/configs/mcpManager.env.tpl
+++ b/charts/agentarea/templates/configs/mcpManager.env.tpl
@@ -15,6 +15,7 @@ KUBERNETES_DOMAIN: "{{ .Values.mcpManager.domain | default "mcp.local" }}"
 KUBERNETES_GATEWAY_NAME: "{{ .Values.mcpManager.gateway.name | default "envoy-gateway" }}"
 KUBERNETES_GATEWAY_NAMESPACE: "{{ .Values.mcpManager.gateway.namespace | default "envoy-gateway-system" }}"
 KUBERNETES_RUNTIME_CLASS: "{{ .Values.mcpManager.runtimeClass | default "" }}"
+KUBERNETES_POD_SERVICE_ACCOUNT_NAME: "{{ include "agentarea.mcpRuntimeServiceAccountName" . }}"
 KUBERNETES_SECURITY_RUN_AS_NON_ROOT: "true"
 KUBERNETES_SECURITY_READ_ONLY_ROOT_FS: "true"
 KUBERNETES_DEFAULT_CPU_REQUEST: "100m"
@@ -80,6 +81,11 @@ MCP_FEATURES_ENABLED: "{{ join "," .Values.mcpManager.features.enabled }}"
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-mcpmanager
       key: KUBERNETES_RUNTIME_CLASS
+- name: KUBERNETES_POD_SERVICE_ACCOUNT_NAME
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "agentarea.fullname" . }}-env-mcpmanager
+      key: KUBERNETES_POD_SERVICE_ACCOUNT_NAME
 - name: KUBERNETES_SECURITY_RUN_AS_NON_ROOT
   valueFrom:
     configMapKeyRef:

--- a/charts/agentarea/templates/jobs/create-kratos-db-job.yaml
+++ b/charts/agentarea/templates/jobs/create-kratos-db-job.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/component: create-kratos-db
     spec:
       restartPolicy: Never
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: wait-for-db
           image: "postgres:alpine"

--- a/charts/agentarea/templates/jobs/create-temporal-db-job.yaml
+++ b/charts/agentarea/templates/jobs/create-temporal-db-job.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/component: create-temporal-db
     spec:
       restartPolicy: Never
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: wait-for-db
           image: "postgres:alpine"

--- a/charts/agentarea/templates/jobs/db-migration.yaml
+++ b/charts/agentarea/templates/jobs/db-migration.yaml
@@ -29,10 +29,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.global.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       initContainers:
         # Wait for database to be ready
         - name: wait-for-db

--- a/charts/agentarea/templates/kratos/jwks-init.yaml
+++ b/charts/agentarea/templates/kratos/jwks-init.yaml
@@ -67,6 +67,7 @@ spec:
     spec:
       serviceAccountName: {{ include "agentarea.fullname" . }}-jwks-sa
       restartPolicy: Never
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: jwks-generator
           image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.backend.image.repository }}:{{ default .Chart.AppVersion .Values.backend.image.tag }}"

--- a/charts/agentarea/templates/kratos/kratos.yaml
+++ b/charts/agentarea/templates/kratos/kratos.yaml
@@ -130,6 +130,7 @@ spec:
         app.kubernetes.io/component: kratos
     spec:
       serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: kratos
           image: "{{ default "" .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ default "oryd/kratos" .Values.kratos.image.repository }}:{{ default "v1.3.1" .Values.kratos.image.tag }}"
@@ -245,6 +246,7 @@ spec:
         app.kubernetes.io/component: kratos-migrate
     spec:
       restartPolicy: Never
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: kratos-migrate
           image: "{{ default "" .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ default "oryd/kratos" .Values.kratos.image.repository }}:{{ default "v1.3.1" .Values.kratos.image.tag }}"

--- a/charts/agentarea/templates/postgresql/statefulset.yaml
+++ b/charts/agentarea/templates/postgresql/statefulset.yaml
@@ -22,10 +22,7 @@ spec:
         {{- include "agentarea.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgresql
     spec:
-      {{- with .Values.global.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"

--- a/charts/agentarea/templates/rustfs/rustfs.yaml
+++ b/charts/agentarea/templates/rustfs/rustfs.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: rustfs
     spec:
       serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: rustfs
           image: "{{ default "rustfs/rustfs" .Values.rustfs.image.repository }}:{{ default "latest" .Values.rustfs.image.tag }}"
@@ -134,6 +135,7 @@ spec:
         app.kubernetes.io/component: rustfs-bucket-init
     spec:
       restartPolicy: Never
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: s3-client
           image: "amazon/aws-cli:2.17.51"

--- a/charts/agentarea/templates/serviceaccount.yaml
+++ b/charts/agentarea/templates/serviceaccount.yaml
@@ -9,5 +9,18 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- include "agentarea.imagePullSecrets" . | nindent 0 }}
 automountServiceAccountToken: true
+{{- end }}
+{{- if and .Values.mcpManager.enabled .Values.mcpManager.runtime.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentarea.mcpRuntimeServiceAccountName" . }}
+  labels:
+    {{- include "agentarea.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-runtime
+{{- include "agentarea.mcpRuntimeImagePullSecrets" . | nindent 0 }}
+automountServiceAccountToken: false
 {{- end }}

--- a/charts/agentarea/templates/warm-pool/daemonset.yaml
+++ b/charts/agentarea/templates/warm-pool/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
       runtimeClassName: kata-qemu
       {{- end }}
       serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: warm-pod
           image: "{{ .Values.mcpManager.warmPool.image.repository }}:{{ .Values.mcpManager.warmPool.image.tag }}"

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -520,6 +520,15 @@ mcpManager:
   # Set to "kata-qemu" for Kata Containers (requires Kata runtime)
   # Leave empty "" for standard container runtime
   runtimeClass: ""
+
+  # Runtime MCP server pods use a separate ServiceAccount so their registry
+  # access can point at the managed MCP runtime registry, not platform images.
+  runtime:
+    serviceAccount:
+      create: true
+      name: ""
+    imagePullSecrets: []
+    # - name: agentarea-mcp-runtime-regcred
   
   # Security context - only used when backend is "docker"
   # For "kubernetes" backend, leave empty: {}


### PR DESCRIPTION
## Summary
- centralize AgentArea chart imagePullSecrets rendering via a shared helper
- keep platform workloads on global.image.pullSecrets
- add mcpManager.runtime.imagePullSecrets for MCP runtime registry access
- add a dedicated MCP runtime ServiceAccount with runtime pull secrets and automountServiceAccountToken disabled
- configure MCP Manager to assign that runtime ServiceAccount to Kubernetes-created MCP server pods
- add a regression test for MCP Manager pod ServiceAccount config parsing

## Direction
Runtime MCP pods should pull from a managed/imported runtime registry path, not directly from user registries. User external registry credentials should belong to the future import/mirror pipeline, not runtime pod imagePullSecrets.

## Validation
- helm dependency build charts/agentarea
- helm lint charts/agentarea
- helm template test charts/agentarea --set global.image.registry=agentarea-ru.registry.twcstorage.ru --set 'global.image.pullSecrets[0].name=platform-regcred' --set 'mcpManager.runtime.imagePullSecrets[0].name=runtime-regcred'
- rendered manifest check: all AgentArea workloads have imagePullSecrets
- rendered manifest check: test-agentarea-mcp-runtime ServiceAccount has runtime-regcred and automountServiceAccountToken=false
- go test ./... (from agentarea-mcp-manager)

## Note
The bundled Valkey subchart has its own pull-secret surface and is not an AgentArea template; it remains controlled by the Valkey chart values if private pulls are needed there.