### PR TITLE
Fix agent task runtime policy and workspace files

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -21,8 +21,8 @@ from agentarea_api.api.deps.services import (
     get_temporal_workflow_service,
 )
 from agentarea_common.auth.dependencies import UserContextDep
-from agentarea_common.config.app import get_app_settings
 from agentarea_common.events.event_stream_service import EventStreamService
+from agentarea_governance.domain.policies import PolicyDocument, PolicyValidationError
 from agentarea_llm.application.model_instance_service import ModelInstanceService
 from agentarea_tasks.schemas.dto import RunCreate
 from agentarea_tasks.task_service import TaskService
@@ -56,6 +56,7 @@ class TaskCreate(BaseModel):
     parameters: dict[str, Any] = {}
     requires_human_approval: bool | None = False
     project_id: str | None = None
+    task_policy: PolicyDocument | None = None
 
 
 class EscalationResolution(BaseModel):
@@ -307,6 +308,7 @@ async def create_task_for_agent_with_stream(
                 parameters=data.parameters,
                 requires_human_approval=data.requires_human_approval or False,
                 project_id=data.project_id,
+                task_policy=data.task_policy,
             )
             task = await task_service.start_run(
                 payload,
@@ -376,6 +378,16 @@ async def create_task_for_agent_with_stream(
                     },
                 )
 
