### PR TITLE
fix(inbox): avoid concurrent queries on shared read session

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/inbox.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/inbox.py
@@ -48,22 +48,21 @@ async def get_inbox_items(
     ordered by most recently updated first. Includes total count for badge/pagination.
     """
     try:
-        import asyncio
-
         query_statuses = [status] if status and status in INBOX_STATUSES else INBOX_STATUSES
         offset = (page - 1) * page_size
 
-        agents_result, tasks, total = await asyncio.gather(
-            agent_service.list(),
-            task_service.task_repository.list_by_statuses(
-                statuses=query_statuses,
-                agent_id=agent_id,
-                limit=page_size,
-                offset=offset,
-            ),
-            task_service.task_repository.count_by_statuses(
-                statuses=query_statuses,
-            ),
+        # Sequential awaits: agent_service and task_service share one AsyncSession
+        # via ReadRepositoryFactoryDep, and asyncpg forbids concurrent ops on a
+        # single connection ("another operation is in progress").
+        agents_result = await agent_service.list()
+        tasks = await task_service.task_repository.list_by_statuses(
+            statuses=query_statuses,
+            agent_id=agent_id,
+            limit=page_size,
+            offset=offset,
+        )
+        total = await task_service.task_repository.count_by_statuses(
+            statuses=query_statuses,
         )
 
         agent_map = {str(agent.id): agent.name for agent in agents_result}


### PR DESCRIPTION
## Summary
- `/v1/inbox/` ran three queries concurrently on a single `AsyncSession` (`agent_service.list()` + `list_by_statuses` + `count_by_statuses`), all reached via the FastAPI-deduped `ReadRepositoryFactoryDep`. asyncpg refuses concurrent ops on one connection (`another operation is in progress`), so under real prod latency the gather'd reads actually overlapped and the request 500'd — the Next.js inbox page caught it and rendered "Failed to load inbox".
- Switched the three reads to sequential awaits. AUTOCOMMIT read session, sub-100ms typical — no meaningful latency cost.

## Test plan
- [ ] Hit `/v1/inbox/` and confirm 200 with items / counts (all four filters used by the UI: no status, `pending`, `completed`, `failed`).
- [ ] `make test` in `agentarea-platform/`.
- [ ] Smoke check the Inbox page in prod after deploy.

## Notes
- Same `asyncio.gather` pattern exists at `agents_tasks.py:158` with two queries on the shared read session — latent, not addressed in this PR.
- Separate UX bug also noticed: frontend sends `status=pending` but backend only knows `waiting_for_approval`, so the "Pending" tab silently returns all three statuses. Left for a follow-up.