### PR TITLE
Forward VERSION as APP_VERSION build-arg in Docker builds

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -151,6 +151,8 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=${{ inputs.component }}
           cache-to: type=gha,mode=max,scope=${{ inputs.component }}
           provenance: false


### PR DESCRIPTION
## Summary
- Reusable `docker-build-push.yml` workflow read `VERSION` but never forwarded it to the build, so the webapp Dockerfile fell back to its `ARG APP_VERSION=0.0.0` default and baked `NEXT_PUBLIC_APP_VERSION=0.0.0` into the Next bundle (sidebar showed `v0.0.0`).
- Pass `APP_VERSION=${{ steps.version.outputs.version }}` as a build-arg to the build step so the real release version is baked into the frontend image. Other component Dockerfiles ignore the unknown arg, which is harmless.

## Test plan
- [ ] CI builds frontend image on `main` and produces tag like `0.0.10-<sha>`.
- [ ] Pull the new image and confirm sidebar shows `v0.0.10` instead of `v0.0.0`.