### PR TITLE
Fix Docker CI by syncing platform lockfile

### DIFF
--- a/agentarea-platform/uv.lock
+++ b/agentarea-platform/uv.lock
@@ -27,7 +27,6 @@ members = [
     "agentarea-wallet",
     "agentarea-worker",
     "agentarea-workspace",
-    "agentarea-workspaces",
 ]
 constraints = [
     { name = "cryptography", specifier = ">=46.0.7" },
@@ -134,7 +133,6 @@ dependencies = [
     { name = "agentarea-tasks" },
     { name = "agentarea-triggers" },
     { name = "agentarea-wallet" },
-    { name = "agentarea-workspaces" },
     { name = "alembic" },
     { name = "click" },
     { name = "croniter" },
@@ -160,7 +158,6 @@ requires-dist = [
     { name = "agentarea-tasks", editable = "libs/tasks" },
     { name = "agentarea-triggers", editable = "libs/triggers" },
     { name = "agentarea-wallet", editable = "libs/wallet" },
-    { name = "agentarea-workspaces", editable = "libs/workspaces" },
     { name = "alembic", specifier = ">=1.15.2" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "croniter", specifier = ">=6.2.2" },
@@ -273,6 +270,11 @@ provides-extras = ["dev"]
 name = "agentarea-governance"
 version = "0.0.10"
 source = { editable = "libs/governance" }
+dependencies = [
+    { name = "agentarea-common" },
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+]
 
 [package.optional-dependencies]
 temporal = [
@@ -282,7 +284,10 @@ temporal = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agentarea-common", editable = "libs/common" },
     { name = "agentarea-execution", marker = "extra == 'temporal'", editable = "libs/execution" },
+    { name = "pydantic", specifier = ">=2.4.2" },
+    { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.12.0" },
 ]
 provides-extras = ["temporal"]
@@ -432,7 +437,7 @@ source = { editable = "libs/tasks" }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "agentarea-common" },
-    { name = "agentarea-workspaces" },
+    { name = "agentarea-governance" },
     { name = "pydantic" },
     { name = "temporalio" },
 ]
@@ -441,7 +446,7 @@ dependencies = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.8" },
     { name = "agentarea-common", editable = "libs/common" },
-    { name = "agentarea-workspaces", editable = "libs/workspaces" },
+    { name = "agentarea-governance", editable = "libs/governance" },
     { name = "pydantic", specifier = ">=2.4.2" },
     { name = "temporalio", specifier = ">=1.0.0" },
 ]
@@ -606,23 +611,6 @@ test = [
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.0" },
-]
-
-[[package]]
-name = "agentarea-workspaces"
-version = "0.0.1"
-source = { editable = "libs/workspaces" }
-dependencies = [
-    { name = "agentarea-common" },
-    { name = "pydantic" },
-    { name = "sqlalchemy" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "agentarea-common", editable = "libs/common" },
-    { name = "pydantic", specifier = ">=2.4.2" },
-    { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Refresh agentarea-platform/uv.lock to match current workspace packages
- Remove stale agentarea-workspaces lock entries and wire agentarea-governance dependencies
- Restore frozen uv installs used by api/worker Docker builds

## Verification
- SKIP=helm-docs,helm-lint bash scripts/preflight.sh
- docker build -f agentarea-platform/apps/api/Dockerfile agentarea-platform --progress=plain
- docker build -f agentarea-platform/apps/worker/Dockerfile agentarea-platform --progress=plain

## Context
Main CI was failing in docker-api and docker-worker at uv sync --frozen --no-dev --no-group test --all-packages because uv.lock was stale.