+        except PolicyValidationError as e:
+            yield _format_sse_event(
+                "error",
+                {
+                    "agent_id": str(agent_id),
+                    "error": str(e),
+                    "error_type": "policy_validation_error",
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
         except ValueError:
             # Agent validation errors
             yield _format_sse_event(
@@ -429,6 +441,7 @@ async def create_task_for_agent_sync(
             parameters=data.parameters,
             requires_human_approval=data.requires_human_approval or False,
             project_id=data.project_id,
+            task_policy=data.task_policy,
         )
         task = await task_service.start_run(
             payload,
@@ -450,6 +463,8 @@ async def create_task_for_agent_sync(
 
         return task_response
 
+    except PolicyValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
     except ValueError as e:
         # Agent validation errors
         raise HTTPException(status_code=404, detail=str(e)) from e
@@ -656,9 +671,8 @@ async def _list_task_artifact_items(
 
 
 def _task_artifact_download_url(agent_id: UUID, task_id: UUID, artifact_path: str) -> str:
-    base = get_app_settings().API_BASE_URL.rstrip("/")
     encoded_path = quote(artifact_path.lstrip("/"), safe="/")
-    return f"{base}/v1/agents/{agent_id}/tasks/{task_id}/artifacts/files/{encoded_path}"
+    return f"/v1/agents/{agent_id}/tasks/{task_id}/artifacts/files/{encoded_path}"
 
 
 async def _verify_task_for_agent(task_service: TaskService, agent_id: UUID, task_id: UUID) -> None:

--- a/agentarea-platform/apps/api/agentarea_api/tools/files_toolset.py
+++ b/agentarea-platform/apps/api/agentarea_api/tools/files_toolset.py
@@ -22,6 +22,7 @@ def _workspace_file_download_url(path: str) -> str:
     description="List, fetch download URLs for, and delete workspace files.",
     category="platform",
     requires_user_confirmation=True,
+    register=False,
 )
 class FilesToolset(Toolset):
     """List, fetch download URLs for, and delete workspace files."""

--- a/agentarea-platform/apps/api/pyproject.toml
+++ b/agentarea-platform/apps/api/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "agentarea-common",
     "agentarea-agents",
     "agentarea-execution",
+    "agentarea-governance",
     "agentarea-llm",
     "agentarea-mcp",
     "agentarea-registry",
@@ -36,6 +37,7 @@ dependencies = [
 agentarea-common = { workspace = true }
 agentarea-agents = { workspace = true }
 agentarea-execution = { workspace = true }
+agentarea-governance = { workspace = true }
 agentarea-llm = { workspace = true }
 agentarea-mcp = { workspace = true }
 agentarea-registry = { workspace = true }

--- a/agentarea-platform/apps/api/tests/test_task_policy_api.py
+++ b/agentarea-platform/apps/api/tests/test_task_policy_api.py
@@ -42,6 +42,23 @@ def _app_for(task_service, context: UserContext) -> FastAPI:
     return app
 
 
+def test_task_artifact_download_url_is_api_relative():
+    agent_id = uuid4()
+    task_id = uuid4()
+
+    url = agents_tasks._task_artifact_download_url(
+        agent_id,
+        task_id,
+        f"tasks/{task_id}/report with spaces.html",
+    )
+
+    assert url == (
+        f"/v1/agents/{agent_id}/tasks/{task_id}/artifacts/files/"
+        f"tasks/{task_id}/report%20with%20spaces.html"
+    )
+    assert "agentarea-backend" not in url
+
+
 @pytest.mark.asyncio
 async def test_task_sync_accepts_task_policy_and_passes_typed_payload():
     agent_id = uuid4()

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/code_tools_loader.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/code_tools_loader.py
@@ -29,6 +29,7 @@ def _ensure_all_toolsets_imported() -> None:
         "agentarea_agents_sdk.tools.calculate_tool",
         "agentarea_agents_sdk.tools.math_toolset",
         "agentarea_agents_sdk.tools.file_toolset",
+        "agentarea_agents_sdk.tools.workspace_files_toolset",
         "agentarea_agents_sdk.tools.web_toolset",
         "agentarea_agents_sdk.tools.shell_toolset",
     ]

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/workspace_files_toolset.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/workspace_files_toolset.py
@@ -1,0 +1,105 @@
+"""Workspace file operations safe to run inside the agent worker.
+
+This toolset intentionally avoids importing ``agentarea_api``. The API process
+also exposes a platform MCP tool with the same user-facing surface, but the
+agent worker needs a pure SDK implementation so code-tool execution does not
+depend on the API package being installed in the worker image.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import quote
+
+from .decorator_tool import Toolset, tool_method
+from .file_toolset import InMemoryStorage, StorageClient
+from .tool_definition import toolset
+
+
+@toolset(
+    namespace="agentarea/workspace_files",
+    display_name="Workspace Files",
+    description="List, fetch API download paths for, and delete workspace files.",
+    category="platform",
+    requires_user_confirmation=True,
+)
+class WorkspaceFilesToolset(Toolset):
+    """Workspace-scoped file operations backed by the injected object store."""
+
+    def __init__(
+        self,
+        storage: StorageClient | None = None,
+        workspace_id: str | None = None,
+        base_prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.storage: StorageClient = storage or InMemoryStorage()
+        self.workspace_id = workspace_id or "_standalone"
+        self.base_prefix = base_prefix.strip("/")
+
+    def _resolve_prefix(self, prefix: str = "") -> str:
+        clean_prefix = prefix.lstrip("/")
+        if ".." in clean_prefix.split("/"):
+            raise ValueError(f"path escapes workspace scope: {prefix!r}")
+        if self.base_prefix and clean_prefix:
+            return f"{self.base_prefix}/{clean_prefix}"
+        return self.base_prefix or clean_prefix
+
+    def _relative(self, path: str) -> str:
+        if self.base_prefix and path.startswith(self.base_prefix + "/"):
+            return path[len(self.base_prefix) + 1 :]
+        return path
+
+    @tool_method
+    async def list(self, prefix: str = "", max_items: int = 200) -> str:
+        """List files in the current workspace's storage."""
+        try:
+            resolved_prefix = self._resolve_prefix(prefix)
+            objects = await self.storage.list(self.workspace_id, prefix=resolved_prefix)
+            rows = []
+            for obj in objects[: max(0, max_items)]:
+                path = getattr(obj, "path", None) or (
+                    obj.get("path") if isinstance(obj, dict) else ""
+                )
+                rows.append(
+                    {
+                        "path": self._relative(path),
+                        "size": getattr(obj, "size", None)
+                        or (obj.get("size") if isinstance(obj, dict) else None),
+                        "content_type": getattr(obj, "content_type", None)
+                        or (obj.get("content_type") if isinstance(obj, dict) else None),
+                    }
+                )
+            return json.dumps(rows, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @tool_method
+    async def get_url(self, path: str, expires_in: int = 3600) -> str:
+        """Return an AgentArea API download path for a workspace file."""
+        try:
+            resolved_path = self._resolve_prefix(path)
+            if not await self.storage.exists(self.workspace_id, resolved_path):
+                return json.dumps({"error": "File not found", "path": path})
+            encoded_path = quote(resolved_path.lstrip("/"), safe="/")
+            return json.dumps(
+                {
+                    "url": f"/v1/files/download/{encoded_path}",
+                    "path": path,
+                    "expires_in": expires_in,
+                }
+            )
+        except Exception as exc:
+            return json.dumps({"error": str(exc), "path": path})
+
+    @tool_method
+    async def delete(self, path: str) -> str:
+        """Delete a workspace file."""
+        try:
+            resolved_path = self._resolve_prefix(path)
+            if not await self.storage.exists(self.workspace_id, resolved_path):
+                return json.dumps({"deleted": False, "error": "File not found"})
+            await self.storage.delete(self.workspace_id, resolved_path)
+            return json.dumps({"deleted": True, "path": path})
+        except Exception as exc:
+            return json.dumps({"deleted": False, "error": str(exc), "path": path})

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_workspace_files_toolset.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_workspace_files_toolset.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from agentarea_agents_sdk.tools.code_tools_loader import create_code_tool_instance
+from agentarea_agents_sdk.tools.file_toolset import InMemoryStorage
+
+
+@pytest.mark.asyncio
+async def test_workspace_files_toolset_runs_without_api_package_context():
+    storage = InMemoryStorage()
+    await storage.put("workspace-1", "shared/report.html", b"<html>ok</html>", "text/html")
+
+    toolset = create_code_tool_instance(
+        "agentarea/workspace_files",
+        extra_kwargs={
+            "storage": storage,
+            "workspace_id": "workspace-1",
+            "base_prefix": "shared",
+        },
+    )
+
+    assert toolset is not None
+    assert toolset.__class__.__module__.startswith("agentarea_agents_sdk.")
+
+    listed = json.loads(await toolset.list())
+    assert listed == [
+        {"path": "report.html", "size": 15, "content_type": "text/html"},
+    ]
+
+    url = json.loads(await toolset.get_url("report.html"))
+    assert url["url"] == "/v1/files/download/shared/report.html"
+
+    deleted = json.loads(await toolset.delete("report.html"))
+    assert deleted == {"deleted": True, "path": "report.html"}

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
@@ -727,7 +727,11 @@ def make_agent_activities(dependencies: ActivityDependencies):
                     # under ``workspaces/{workspace_id}/tasks/{task_id}/`` so
                     # artifacts are grouped by workspace and scoped per task.
                     extra_kwargs: dict = {}
-                    if tool_name in ("agentarea/files", "agentarea/web"):
+                    if tool_name in (
+                        "agentarea/files",
+                        "agentarea/web",
+                        "agentarea/workspace_files",
+                    ):
                         from agentarea_common.artifacts import ArtifactService
 
                         base_prefix = f"tasks/{request.task_id}" if request.task_id else "shared"

--- a/agentarea-platform/libs/execution/agentarea_execution/models.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/models.py
@@ -77,6 +77,7 @@ class AgentExecutionRequest(BaseModel):
 
     # Additional workflow metadata
     workflow_metadata: dict[str, Any] = Field(default_factory=dict)
+    effective_policy: dict[str, Any] | None = None
 
     # Continue-as-new state (populated when workflow restarts with fresh event history)
     continued_state: dict[str, Any] | None = None
@@ -256,6 +257,7 @@ class LLMCallRequest(BaseModel):
     agent_id: str | None = None
     execution_id: str | None = None
     resolved_model: dict | None = None  # Cached ResolvedModelInfo dict; None = DB lookup
+    effective_policy: dict[str, Any] | None = None
 
 
 class LLMUsage(BaseModel):
@@ -288,6 +290,7 @@ class MCPToolRequest(BaseModel):
     agent_id: UUID | None = None  # Calling agent — used by self-referential tools (e.g. triggers)
     tools: list[dict[str, Any]] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    effective_policy: dict[str, Any] | None = None
 
 
 class MCPToolResult(BaseModel):

--- a/agentarea-platform/libs/execution/agentarea_execution/runners/temporal_runner.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/runners/temporal_runner.py
@@ -138,8 +138,8 @@ class TemporalAgentRunner(BaseAgentRunner):
 
         from ..models import LLMCallRequest
         from ..workflows.constants import (
-            DEFAULT_RETRY_ATTEMPTS,
             LLM_CALL_TIMEOUT,
+            LLM_RETRY_ATTEMPTS,
             Activities,
         )
 
@@ -182,7 +182,7 @@ class TemporalAgentRunner(BaseAgentRunner):
             Activities.CALL_LLM,
             args=[llm_request],
             start_to_close_timeout=LLM_CALL_TIMEOUT,
-            retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
+            retry_policy=RetryPolicy(maximum_attempts=LLM_RETRY_ATTEMPTS),
         )
 
         # Extract usage info and update budget

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -92,6 +92,7 @@ from .constants import (
     EVENT_PUBLISH_TIMEOUT,
     HEARTBEAT_TIMEOUT,
     LLM_CALL_TIMEOUT,
+    LLM_RETRY_ATTEMPTS,
     MAX_ITERATIONS,
     TOOL_EXECUTION_TIMEOUT,
     TOOL_OUTPUT_OFFLOAD_CHARS,
@@ -332,6 +333,7 @@ class AgentExecutionWorkflow:
         self.state.goal = self._build_goal_from_request(request)
         self.state.status = ExecutionStatus.INITIALIZING
         self.state.budget_usd = request.budget_usd
+        self.state.effective_policy = request.effective_policy
         self._workflow_metadata = dict(request.workflow_metadata or {})
 
         # Initialize helpers
@@ -747,6 +749,7 @@ class AgentExecutionWorkflow:
         self.state.service_cost_used = state.service_cost_used
         self.state.wallet_id = state.wallet_id
         self.state.resolved_model = state.resolved_model
+        self.state.effective_policy = state.effective_policy
         self.state.status = ExecutionStatus.EXECUTING
 
         # Restore messages from compacted dicts
@@ -841,6 +844,7 @@ class AgentExecutionWorkflow:
             service_cost_used=self.state.service_cost_used,
             wallet_id=self.state.wallet_id,
             resolved_model=self.state.resolved_model,
+            effective_policy=self.state.effective_policy,
         )
 
         # Publish event before continuing (persisted in DB via tier 2)
@@ -867,6 +871,7 @@ class AgentExecutionWorkflow:
             if self.state.goal
             else MAX_ITERATIONS,
             budget_usd=self.state.budget_usd,
+            effective_policy=self.state.effective_policy,
             continued_state=continued_state.model_dump(),
         )
 
@@ -1014,7 +1019,7 @@ class AgentExecutionWorkflow:
 
         # Check maximum iterations
         max_iterations = self.state.goal.max_iterations if self.state.goal else MAX_ITERATIONS
-        if self.state.current_iteration >= max_iterations:
+        if self.state.current_iteration > max_iterations:
             workflow.logger.info(
                 f"Max iterations reached ({max_iterations}) - terminating workflow"
             )
@@ -1237,6 +1242,7 @@ class AgentExecutionWorkflow:
                 agent_id=self.state.agent_id,
                 execution_id=self.state.execution_id,
                 resolved_model=self.state.resolved_model,
+                effective_policy=self.state.effective_policy,
             )
 
             response: LLMCallResult = await workflow.execute_activity(
@@ -1244,7 +1250,7 @@ class AgentExecutionWorkflow:
                 args=[llm_request],
                 start_to_close_timeout=LLM_CALL_TIMEOUT,
                 heartbeat_timeout=HEARTBEAT_TIMEOUT,
-                retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
+                retry_policy=RetryPolicy(maximum_attempts=LLM_RETRY_ATTEMPTS),
             )
 
             # Normalize response fields to support both Pydantic model and plain dict
@@ -1721,6 +1727,7 @@ class AgentExecutionWorkflow:
                 agent_id=UUID(self.state.agent_id) if self.state.agent_id else None,
                 tools=self.state.agent_config.get("tools"),
                 metadata=self._workflow_metadata or {},
+                effective_policy=self.state.effective_policy,
             )
 
             result_obj = await workflow.execute_activity(
@@ -2334,6 +2341,7 @@ class AgentExecutionWorkflow:
                     "parent_agent_id": self.state.agent_id,
                     "parent_task_id": self.state.task_id,
                 },
+                effective_policy=self.state.effective_policy,
             )
 
             # Start child workflow and await result
@@ -2917,7 +2925,9 @@ class AgentExecutionWorkflow:
             success_criteria=request.task_parameters.get(
                 "success_criteria", ["Task completed successfully"]
             ),
-            max_iterations=request.task_parameters.get("max_iterations", MAX_ITERATIONS),
+            max_iterations=request.task_parameters.get(
+                "max_iterations", request.max_reasoning_iterations
+            ),
             requires_human_approval=request.requires_human_approval,
             context=request.task_parameters,
         )

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/constants.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/constants.py
@@ -11,7 +11,7 @@ BUDGET_WARNING_THRESHOLD: Final[float] = 0.8  # 80% of budget
 
 # Timeout configurations
 ACTIVITY_TIMEOUT: Final[timedelta] = timedelta(minutes=5)
