### PR TITLE
Fix MCPServerResponse for nullable docker_image_url

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_servers_specifications.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_servers_specifications.py
@@ -19,7 +19,7 @@ class MCPServerResponse(BaseModel):
     id: UUID
     name: str
     description: str
-    docker_image_url: str
+    docker_image_url: str | None = None
     version: str
     tags: list[str]
     is_public: bool


### PR DESCRIPTION
## Summary
- `MCPServerResponse.docker_image_url` typed as `str` but DB column is nullable (since migration `jj1_make_docker_image_url_nullable`) for remote-URL MCP servers
- This caused a 500 on `GET /v1/mcp-servers` whenever any server had `docker_image_url=NULL`
- Aligned response schema with the domain model (`str | None = None`)

## Test plan
- [x] Reload backend with `--reload`, hit `GET /v1/mcp-servers/` against a workspace containing a remote-URL server — no 500
- [x] Frontend `/mcp-servers` page loads