-LLM_CALL_TIMEOUT: Final[timedelta] = timedelta(minutes=2)
+LLM_CALL_TIMEOUT: Final[timedelta] = timedelta(minutes=10)
 TOOL_EXECUTION_TIMEOUT: Final[timedelta] = timedelta(minutes=35)
 EVENT_PUBLISH_TIMEOUT: Final[timedelta] = timedelta(seconds=5)
 
@@ -24,6 +24,7 @@ DELEGATION_TIMEOUT: Final[timedelta] = timedelta(minutes=10)  # Max time for chi
 # Retry policies
 DEFAULT_RETRY_ATTEMPTS: Final[int] = 3
 EVENT_PUBLISH_RETRY_ATTEMPTS: Final[int] = 1
+LLM_RETRY_ATTEMPTS: Final[int] = 1
 
 
 # Context window management

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/models.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/models.py
@@ -114,6 +114,7 @@ class ContinueAsNewState(BaseModel):
     wallet_id: str | None = None
     # Cached model resolution — preserved across continue-as-new
     resolved_model: dict | None = None
+    effective_policy: dict[str, Any] | None = None
 
 
 class AgentExecutionState(BaseModel):
@@ -147,3 +148,4 @@ class AgentExecutionState(BaseModel):
     wallet_id: str | None = None
     # Cached model resolution — resolved once at workflow start
     resolved_model: dict | None = None
+    effective_policy: dict[str, Any] | None = None

--- a/agentarea-platform/libs/execution/tests/unit/test_policy_propagation_models.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_policy_propagation_models.py
@@ -9,6 +9,7 @@ from agentarea_execution.models import (
     MCPToolRequest,
 )
 from agentarea_execution.workflows.agent_execution_workflow import AgentExecutionWorkflow
+from agentarea_execution.workflows.constants import LLM_CALL_TIMEOUT, LLM_RETRY_ATTEMPTS
 from agentarea_execution.workflows.models import (
     AgentExecutionState,
     AgentGoal,
@@ -98,6 +99,33 @@ def test_workflow_initialization_stores_effective_policy_from_request():
     source = inspect.getsource(AgentExecutionWorkflow._initialize_workflow)
 
     assert "self.state.effective_policy = request.effective_policy" in source
+
+
+def test_workflow_goal_uses_request_max_reasoning_iterations_by_default():
+    request = AgentExecutionRequest(
+        task_id=uuid4(),
+        agent_id=uuid4(),
+        user_id="user-1",
+        workspace_id="workspace-1",
+        task_query="do work",
+        max_reasoning_iterations=7,
+    )
+
+    workflow_obj = AgentExecutionWorkflow()
+    goal = workflow_obj._build_goal_from_request(request)
+
+    assert goal.max_iterations == 7
+
+
+def test_workflow_iteration_limit_allows_configured_final_iteration():
+    source = inspect.getsource(AgentExecutionWorkflow._should_continue_execution)
+
+    assert "self.state.current_iteration > max_iterations" in source
+
+
+def test_llm_activity_timeout_allows_large_generations_without_retries():
+    assert LLM_CALL_TIMEOUT.total_seconds() == 600
+    assert LLM_RETRY_ATTEMPTS == 1
 
 
 def test_workflow_continue_as_new_and_activity_payloads_carry_effective_policy():

--- a/agentarea-platform/libs/tasks/agentarea_tasks/domain/models.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/domain/models.py
@@ -170,6 +170,7 @@ class SimpleTask(BaseModel):
     completed_at: datetime | None = None
     execution_id: str | None = None  # Temporal workflow execution ID or other execution identifier
     metadata: dict[str, Any] = {}  # Additional metadata for task management
+    effective_policy: dict[str, Any] | None = None  # Resolved governance policy passed to execution
 
     @field_validator("result", mode="before")
     @classmethod

--- a/agentarea-platform/libs/tasks/agentarea_tasks/schemas/dto.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/schemas/dto.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+from agentarea_governance.domain.policies import PolicyDocument
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -55,4 +56,8 @@ class RunCreate(BaseModel):
     project_id: str | None = Field(
         default=None,
         description="Optional project scope for billing / organization.",
+    )
+    task_policy: PolicyDocument | None = Field(
+        default=None,
+        description="Optional task-scoped governance policy that may only tighten higher scopes.",
     )

--- a/agentarea-platform/libs/tasks/agentarea_tasks/temporal_task_manager.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/temporal_task_manager.py
@@ -138,6 +138,7 @@ class TemporalTaskManager(BaseTaskManager):
                     (task.metadata or {}).get("requires_human_approval", False)
                 ),
                 workflow_metadata=task.metadata or {},
+                effective_policy=task.effective_policy,
             )
 
             # Start the workflow using the correct workflow name and arguments
@@ -153,6 +154,7 @@ class TemporalTaskManager(BaseTaskManager):
                 "max_reasoning_iterations": execution_request.max_reasoning_iterations,
                 "requires_human_approval": execution_request.requires_human_approval,
                 "workflow_metadata": execution_request.workflow_metadata,
+                "effective_policy": execution_request.effective_policy,
             }
 
             # Create workflow config with task queue

--- a/agentarea-platform/uv.lock
+++ b/agentarea-platform/uv.lock
@@ -27,7 +27,6 @@ members = [
     "agentarea-wallet",
     "agentarea-worker",
     "agentarea-workspace",
-    "agentarea-workspaces",
 ]
 constraints = [
     { name = "cryptography", specifier = ">=46.0.7" },
@@ -125,6 +124,7 @@ dependencies = [
     { name = "agentarea-agents" },
     { name = "agentarea-common" },
     { name = "agentarea-execution" },
+    { name = "agentarea-governance" },
     { name = "agentarea-llm" },
     { name = "agentarea-mcp" },
     { name = "agentarea-openapi" },
@@ -134,7 +134,6 @@ dependencies = [
     { name = "agentarea-tasks" },
     { name = "agentarea-triggers" },
     { name = "agentarea-wallet" },
-    { name = "agentarea-workspaces" },
     { name = "alembic" },
     { name = "click" },
     { name = "croniter" },
@@ -151,6 +150,7 @@ requires-dist = [
     { name = "agentarea-agents", editable = "libs/agents" },
     { name = "agentarea-common", editable = "libs/common" },
     { name = "agentarea-execution", editable = "libs/execution" },
+    { name = "agentarea-governance", editable = "libs/governance" },
     { name = "agentarea-llm", editable = "libs/llm" },
     { name = "agentarea-mcp", editable = "libs/mcp" },
     { name = "agentarea-openapi", editable = "libs/openapi" },
@@ -160,7 +160,6 @@ requires-dist = [
     { name = "agentarea-tasks", editable = "libs/tasks" },
     { name = "agentarea-triggers", editable = "libs/triggers" },
     { name = "agentarea-wallet", editable = "libs/wallet" },
-    { name = "agentarea-workspaces", editable = "libs/workspaces" },
     { name = "alembic", specifier = ">=1.15.2" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "croniter", specifier = ">=6.2.2" },
@@ -273,6 +272,11 @@ provides-extras = ["dev"]
 name = "agentarea-governance"
 version = "0.0.10"
 source = { editable = "libs/governance" }
+dependencies = [
+    { name = "agentarea-common" },
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+]
 
 [package.optional-dependencies]
 temporal = [
@@ -282,7 +286,10 @@ temporal = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agentarea-common", editable = "libs/common" },
     { name = "agentarea-execution", marker = "extra == 'temporal'", editable = "libs/execution" },
+    { name = "pydantic", specifier = ">=2.4.2" },
+    { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "temporalio", marker = "extra == 'temporal'", specifier = ">=1.12.0" },
 ]
 provides-extras = ["temporal"]
@@ -432,7 +439,7 @@ source = { editable = "libs/tasks" }
 dependencies = [
     { name = "a2a-sdk" },
     { name = "agentarea-common" },
-    { name = "agentarea-workspaces" },
+    { name = "agentarea-governance" },
     { name = "pydantic" },
     { name = "temporalio" },
 ]
@@ -441,7 +448,7 @@ dependencies = [
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.2.8" },
     { name = "agentarea-common", editable = "libs/common" },
-    { name = "agentarea-workspaces", editable = "libs/workspaces" },
+    { name = "agentarea-governance", editable = "libs/governance" },
     { name = "pydantic", specifier = ">=2.4.2" },
     { name = "temporalio", specifier = ">=1.0.0" },
 ]
@@ -606,23 +613,6 @@ test = [
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.0" },
-]
-
-[[package]]
-name = "agentarea-workspaces"
-version = "0.0.1"
-source = { editable = "libs/workspaces" }
-dependencies = [
-    { name = "agentarea-common" },
-    { name = "pydantic" },
-    { name = "sqlalchemy" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "agentarea-common", editable = "libs/common" },
-    { name = "pydantic", specifier = ">=2.4.2" },
-    { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 
 [[package]]

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -3810,6 +3810,16 @@ export interface components {
             /** Tools */
             tools?: components["schemas"]["ToolConfigYAML"][] | null;
         };
+        /**
+         * ApprovalPolicy
+         * @description Human approval and escalation requirements.
+         */
+        ApprovalPolicy: {
+            /** Escalation Rules */
+            escalation_rules?: string[];
+            /** Requires Human Approval */
+            requires_human_approval?: boolean | null;
+        };
         /** AssociationBody */
         AssociationBody: {
             /** Id */
@@ -3896,6 +3906,30 @@ export interface components {
              * @description ZIP file containing the skill package
              */
             file: string;
+        };
+        /**
+         * BudgetPolicy
+         * @description Budget-related ceilings.
+         */
+        BudgetPolicy: {
+            /** Monthly Spend Cap Usd */
+            monthly_spend_cap_usd?: number | string | null;
+            /** Run Budget Usd */
+            run_budget_usd?: number | string | null;
+            /** Service Budget Usd */
+            service_budget_usd?: number | string | null;
+        };
+        /**
+         * ContentSafetyPolicy
+         * @description Content-safety governance controls.
+         */
+        ContentSafetyPolicy: {
+            /** Output Sanitizer Enabled */
+            output_sanitizer_enabled?: boolean | null;
+            /** Prompt Injection Detection Enabled */
+            prompt_injection_detection_enabled?: boolean | null;
+            /** Semantic Guard Threshold */
+            semantic_guard_threshold?: number | null;
         };
         /** CreateInvitationBody */
         CreateInvitationBody: {
@@ -5243,6 +5277,17 @@ export interface components {
             /** Tx Hash */
             tx_hash?: string | null;
         };
+        /**
+         * PolicyDocument
+         * @description Source policy document stored per scope.
+         */
+        PolicyDocument: {
+            approval?: components["schemas"]["ApprovalPolicy"] | null;
+            budget?: components["schemas"]["BudgetPolicy"] | null;
+            content_safety?: components["schemas"]["ContentSafetyPolicy"] | null;
+            tokens?: components["schemas"]["TokenPolicy"] | null;
+            tools?: components["schemas"]["ToolsPolicy"] | null;
+        };
         /** ProjectAgentRef */
         ProjectAgentRef: {
             /**
@@ -5935,6 +5980,7 @@ export interface components {
              * @default false
              */
             requires_human_approval: boolean | null;
+            task_policy?: components["schemas"]["PolicyDocument"] | null;
         };
         /**
          * TaskEvent
@@ -6137,6 +6183,16 @@ export interface components {
             total_cost?: number | null;
         };
         /**
+         * TokenPolicy
+         * @description Token-related ceilings.
+         */
+        TokenPolicy: {
+            /** Max Tokens */
+            max_tokens?: number | null;
+            /** Max Tokens Per Call */
+            max_tokens_per_call?: number | null;
+        };
+        /**
          * ToolConfigYAML
          * @description Tool configuration in YAML format.
          */
@@ -6190,6 +6246,16 @@ export interface components {
             openapi_connection_id?: string | null;
             /** Requires User Confirmation */
             requires_user_confirmation?: boolean | null;
+        };
+        /**
+         * ToolsPolicy
+         * @description MCP tool capability restrictions.
+         */
+        ToolsPolicy: {
+            /** Allowed */
+            allowed?: string[] | null;
+            /** Denied */
+            denied?: string[];
         };
         /**
          * TriggerCreate


### PR DESCRIPTION
## Summary
- propagate task-scoped governance policy through task creation, Temporal workflow state, LLM/MCP payloads, child workflows, and continue-as-new
- add worker-safe SDK implementation for `agentarea/workspace_files` and return API-relative artifact URLs instead of internal storage/backend hosts
- respect `max_reasoning_iterations`, fix the max-iteration off-by-one, and make long LLM calls bounded without duplicate retries

## Verification
- `uv lock --check`
- `uv run pytest apps/api/tests/test_task_policy_api.py libs/execution/tests/unit/test_policy_propagation_models.py libs/agentarea-agents-sdk/tests/test_workspace_files_toolset.py -q`
- `uv run ruff check ...`
- dev cluster fresh agent task `21565e93-ae49-4aab-aed0-56eec48793cc` completed successfully with web, shell, files, and workspace_files tools; HTML artifact `constract_runtimefix_smoke.html` was created and artifact `download_url` is API-relative
