### PR TITLE
feat(agents): lazy load_mode for OpenAPI tools (#115)

### DIFF
--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/__init__.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/__init__.py
@@ -19,7 +19,7 @@ from .tool_definition import (
     toolset,
 )
 from .tool_executor import ToolExecutor
-from .tool_manager import ToolManager
+from .tool_manager import DiscoveryResult, ToolManager
 from .tool_provider import (
     AgentToolProvider,
     BuiltinToolProvider,
@@ -48,6 +48,7 @@ __all__ = [
     "ToolExecutionError",
     "ToolExecutor",
     "ToolManager",
+    "DiscoveryResult",
     "ToolRegistry",
     "Toolset",
     "ToolsetAdapter",

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/__init__.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/__init__.py
@@ -1,0 +1,35 @@
+"""Tool disclosure policies — Strategy + Factory for managing per-call context."""
+
+from .policies import LOAD_TOOLS_NAME, ExplicitPolicy, NamedLookupPolicy
+from .protocol import (
+    DisclosureContext,
+    Partition,
+    RevealRequest,
+    RevealResult,
+    SearchableEntry,
+    ToolCandidate,
+    ToolDisclosurePolicy,
+)
+from .registry import list_policies, policy_from_config, register_policy
+
+# Built-in policy registrations. `searchable` is the YAML shorthand alias users
+# put into ToolSettingsYAML.load_mode; named_lookup is the canonical name.
+register_policy("explicit", ExplicitPolicy)
+register_policy("named_lookup", NamedLookupPolicy)
+register_policy("searchable", NamedLookupPolicy)
+
+__all__ = [
+    "DisclosureContext",
+    "ExplicitPolicy",
+    "LOAD_TOOLS_NAME",
+    "NamedLookupPolicy",
+    "Partition",
+    "RevealRequest",
+    "RevealResult",
+    "SearchableEntry",
+    "ToolCandidate",
+    "ToolDisclosurePolicy",
+    "list_policies",
+    "policy_from_config",
+    "register_policy",
+]

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/policies.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/policies.py
@@ -1,0 +1,152 @@
+"""Concrete ToolDisclosurePolicy implementations.
+
+ExplicitPolicy preserves the legacy "ship every schema every call" behavior.
+NamedLookupPolicy ships only a name+description catalog plus a `load_tools`
+meta-tool; the LLM picks names from the catalog and we resolve them on demand.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .protocol import (
+    DisclosureContext,
+    Partition,
+    RevealRequest,
+    RevealResult,
+    ToolCandidate,
+)
+
+LOAD_TOOLS_NAME = "load_tools"
+
+
+class ExplicitPolicy:
+    """All schemas in context every call. Identity policy — no behavior change."""
+
+    def partition(
+        self, candidates: list[ToolCandidate], ctx: DisclosureContext
+    ) -> Partition:
+        return Partition(explicit=[c.schema for c in candidates], deferred=[])
+
+    def render_catalog(
+        self, deferred: list[ToolCandidate], ctx: DisclosureContext
+    ) -> str:
+        return ""
+
+    def get_meta_tool_definitions(
+        self, ctx: DisclosureContext
+    ) -> list[dict[str, Any]]:
+        return []
+
+    def reveal(
+        self,
+        request: RevealRequest,
+        pool: list[ToolCandidate],
+        ctx: DisclosureContext,
+    ) -> RevealResult:
+        return RevealResult()
+
+
+class NamedLookupPolicy:
+    """Catalog of name+description in the system prompt; reveal by exact name.
+
+    Token-saving choice: we never put per-operation `inputSchema` blocks in
+    `available_tools` until the LLM explicitly asks for them via `load_tools`.
+    """
+
+    def partition(
+        self, candidates: list[ToolCandidate], ctx: DisclosureContext
+    ) -> Partition:
+        return Partition(explicit=[], deferred=list(candidates))
+
+    def render_catalog(
+        self, deferred: list[ToolCandidate], ctx: DisclosureContext
+    ) -> str:
+        if not deferred:
+            return ""
+
+        groups: dict[str, list[ToolCandidate]] = {}
+        for c in deferred:
+            groups.setdefault(c.connection_id or "default", []).append(c)
+
+        lines = [
+            "",
+            "## Available OpenAPI Operations",
+            (
+                f'Call {LOAD_TOOLS_NAME}(["name1","name2"]) with the exact '
+                "operation names you need before invoking them."
+            ),
+        ]
+        for connection_id in sorted(groups.keys()):
+            lines.append("")
+            lines.append(f"[{connection_id}]")
+            for cand in sorted(groups[connection_id], key=lambda c: c.name):
+                stripped = (cand.description or "").strip()
+                first_line = stripped.splitlines()[0] if stripped else ""
+                lines.append(
+                    f"- {cand.name}: {first_line}" if first_line else f"- {cand.name}"
+                )
+        return "\n".join(lines)
+
+    def get_meta_tool_definitions(
+        self, ctx: DisclosureContext
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": LOAD_TOOLS_NAME,
+                    "description": (
+                        "Load full schemas for operations listed in 'Available OpenAPI "
+                        "Operations'. Pass the exact operation names you need; after this "
+                        "call those operations become callable as regular tools."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "tool_names": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Exact operation names from the catalog.",
+                            }
+                        },
+                        "required": ["tool_names"],
+                    },
+                },
+            }
+        ]
+
+    def reveal(
+        self,
+        request: RevealRequest,
+        pool: list[ToolCandidate],
+        ctx: DisclosureContext,
+    ) -> RevealResult:
+        index = {c.name: c for c in pool}
+        revealed: list[dict[str, Any]] = []
+        matched: list[str] = []
+        unknown: list[str] = []
+        for name in request.tool_names:
+            cand = index.get(name)
+            if cand is None:
+                unknown.append(name)
+            else:
+                revealed.append(cand.schema)
+                matched.append(name)
+
+        if unknown:
+            valid_preview = sorted(index.keys())[:20]
+            message = (
+                f"Loaded {len(matched)} of {len(request.tool_names)} requested operations. "
+                f"Unknown names: {unknown}. "
+                f"Valid examples: {valid_preview}"
+                + (" (more available)" if len(index) > 20 else "")
+            )
+        else:
+            message = f"Loaded {len(matched)} operations: {matched}"
+        return RevealResult(
+            revealed=revealed,
+            matched_names=matched,
+            unknown_names=unknown,
+            message=message,
+        )

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/protocol.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/protocol.py
@@ -1,0 +1,102 @@
+"""ToolDisclosurePolicy protocol and supporting types.
+
+GoF Strategy: a swappable algorithm family for managing how tools enter and
+leave the LLM's per-call context. The workflow depends only on this protocol;
+concrete policies are interchangeable, and decorators (truncation, threshold,
+metrics) compose at runtime without workflow changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class ToolCandidate:
+    """A tool that the policy may keep explicit or defer.
+
+    Carries enough metadata for both the catalog block (name + description)
+    and on-demand reveal (full schema).
+    """
+
+    name: str
+    description: str
+    schema: dict[str, Any]
+    connection_id: str = ""
+    source_type: str = "openapi"
+
+
+@dataclass
+class SearchableEntry:
+    """Lightweight projection of a deferred candidate, for the catalog block."""
+
+    name: str
+    description: str
+    connection_id: str = ""
+
+
+@dataclass
+class Partition:
+    """Result of policy.partition: explicit schemas + deferred candidates."""
+
+    explicit: list[dict[str, Any]] = field(default_factory=list)
+    deferred: list[ToolCandidate] = field(default_factory=list)
+
+
+@dataclass
+class RevealRequest:
+    """Input to policy.reveal."""
+
+    tool_names: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RevealResult:
+    """Result of policy.reveal."""
+
+    revealed: list[dict[str, Any]] = field(default_factory=list)
+    matched_names: list[str] = field(default_factory=list)
+    unknown_names: list[str] = field(default_factory=list)
+    message: str = ""
+
+
+@dataclass
+class DisclosureContext:
+    """Dependency-injected context for policy decisions."""
+
+    model_name: str = ""
+    context_window: int = 0
+    iteration: int = 0
+
+
+@runtime_checkable
+class ToolDisclosurePolicy(Protocol):
+    """Strategy: decides what enters context now, what's deferred, and how to reveal."""
+
+    def partition(
+        self, candidates: list[ToolCandidate], ctx: DisclosureContext
+    ) -> Partition:
+        """Split candidates into explicit (full schemas) and deferred (catalog only)."""
+        ...
+
+    def render_catalog(
+        self, deferred: list[ToolCandidate], ctx: DisclosureContext
+    ) -> str:
+        """System-prompt block describing deferred tools. Empty string = no block."""
+        ...
+
+    def get_meta_tool_definitions(
+        self, ctx: DisclosureContext
+    ) -> list[dict[str, Any]]:
+        """Function-call meta-tools the LLM uses to interact with this policy."""
+        ...
+
+    def reveal(
+        self,
+        request: RevealRequest,
+        pool: list[ToolCandidate],
+        ctx: DisclosureContext,
+    ) -> RevealResult:
+        """Resolve a reveal request into full schemas to append to the LLM context."""
+        ...

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/registry.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/disclosure/registry.py
@@ -1,0 +1,55 @@
+"""Factory + registry for ToolDisclosurePolicy.
+
+Maps a config string or dict (e.g. `load_mode: "searchable"` from YAML) to a
+concrete policy instance. New policies register themselves once at import.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .protocol import ToolDisclosurePolicy
+
+_REGISTRY: dict[str, Callable[[], ToolDisclosurePolicy]] = {}
+
+
+def register_policy(name: str, factory: Callable[[], ToolDisclosurePolicy]) -> None:
+    """Register a policy factory under a name. Idempotent — last write wins."""
+    _REGISTRY[name] = factory
+
+
+def list_policies() -> list[str]:
+    """Names of all registered policies."""
+    return sorted(_REGISTRY.keys())
+
+
+def policy_from_config(config: str | dict | None) -> ToolDisclosurePolicy:
+    """Resolve a config value into a policy instance.
+
+    Accepts:
+        None         -> ExplicitPolicy (registered as "explicit")
+        "<name>"     -> registered factory by name
+        {"name": x}  -> registered factory by x
+    """
+    if config is None:
+        name = "explicit"
+    elif isinstance(config, str):
+        name = config
+    elif isinstance(config, dict):
+        raw = config.get("name", "")
+        if not isinstance(raw, str) or not raw:
+            raise ValueError(
+                f"disclosure policy config dict must have non-empty 'name': {config!r}"
+            )
+        name = raw
+    else:
+        raise ValueError(
+            f"disclosure policy config must be None, str, or dict; got {type(config).__name__}"
+        )
+
+    factory = _REGISTRY.get(name)
+    if factory is None:
+        raise ValueError(
+            f"Unknown disclosure policy: {name!r}. Available: {sorted(_REGISTRY.keys())}"
+        )
+    return factory()

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/openapi_tool.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/openapi_tool.py
@@ -374,3 +374,35 @@ class OpenAPIToolFactory:
             allowed_tools,
         )
         return tools
+
+    @staticmethod
+    def get_tool_definition_by_name(connection: Any, tool_name: str) -> dict[str, Any] | None:
+        """Build an OpenAI function definition for one operation by name.
+
+        Used by the disclosure layer to lazily reveal a single tool's full
+        schema without instantiating an `OpenAPITool` object. Looks up
+        `connection.available_tools` (the pre-parsed `{name, description,
+        inputSchema}` JSON column) and matches against either the raw
+        operation name or its slugified form (the latter is what the LLM
+        sees, since OpenAPITool.name slugifies on construction).
+
+        Returns None if the connection has no available_tools or no match.
+        """
+        available = getattr(connection, "available_tools", None) or []
+        target_slug = _slugify_name(tool_name)
+        for op in available:
+            op_name = op.get("name") or ""
+            if not op_name:
+                continue
+            if op_name == tool_name or _slugify_name(op_name) == target_slug:
+                return {
+                    "type": "function",
+                    "function": {
+                        "name": _slugify_name(op_name),
+                        "description": op.get("description")
+                        or f"OpenAPI operation {op_name}",
+                        "parameters": op.get("inputSchema")
+                        or {"type": "object", "properties": {}},
+                    },
+                }
+        return None

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/tool_manager.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/tool_manager.py
@@ -1,6 +1,7 @@
 """Service for managing and discovering available tools."""
 
 import logging
+from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
@@ -9,7 +10,7 @@ from .base_tool import ToolRegistry
 from .code_tools_loader import create_code_tool_instance
 from .completion_tool import CompletionTool
 from .mcp_tool import MCPToolFactory
-from .openapi_tool import OpenAPIToolFactory
+from .openapi_tool import OpenAPIToolFactory, _slugify_name
 from .tool_provider import (
     AgentToolProvider,
     BuiltinToolProvider,
@@ -20,6 +21,21 @@ from .tool_provider import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiscoveryResult:
+    """Output of `discover_available_tools_split`.
+
+    `explicit_tools` ships full OpenAI function definitions into the LLM
+    context every call. `searchable_entries` are deferred — they live in
+    workflow state for the `load_tools` meta-tool to reveal on demand. Each
+    entry is a dict matching the ToolCandidate shape: name, description,
+    connection_id, schema, source_type.
+    """
+
+    explicit_tools: list[dict[str, Any]] = field(default_factory=list)
+    searchable_entries: list[dict[str, Any]] = field(default_factory=list)
 
 
 class ToolManager:
@@ -50,25 +66,77 @@ class ToolManager:
         workspace_id: str | None = None,
         user_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Discover available tools for an agent.
+        """Discover available tools for an agent (legacy flat-list API).
 
-        Args:
-            agent_id: The agent ID
-            tools_config: Agent's tools configuration (list of tool definitions)
-            mcp_server_instance_service: Service for MCP server instances
-            agent_service: Optional agent service for resolving agent-type tools
-            base_url: Base URL for constructing A2A endpoints
-            auth_token: Optional auth token for A2A calls
-
-        Returns:
-            List of available tool definitions (OpenAI format)
+        Ignores `load_mode` and always returns full schemas for every tool —
+        existing callers keep their current behavior. New code should use
+        `discover_available_tools_split` to honor `load_mode`.
         """
-        # Start with built-in tools
-        all_tools = self.registry.get_openai_functions()
+        result = await self._discover(
+            agent_id=agent_id,
+            tools_config=tools_config,
+            mcp_server_instance_service=mcp_server_instance_service,
+            agent_service=agent_service,
+            base_url=base_url,
+            auth_token=auth_token,
+            task_service=task_service,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            force_explicit=True,
+        )
+        return result.explicit_tools
+
+    async def discover_available_tools_split(
+        self,
+        agent_id: UUID,
+        tools_config: list[dict[str, Any]] | None,
+        mcp_server_instance_service,
+        agent_service=None,
+        base_url: str = "",
+        auth_token: str | None = None,
+        task_service=None,
+        workspace_id: str | None = None,
+        user_id: str | None = None,
+    ) -> DiscoveryResult:
+        """Discover tools, honoring `settings.load_mode` per tool.
+
+        For OpenAPI tools with `load_mode == "searchable"`, schemas go into
+        `searchable_entries` (deferred pool) instead of `explicit_tools`.
+        Other tool types and `load_mode == "explicit"` (or absent) preserve
+        legacy behavior — full schemas in `explicit_tools`.
+        """
+        return await self._discover(
+            agent_id=agent_id,
+            tools_config=tools_config,
+            mcp_server_instance_service=mcp_server_instance_service,
+            agent_service=agent_service,
+            base_url=base_url,
+            auth_token=auth_token,
+            task_service=task_service,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            force_explicit=False,
+        )
+
+    async def _discover(
+        self,
+        agent_id: UUID,
+        tools_config: list[dict[str, Any]] | None,
+        mcp_server_instance_service,
+        agent_service,
+        base_url: str,
+        auth_token: str | None,
+        task_service,
+        workspace_id: str | None,
+        user_id: str | None,
+        force_explicit: bool,
+    ) -> DiscoveryResult:
+        """Shared discovery worker. Public methods select force_explicit."""
+        result = DiscoveryResult(explicit_tools=list(self.registry.get_openai_functions()))
 
         if not tools_config:
             logger.info(f"No tools configured for agent {agent_id}")
-            return all_tools
+            return result
 
         for tool in tools_config:
             tool_type = tool.get("type")
@@ -76,7 +144,6 @@ class ToolManager:
             settings = tool.get("settings", {})
 
             if tool_type == "code":
-                # Code-based tool
                 disabled_methods = settings.get("disabled_methods", [])
                 toolset_methods = (
                     {method: False for method in disabled_methods} if disabled_methods else {}
@@ -89,14 +156,12 @@ class ToolManager:
                     if isinstance(tool_instance, Toolset):
                         tool_instance = ToolsetAdapter(tool_instance)
 
-                    all_tools.append(tool_instance.get_openai_function_definition())
+                    result.explicit_tools.append(tool_instance.get_openai_function_definition())
                     logger.info(f"Added code tool: {tool_name}")
                 else:
                     logger.warning(f"Unknown code tool requested: {tool_name}")
 
             elif tool_type == "mcp":
-                # MCP tool - find instance by ID or name
-                # Normalize allowed_tools: can be str[] or {tool_name, ...}[]
                 raw_allowed = settings.get("allowed_tools") or []
                 allowed_names = [
                     (t["tool_name"] if isinstance(t, dict) else t) for t in raw_allowed
@@ -105,10 +170,9 @@ class ToolManager:
                     tool_name, allowed_names, mcp_server_instance_service
                 )
                 for mcp_tool in mcp_tools:
-                    all_tools.append(mcp_tool.get_openai_function_definition())
+                    result.explicit_tools.append(mcp_tool.get_openai_function_definition())
 
             elif tool_type == "agent":
-                # Agent-to-agent tool via A2A protocol
                 if not agent_service or not base_url:
                     logger.warning(
                         f"Skipping agent tool '{tool_name}': agent_service or base_url not provided"
@@ -127,7 +191,7 @@ class ToolManager:
                     user_id=user_id,
                 )
                 if a2a_tool:
-                    all_tools.append(a2a_tool.get_openai_function_definition())
+                    result.explicit_tools.append(a2a_tool.get_openai_function_definition())
                     logger.info(f"Added agent tool: {tool_name}")
 
             elif tool_type == "openapi":
@@ -139,11 +203,20 @@ class ToolManager:
                 allowed_names = [
                     (t["tool_name"] if isinstance(t, dict) else t) for t in raw_allowed
                 ]
-                openapi_tools = await self._discover_openapi_tools_by_name(
-                    connection_ref, allowed_names, self._openapi_connection_service
-                )
-                for openapi_tool in openapi_tools:
-                    all_tools.append(openapi_tool.get_openai_function_definition())
+                load_mode = settings.get("load_mode")
+                if load_mode == "searchable" and not force_explicit:
+                    entries = await self._build_openapi_searchable_entries(
+                        connection_ref, allowed_names, self._openapi_connection_service
+                    )
+                    result.searchable_entries.extend(entries)
+                else:
+                    openapi_tools = await self._discover_openapi_tools_by_name(
+                        connection_ref, allowed_names, self._openapi_connection_service
+                    )
+                    for openapi_tool in openapi_tools:
+                        result.explicit_tools.append(
+                            openapi_tool.get_openai_function_definition()
+                        )
 
             else:
                 logger.warning(
@@ -151,8 +224,105 @@ class ToolManager:
                     extra={"tool_config": tool},
                 )
 
-        logger.info(f"Discovered {len(all_tools)} tools for agent {agent_id}")
-        return all_tools
+        logger.info(
+            "Discovered %d explicit tools and %d searchable entries for agent %s",
+            len(result.explicit_tools),
+            len(result.searchable_entries),
+            agent_id,
+        )
+        return result
+
+    async def _build_openapi_searchable_entries(
+        self,
+        connection_name_or_id: str,
+        allowed_tools: list[str],
+        openapi_connection_service,
+    ) -> list[dict[str, Any]]:
+        """Cheap path: read pre-parsed `available_tools` from the DB, no spec re-parse.
+
+        Returns ToolCandidate-shaped dicts ready for the workflow's
+        searchable pool: {name, description, connection_id, schema, source_type}.
+        Schemas are pre-built so `load_tools` reveal becomes a dict lookup at
+        runtime — no per-call connection refetch.
+        """
+        if not openapi_connection_service:
+            logger.warning(
+                "Skipping openapi tool %r: no openapi_connection_service provided",
+                connection_name_or_id,
+            )
+            return []
+
+        connection = await self._resolve_openapi_connection(
+            connection_name_or_id, openapi_connection_service
+        )
+        if not connection:
+            return []
+
+        available = getattr(connection, "available_tools", None) or []
+        allowed_set = set(allowed_tools) if allowed_tools else None
+
+        entries: list[dict[str, Any]] = []
+        for op in available:
+            raw_name = op.get("name") or ""
+            if not raw_name:
+                continue
+            if allowed_set is not None and raw_name not in allowed_set:
+                continue
+            slugified = _slugify_name(raw_name)
+            description = op.get("description") or f"OpenAPI operation {raw_name}"
+            schema = {
+                "type": "function",
+                "function": {
+                    "name": slugified,
+                    "description": description,
+                    "parameters": op.get("inputSchema")
+                    or {"type": "object", "properties": {}},
+                },
+            }
+            entries.append(
+                {
+                    "name": slugified,
+                    "description": description,
+                    "connection_id": str(getattr(connection, "id", "") or connection_name_or_id),
+                    "schema": schema,
+                    "source_type": "openapi",
+                }
+            )
+        return entries
+
+    async def _resolve_openapi_connection(
+        self,
+        connection_name_or_id: str,
+        openapi_connection_service,
+    ):
+        """Resolve a UUID-or-name reference to an OpenAPIConnection record.
+
+        Mirrors the resolution path used by `OpenAPIToolFactory.create_tools_from_connection`
+        so legacy and searchable paths agree on which connection they pick.
+        """
+        try:
+            try:
+                uuid_val = UUID(str(connection_name_or_id))
+                conn = await openapi_connection_service.get_connection(uuid_val)
+                if conn:
+                    return conn
+            except (ValueError, AttributeError):
+                pass
+            connections, _ = await openapi_connection_service.list_connections(
+                search=str(connection_name_or_id)
+            )
+            for conn in connections:
+                if conn.name == str(connection_name_or_id):
+                    return conn
+        except Exception as e:
+            logger.error(
+                "Failed to resolve OpenAPI connection %r: %s",
+                connection_name_or_id,
+                e,
+                exc_info=True,
+            )
+        logger.warning("OpenAPI connection not found: %r", connection_name_or_id)
+        return None
 
     async def _discover_mcp_tools(
         self,

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_disclosure_policies.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_disclosure_policies.py
@@ -1,0 +1,157 @@
+"""Behavior of ExplicitPolicy and NamedLookupPolicy concrete strategies."""
+
+from agentarea_agents_sdk.tools.disclosure import (
+    LOAD_TOOLS_NAME,
+    DisclosureContext,
+    ExplicitPolicy,
+    NamedLookupPolicy,
+    RevealRequest,
+    ToolCandidate,
+)
+
+CTX = DisclosureContext()
+
+
+def _candidate(name: str, conn: str = "stripe-api", desc: str = "") -> ToolCandidate:
+    return ToolCandidate(
+        name=name,
+        description=desc or f"Operation {name}",
+        schema={
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": desc or f"Operation {name}",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        connection_id=conn,
+    )
+
+
+# ---- ExplicitPolicy ----------------------------------------------------------
+
+
+def test_explicit_partition_keeps_all_schemas_explicit():
+    cands = [_candidate("a"), _candidate("b")]
+    p = ExplicitPolicy().partition(cands, CTX)
+    assert len(p.explicit) == 2
+    assert p.deferred == []
+    assert p.explicit[0]["function"]["name"] == "a"
+
+
+def test_explicit_render_catalog_empty():
+    assert ExplicitPolicy().render_catalog([_candidate("a")], CTX) == ""
+
+
+def test_explicit_no_meta_tools():
+    assert ExplicitPolicy().get_meta_tool_definitions(CTX) == []
+
+
+def test_explicit_reveal_is_noop():
+    r = ExplicitPolicy().reveal(RevealRequest(tool_names=["a"]), [_candidate("a")], CTX)
+    assert r.revealed == []
+    assert r.matched_names == []
+    assert r.unknown_names == []
+
+
+# ---- NamedLookupPolicy -------------------------------------------------------
+
+
+def test_named_lookup_defers_all():
+    cands = [_candidate("a"), _candidate("b")]
+    p = NamedLookupPolicy().partition(cands, CTX)
+    assert p.explicit == []
+    assert [c.name for c in p.deferred] == ["a", "b"]
+
+
+def test_named_lookup_catalog_empty_when_no_deferred():
+    assert NamedLookupPolicy().render_catalog([], CTX) == ""
+
+
+def test_named_lookup_catalog_groups_by_connection():
+    cands = [
+        _candidate("createCharge", conn="stripe-api", desc="Create a charge."),
+        _candidate("listCustomers", conn="stripe-api", desc="List customers."),
+        _candidate("listRepos", conn="github-api", desc="List repos."),
+    ]
+    text = NamedLookupPolicy().render_catalog(cands, CTX)
+    assert "## Available OpenAPI Operations" in text
+    assert "[github-api]" in text
+    assert "[stripe-api]" in text
+    assert "- createCharge: Create a charge." in text
+    assert "- listCustomers: List customers." in text
+    assert "- listRepos: List repos." in text
+    # github-api comes first alphabetically
+    assert text.index("[github-api]") < text.index("[stripe-api]")
+
+
+def test_named_lookup_catalog_handles_missing_description():
+    cand = ToolCandidate(name="foo", description="", schema={}, connection_id="api")
+    text = NamedLookupPolicy().render_catalog([cand], CTX)
+    assert "- foo" in text
+    assert "- foo:" not in text
+
+
+def test_named_lookup_catalog_takes_first_line_of_multiline_description():
+    cand = _candidate("foo", desc="First line.\nSecond line should not appear.")
+    text = NamedLookupPolicy().render_catalog([cand], CTX)
+    assert "First line." in text
+    assert "Second line" not in text
+
+
+def test_named_lookup_catalog_handles_whitespace_only_description():
+    """A truthy-but-empty description (e.g. \"  \\n\") used to crash on splitlines()[0]."""
+    cand = ToolCandidate(name="foo", description="   \n", schema={}, connection_id="api")
+    text = NamedLookupPolicy().render_catalog([cand], CTX)
+    assert "- foo" in text
+    assert "- foo:" not in text
+
+
+def test_named_lookup_meta_tool_shape():
+    defs = NamedLookupPolicy().get_meta_tool_definitions(CTX)
+    assert len(defs) == 1
+    fn = defs[0]
+    assert fn["type"] == "function"
+    assert fn["function"]["name"] == LOAD_TOOLS_NAME
+    params = fn["function"]["parameters"]
+    assert params["type"] == "object"
+    assert params["required"] == ["tool_names"]
+    assert params["properties"]["tool_names"]["type"] == "array"
+    assert params["properties"]["tool_names"]["items"]["type"] == "string"
+
+
+def test_named_lookup_reveal_matches_known_names():
+    pool = [_candidate("a"), _candidate("b"), _candidate("c")]
+    r = NamedLookupPolicy().reveal(RevealRequest(tool_names=["a", "c"]), pool, CTX)
+    assert r.matched_names == ["a", "c"]
+    assert r.unknown_names == []
+    assert [s["function"]["name"] for s in r.revealed] == ["a", "c"]
+    assert "Loaded 2 operations" in r.message
+
+
+def test_named_lookup_reveal_reports_unknown_with_valid_preview():
+    pool = [_candidate("known")]
+    r = NamedLookupPolicy().reveal(
+        RevealRequest(tool_names=["known", "missing"]), pool, CTX
+    )
+    assert r.matched_names == ["known"]
+    assert r.unknown_names == ["missing"]
+    assert "Unknown names: ['missing']" in r.message
+    assert "known" in r.message
+
+
+def test_named_lookup_reveal_caps_valid_examples_at_20():
+    pool = [_candidate(f"op_{i:03d}") for i in range(50)]
+    r = NamedLookupPolicy().reveal(
+        RevealRequest(tool_names=["nope"]), pool, CTX
+    )
+    assert r.unknown_names == ["nope"]
+    assert "more available" in r.message
+
+
+def test_named_lookup_reveal_empty_request_returns_empty():
+    pool = [_candidate("a")]
+    r = NamedLookupPolicy().reveal(RevealRequest(tool_names=[]), pool, CTX)
+    assert r.matched_names == []
+    assert r.unknown_names == []
+    assert r.revealed == []

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_disclosure_protocol.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_disclosure_protocol.py
@@ -1,0 +1,129 @@
+"""Protocol shape, type defaults, and registry behavior for disclosure module."""
+
+import pytest
+
+from agentarea_agents_sdk.tools.disclosure import (
+    DisclosureContext,
+    ExplicitPolicy,
+    NamedLookupPolicy,
+    Partition,
+    RevealRequest,
+    RevealResult,
+    ToolCandidate,
+    ToolDisclosurePolicy,
+    list_policies,
+    policy_from_config,
+    register_policy,
+)
+
+
+def test_protocol_runtime_checkable_for_explicit():
+    assert isinstance(ExplicitPolicy(), ToolDisclosurePolicy)
+
+
+def test_protocol_runtime_checkable_for_named_lookup():
+    assert isinstance(NamedLookupPolicy(), ToolDisclosurePolicy)
+
+
+def test_protocol_rejects_non_policy_object():
+    class NotAPolicy:
+        def partition(self, *_):
+            return None
+
+    # Missing render_catalog/get_meta_tool_definitions/reveal — protocol mismatch.
+    assert not isinstance(NotAPolicy(), ToolDisclosurePolicy)
+
+
+def test_disclosure_context_defaults():
+    ctx = DisclosureContext()
+    assert ctx.model_name == ""
+    assert ctx.context_window == 0
+    assert ctx.iteration == 0
+
+
+def test_partition_defaults_empty():
+    p = Partition()
+    assert p.explicit == []
+    assert p.deferred == []
+
+
+def test_reveal_request_defaults_empty_names():
+    assert RevealRequest().tool_names == []
+
+
+def test_reveal_result_defaults_empty():
+    r = RevealResult()
+    assert r.revealed == []
+    assert r.matched_names == []
+    assert r.unknown_names == []
+    assert r.message == ""
+
+
+def test_tool_candidate_defaults():
+    c = ToolCandidate(name="x", description="y", schema={"a": 1})
+    assert c.connection_id == ""
+    assert c.source_type == "openapi"
+
+
+def test_registry_lists_builtin_policies():
+    names = list_policies()
+    assert "explicit" in names
+    assert "named_lookup" in names
+    assert "searchable" in names
+
+
+def test_policy_from_config_none_returns_explicit():
+    assert isinstance(policy_from_config(None), ExplicitPolicy)
+
+
+def test_policy_from_config_string_explicit():
+    assert isinstance(policy_from_config("explicit"), ExplicitPolicy)
+
+
+def test_policy_from_config_string_named_lookup():
+    assert isinstance(policy_from_config("named_lookup"), NamedLookupPolicy)
+
+
+def test_policy_from_config_searchable_alias():
+    """`searchable` is the YAML-shorthand alias for NamedLookupPolicy."""
+    assert isinstance(policy_from_config("searchable"), NamedLookupPolicy)
+
+
+def test_policy_from_config_dict_form():
+    assert isinstance(policy_from_config({"name": "named_lookup"}), NamedLookupPolicy)
+
+
+def test_policy_from_config_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown disclosure policy"):
+        policy_from_config("nonexistent")
+
+
+def test_policy_from_config_dict_without_name_raises():
+    with pytest.raises(ValueError, match="non-empty 'name'"):
+        policy_from_config({})
+
+
+def test_policy_from_config_invalid_type_raises():
+    with pytest.raises(ValueError, match="must be None, str, or dict"):
+        policy_from_config(123)  # type: ignore[arg-type]
+
+
+def test_register_policy_round_trip():
+    """Custom policies can register and resolve via the same factory entrypoint."""
+
+    class FakePolicy:
+        def partition(self, *a, **k):
+            return Partition()
+
+        def render_catalog(self, *a, **k):
+            return ""
+
+        def get_meta_tool_definitions(self, *a, **k):
+            return []
+
+        def reveal(self, *a, **k):
+            return RevealResult()
+
+    register_policy("test_fake", FakePolicy)
+    assert "test_fake" in list_policies()
+    assert isinstance(policy_from_config("test_fake"), FakePolicy)

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_openapi_tool_definition_lookup.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_openapi_tool_definition_lookup.py
@@ -1,0 +1,80 @@
+"""OpenAPIToolFactory.get_tool_definition_by_name — by-name schema lookup."""
+
+from types import SimpleNamespace
+
+from agentarea_agents_sdk.tools.openapi_tool import OpenAPIToolFactory
+
+
+def _conn(*ops):
+    return SimpleNamespace(available_tools=list(ops))
+
+
+def test_returns_function_definition_for_known_name():
+    op = {
+        "name": "listCustomers",
+        "description": "List Stripe customers.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"limit": {"type": "integer"}},
+            "required": [],
+        },
+    }
+    result = OpenAPIToolFactory.get_tool_definition_by_name(_conn(op), "listCustomers")
+    assert result is not None
+    assert result["type"] == "function"
+    assert result["function"]["name"] == "listCustomers"
+    assert result["function"]["description"] == "List Stripe customers."
+    assert result["function"]["parameters"]["properties"]["limit"]["type"] == "integer"
+
+
+def test_returns_none_for_unknown_name():
+    op = {"name": "listCustomers", "description": "x", "inputSchema": {"type": "object"}}
+    assert (
+        OpenAPIToolFactory.get_tool_definition_by_name(_conn(op), "createInvoice") is None
+    )
+
+
+def test_returns_none_when_connection_has_no_available_tools():
+    conn = SimpleNamespace(available_tools=None)
+    assert OpenAPIToolFactory.get_tool_definition_by_name(conn, "x") is None
+
+
+def test_returns_none_when_connection_lacks_attribute():
+    conn = SimpleNamespace()
+    assert OpenAPIToolFactory.get_tool_definition_by_name(conn, "x") is None
+
+
+def test_matches_slugified_name_too():
+    """LLM-facing names are slugified; lookup must accept the slug back."""
+    op = {
+        "name": "List items / orders",
+        "description": "Slashed and spaced operation name.",
+        "inputSchema": {"type": "object"},
+    }
+    result = OpenAPIToolFactory.get_tool_definition_by_name(
+        _conn(op), "List_items___orders"
+    )
+    assert result is not None
+    assert result["function"]["name"] == "List_items___orders"
+
+
+def test_falls_back_to_method_path_description_when_missing():
+    op = {"name": "doStuff", "description": "", "inputSchema": {"type": "object"}}
+    result = OpenAPIToolFactory.get_tool_definition_by_name(_conn(op), "doStuff")
+    assert result is not None
+    assert "doStuff" in result["function"]["description"]
+
+
+def test_falls_back_to_empty_object_schema_when_input_schema_missing():
+    op = {"name": "noParams", "description": "x"}
+    result = OpenAPIToolFactory.get_tool_definition_by_name(_conn(op), "noParams")
+    assert result is not None
+    assert result["function"]["parameters"]["type"] == "object"
+    assert "properties" in result["function"]["parameters"]
+
+
+def test_skips_entries_with_blank_name():
+    bad = {"name": "", "description": "x", "inputSchema": {}}
+    good = {"name": "real", "description": "y", "inputSchema": {"type": "object"}}
+    assert OpenAPIToolFactory.get_tool_definition_by_name(_conn(bad, good), "real") is not None
+    assert OpenAPIToolFactory.get_tool_definition_by_name(_conn(bad), "") is None

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_tool_manager_openapi_load_mode.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_tool_manager_openapi_load_mode.py
@@ -1,0 +1,239 @@
+"""ToolManager honoring load_mode for OpenAPI tools (split discovery)."""
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from agentarea_agents_sdk.tools.tool_manager import DiscoveryResult, ToolManager
+
+
+class _FakeOpenAPIService:
+    """Minimal stand-in for OpenAPIConnectionService."""
+
+    def __init__(self, connection):
+        self._connection = connection
+
+    async def get_connection(self, connection_id):
+        if str(connection_id) == str(self._connection.id):
+            return self._connection
+        return None
+
+    async def list_connections(self, search=None):
+        if not search or self._connection.name == search:
+            return [self._connection], 1
+        return [], 0
+
+
+def _make_connection(num_ops: int = 3, name: str = "stripe-api"):
+    """Build a connection with both `available_tools` (for searchable path)
+    and a real spec_content (for explicit path which re-parses)."""
+    available_tools = [
+        {
+            "name": f"op_{i:02d}",
+            "description": f"Operation {i}",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": [],
+            },
+        }
+        for i in range(num_ops)
+    ]
+    paths = {
+        f"/op/{i:02d}": {
+            "get": {
+                "operationId": f"op_{i:02d}",
+                "summary": f"Operation {i}",
+                "parameters": [
+                    {"name": "x", "in": "query", "schema": {"type": "string"}}
+                ],
+                "responses": {"200": {"description": "ok"}},
+            }
+        }
+        for i in range(num_ops)
+    }
+    return SimpleNamespace(
+        id=uuid4(),
+        name=name,
+        spec_content={"openapi": "3.0.0", "info": {"title": name, "version": "1"}, "paths": paths},
+        available_tools=available_tools,
+    )
+
+
+@pytest.mark.asyncio
+async def test_searchable_load_mode_routes_to_searchable_entries():
+    conn = _make_connection(num_ops=5)
+    svc = _FakeOpenAPIService(conn)
+    manager = ToolManager(openapi_connection_service=svc)
+
+    tools_config = [
+        {
+            "type": "openapi",
+            "name": conn.name,
+            "settings": {
+                "openapi_connection_id": str(conn.id),
+                "load_mode": "searchable",
+            },
+        }
+    ]
+    result = await manager.discover_available_tools_split(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=tools_config,
+        mcp_server_instance_service=None,
+    )
+    assert isinstance(result, DiscoveryResult)
+    # No openapi schemas in explicit (only the built-in completion remains).
+    explicit_names = {t["function"]["name"] for t in result.explicit_tools}
+    assert "completion" in explicit_names
+    assert not any(name.startswith("op_") for name in explicit_names)
+    # All 5 operations land in the searchable pool with full ToolCandidate shape.
+    assert len(result.searchable_entries) == 5
+    entry = result.searchable_entries[0]
+    assert entry["name"].startswith("op_")
+    assert entry["description"].startswith("Operation")
+    assert entry["connection_id"] == str(conn.id)
+    assert entry["source_type"] == "openapi"
+    assert entry["schema"]["type"] == "function"
+    assert entry["schema"]["function"]["parameters"]["type"] == "object"
+
+
+@pytest.mark.asyncio
+async def test_explicit_load_mode_keeps_full_schemas_in_explicit():
+    conn = _make_connection(num_ops=3)
+    svc = _FakeOpenAPIService(conn)
+    manager = ToolManager(openapi_connection_service=svc)
+
+    tools_config = [
+        {
+            "type": "openapi",
+            "name": conn.name,
+            "settings": {
+                "openapi_connection_id": str(conn.id),
+                "load_mode": "explicit",
+            },
+        }
+    ]
+    result = await manager.discover_available_tools_split(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=tools_config,
+        mcp_server_instance_service=None,
+    )
+    assert result.searchable_entries == []
+    op_names = {
+        t["function"]["name"]
+        for t in result.explicit_tools
+        if t["function"]["name"].startswith("op_")
+    }
+    assert op_names == {"op_00", "op_01", "op_02"}
+
+
+@pytest.mark.asyncio
+async def test_missing_load_mode_treated_as_explicit():
+    conn = _make_connection(num_ops=2)
+    svc = _FakeOpenAPIService(conn)
+    manager = ToolManager(openapi_connection_service=svc)
+
+    tools_config = [
+        {
+            "type": "openapi",
+            "name": conn.name,
+            "settings": {"openapi_connection_id": str(conn.id)},
+        }
+    ]
+    result = await manager.discover_available_tools_split(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=tools_config,
+        mcp_server_instance_service=None,
+    )
+    assert result.searchable_entries == []
+    op_names = {
+        t["function"]["name"]
+        for t in result.explicit_tools
+        if t["function"]["name"].startswith("op_")
+    }
+    assert op_names == {"op_00", "op_01"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_discover_available_tools_ignores_load_mode():
+    """Old API ignores load_mode and always returns full schemas (back-compat)."""
+    conn = _make_connection(num_ops=2)
+    svc = _FakeOpenAPIService(conn)
+    manager = ToolManager(openapi_connection_service=svc)
+
+    tools_config = [
+        {
+            "type": "openapi",
+            "name": conn.name,
+            "settings": {
+                "openapi_connection_id": str(conn.id),
+                "load_mode": "searchable",  # would normally defer
+            },
+        }
+    ]
+    flat = await manager.discover_available_tools(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=tools_config,
+        mcp_server_instance_service=None,
+    )
+    assert isinstance(flat, list)
+    op_names = {
+        t["function"]["name"] for t in flat if t["function"]["name"].startswith("op_")
+    }
+    assert op_names == {"op_00", "op_01"}
+
+
+@pytest.mark.asyncio
+async def test_searchable_filters_by_allowed_tools():
+    conn = _make_connection(num_ops=4)
+    svc = _FakeOpenAPIService(conn)
+    manager = ToolManager(openapi_connection_service=svc)
+
+    tools_config = [
+        {
+            "type": "openapi",
+            "name": conn.name,
+            "settings": {
+                "openapi_connection_id": str(conn.id),
+                "load_mode": "searchable",
+                "allowed_tools": ["op_01", "op_03"],
+            },
+        }
+    ]
+    result = await manager.discover_available_tools_split(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=tools_config,
+        mcp_server_instance_service=None,
+    )
+    assert {e["name"] for e in result.searchable_entries} == {"op_01", "op_03"}
+
+
+@pytest.mark.asyncio
+async def test_no_openapi_service_yields_no_searchable_entries():
+    manager = ToolManager(openapi_connection_service=None)
+    tools_config = [
+        {
+            "type": "openapi",
+            "name": "some-api",
+            "settings": {"load_mode": "searchable"},
+        }
+    ]
+    result = await manager.discover_available_tools_split(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=tools_config,
+        mcp_server_instance_service=None,
+    )
+    assert result.searchable_entries == []
+
+
+@pytest.mark.asyncio
+async def test_empty_tools_config_returns_only_builtins():
+    manager = ToolManager()
+    result = await manager.discover_available_tools_split(
+        agent_id=UUID("11111111-1111-1111-1111-111111111111"),
+        tools_config=None,
+        mcp_server_instance_service=None,
+    )
+    assert result.searchable_entries == []
+    assert any(t["function"]["name"] == "completion" for t in result.explicit_tools)

--- a/agentarea-platform/libs/agents/agentarea_agents/schemas/import_export.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/schemas/import_export.py
@@ -60,6 +60,11 @@ class ToolSettingsYAML(BaseModel):
     description_override: str | None = None  # For agent tools — custom description
     requires_user_confirmation: bool | None = None  # Require human approval before execution
     openapi_connection_id: str | None = None  # For openapi tools — stable UUID lookup
+    # Disclosure mode for the tool's schemas. "explicit" puts every operation's
+    # full schema into every LLM call (legacy). "searchable" defers schemas
+    # behind a `load_tools` meta-tool, with a name+description catalog in the
+    # system prompt. Currently honored only for openapi tools.
+    load_mode: Literal["explicit", "searchable"] | None = None
 
 
 class ToolConfigYAML(BaseModel):

--- a/agentarea-platform/libs/agents/tests/test_tool_settings_load_mode.py
+++ b/agentarea-platform/libs/agents/tests/test_tool_settings_load_mode.py
@@ -1,0 +1,69 @@
+"""ToolSettingsYAML.load_mode field — accepts the two literals, round-trips through YAML."""
+
+import yaml
+from pydantic import ValidationError
+import pytest
+
+from agentarea_agents.schemas.import_export import (
+    ToolConfigYAML,
+    ToolSettingsYAML,
+)
+
+
+def test_load_mode_defaults_to_none():
+    s = ToolSettingsYAML()
+    assert s.load_mode is None
+
+
+def test_load_mode_accepts_explicit():
+    s = ToolSettingsYAML(load_mode="explicit")
+    assert s.load_mode == "explicit"
+
+
+def test_load_mode_accepts_searchable():
+    s = ToolSettingsYAML(load_mode="searchable")
+    assert s.load_mode == "searchable"
+
+
+def test_load_mode_rejects_unknown_string():
+    with pytest.raises(ValidationError):
+        ToolSettingsYAML(load_mode="lazy")  # type: ignore[arg-type]
+
+
+def test_load_mode_round_trips_through_yaml():
+    original = ToolConfigYAML(
+        type="openapi",
+        name="stripe-api",
+        settings=ToolSettingsYAML(
+            openapi_connection_id="11111111-1111-1111-1111-111111111111",
+            load_mode="searchable",
+        ),
+    )
+    serialized = yaml.safe_dump(original.model_dump(exclude_none=True))
+    parsed = ToolConfigYAML(**yaml.safe_load(serialized))
+    assert parsed.settings is not None
+    assert parsed.settings.load_mode == "searchable"
+    assert parsed.settings.openapi_connection_id == "11111111-1111-1111-1111-111111111111"
+
+
+def test_load_mode_omitted_when_none_in_export():
+    """exclude_none=True keeps existing YAML files free of the new field."""
+    cfg = ToolConfigYAML(
+        type="openapi",
+        name="stripe-api",
+        settings=ToolSettingsYAML(openapi_connection_id="abc"),
+    )
+    dumped = cfg.model_dump(exclude_none=True)
+    assert "load_mode" not in dumped["settings"]
+
+
+def test_load_mode_legal_on_non_openapi_tools_for_now():
+    """Field is parsed regardless of type — validation that it only applies to
+    openapi happens at runtime in the workflow, not in the schema."""
+    cfg = ToolConfigYAML(
+        type="mcp",
+        name="some-mcp",
+        settings=ToolSettingsYAML(load_mode="searchable"),
+    )
+    assert cfg.settings is not None
+    assert cfg.settings.load_mode == "searchable"

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
@@ -81,6 +81,7 @@ from ..models import (
     ResolveAgentToolsResult,
     ResolvedModelInfo,
     ResolveModelRequest,
+    SearchableToolEntry,
     SearchHistoryRequest,
     SearchHistoryResult,
     SkillFileRequest,
@@ -90,7 +91,9 @@ from ..models import (
     StoreHistoryResult,
     StoreOutputRequest,
     StoreOutputResult,
+    ToolDefinition,
     ToolDiscoveryRequest,
+    ToolDiscoveryResult,
     ToolProviderData,
     UpdateTaskStatusRequest,
     UpdateTaskStatusResult,
@@ -356,8 +359,13 @@ def make_agent_activities(dependencies: ActivityDependencies):
     @activity.defn
     async def discover_available_tools_activity(
         request: ToolDiscoveryRequest,
-    ) -> list[dict[str, Any]]:  # Keep backward compatible
-        """Discover available tools for an agent."""
+    ) -> ToolDiscoveryResult:
+        """Discover available tools for an agent.
+
+        Honors `settings.load_mode` per OpenAPI tool — operations marked
+        `searchable` go into `searchable_entries` (deferred pool) instead of
+        `tools` (the per-call LLM context).
+        """
         user_context = create_user_context(request.user_context_data)
 
         async with ActivityContext(container, user_context) as ctx:
@@ -370,10 +378,10 @@ def make_agent_activities(dependencies: ActivityDependencies):
             if not agent:
                 raise ValueError(f"Agent {request.agent_id} not found")
 
-            # Use tool manager to discover available tools
+            # Use tool manager to discover available tools (split path).
             tool_manager = ToolManager(openapi_connection_service=openapi_connection_service)
             base_url = f"{dependencies.settings.app.API_BASE_URL}/api/v1"
-            all_tools = await tool_manager.discover_available_tools(
+            split = await tool_manager.discover_available_tools_split(
                 agent_id=request.agent_id,
                 tools_config=agent.tools,
                 mcp_server_instance_service=mcp_server_instance_service,
@@ -381,7 +389,18 @@ def make_agent_activities(dependencies: ActivityDependencies):
                 base_url=base_url,
             )
 
-            return all_tools
+            tool_defs = [ToolDefinition(**t) for t in split.explicit_tools]
+            searchable = [
+                SearchableToolEntry(
+                    name=e.get("name", ""),
+                    description=e.get("description", ""),
+                    connection_id=e.get("connection_id", ""),
+                    schema=e.get("schema") or {},
+                    source_type=e.get("source_type", "openapi"),
+                )
+                for e in split.searchable_entries
+            ]
+            return ToolDiscoveryResult(tools=tool_defs, searchable_entries=searchable)
 
     @activity.defn
     async def discover_tool_providers_activity(

--- a/agentarea-platform/libs/execution/agentarea_execution/models.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/models.py
@@ -237,10 +237,39 @@ class ToolDefinition(BaseModel):
     function: dict[str, Any]
 
 
+class SearchableToolEntry(BaseModel):
+    """Deferred tool entry — used by the disclosure layer for `load_tools`.
+
+    Carries enough metadata for the catalog block (name + description) and
+    for on-demand reveal (full schema + connection_id). Lives in workflow
+    state until revealed; never sent to the LLM directly.
+
+    Note: `schema_` is aliased to JSON key `"schema"` because Pydantic's
+    BaseModel reserves `schema` on the class. Callers MUST use
+    `model_dump(by_alias=True)` to round-trip through the workflow's
+    `searchable_tool_pool` (plain dicts) — otherwise the dict key becomes
+    `schema_` and `ToolCandidate(**c)` reconstruction will silently miss it.
+    """
+
+    name: str
+    description: str = ""
+    connection_id: str = ""
+    schema_: dict[str, Any] = Field(default_factory=dict, alias="schema")
+    source_type: str = "openapi"
+
+    model_config = {"populate_by_name": True}
+
+
 class ToolDiscoveryResult(BaseModel):
-    """Tools discovery result."""
+    """Tools discovery result.
+
+    `tools` ships in the LLM's available_tools every call (current behavior).
+    `searchable_entries` is the deferred pool for the `load_tools` meta-tool;
+    schemas land in available_tools only when the LLM explicitly reveals them.
+    """
 
     tools: list[ToolDefinition]
+    searchable_entries: list[SearchableToolEntry] = Field(default_factory=list)
 
 
 class LLMCallRequest(BaseModel):

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -10,6 +10,13 @@ with workflow.unsafe.imports_passed_through():
     from uuid import UUID
 
     from agentarea_agents_sdk.skills import SkillActivationTool, SkillCatalogBuilder, SkillEntry
+    from agentarea_agents_sdk.tools.disclosure import (
+        DisclosureContext,
+        NamedLookupPolicy,
+        RevealRequest,
+        ToolCandidate,
+        ToolDisclosurePolicy,
+    )
     from agentarea_agents_sdk.tools.tool_catalog import ToolCatalog
     from agentarea_agents_sdk.tools.tool_provider import (
         AgentToolProvider,
@@ -124,6 +131,9 @@ class AgentExecutionWorkflow:
         self._a2ui_action_queue: list[dict[str, Any]] = []
         self._skill_tool: SkillActivationTool | None = None
         self._tool_catalog: ToolCatalog | None = None
+        # OpenAPI disclosure: NamedLookupPolicy when pool is non-empty, else None.
+        # Stateless wrt the policy itself — pool lives in state.searchable_tool_pool.
+        self._disclosure_policy: ToolDisclosurePolicy | None = None
         self._pending_escalations: dict[str, PendingEscalation] = {}
         # Generic message queue — queued user messages drained before each LLM call
         self._message_queue: list[dict[str, Any]] = []
@@ -495,6 +505,32 @@ class AgentExecutionWorkflow:
                         except Exception:  # noqa: S110
                             pass
 
+            # Searchable OpenAPI pool — operations marked load_mode=searchable
+            # are deferred behind a `load_tools` meta-tool. The catalog text
+            # (added later, alongside skill catalog) and the meta-tool
+            # together let the LLM ask for schemas on demand.
+            searchable_entries_raw: list[dict[str, Any]] = []
+            try:
+                raw_entries = tools_result.searchable_entries
+            except AttributeError:
+                raw_entries = []
+            for entry in raw_entries or []:
+                if hasattr(entry, "model_dump"):
+                    searchable_entries_raw.append(entry.model_dump(by_alias=True))
+                elif isinstance(entry, dict):
+                    searchable_entries_raw.append(entry)
+            if searchable_entries_raw:
+                self.state.searchable_tool_pool = searchable_entries_raw
+                self._disclosure_policy = NamedLookupPolicy()
+                meta_tools = self._disclosure_policy.get_meta_tool_definitions(
+                    DisclosureContext(
+                        model_name=str(self.state.agent_config.get("model_id", "")),
+                        context_window=self.state.context_window,
+                        iteration=self.state.current_iteration,
+                    )
+                )
+                available_tools.extend(meta_tools)
+
         # === Built-in completion tool (always present, canonical definition) ===
         # Remove any existing completion/task_complete from discovery — we always
         # use our own definition with correct description and required params.
@@ -745,6 +781,39 @@ class AgentExecutionWorkflow:
         self.state.context_strategy = state.context_strategy
         self.state.history_chunk_counter = state.history_chunk_counter
         self.state.activated_tool_sources = state.activated_tool_sources
+        self.state.searchable_tool_pool = state.searchable_tool_pool
+        self.state.revealed_openapi_tools = state.revealed_openapi_tools
+        # Re-instantiate disclosure policy stateless from pool presence so
+        # post-replay tool dispatch can route load_tools and rebuild the
+        # catalog block on subsequent iterations.
+        if self.state.searchable_tool_pool:
+            self._disclosure_policy = NamedLookupPolicy()
+            # Reconcile previously revealed names against the restored pool.
+            # If a connection's `available_tools` shrunk between runs, drop the
+            # stale schema from `available_tools`, drop the name from the
+            # revealed list, and warn — otherwise the LLM would see a tool it
+            # can no longer execute.
+            pool_names = {c["name"] for c in self.state.searchable_tool_pool}
+            stale = [
+                name
+                for name in self.state.revealed_openapi_tools
+                if name not in pool_names
+            ]
+            if stale:
+                workflow.logger.warning(
+                    "Dropping %d stale revealed OpenAPI tool(s) on continue-as-new: %s",
+                    len(stale),
+                    stale,
+                )
+                stale_set = set(stale)
+                self.state.revealed_openapi_tools = [
+                    n for n in self.state.revealed_openapi_tools if n not in stale_set
+                ]
+                self.state.available_tools = [
+                    t
+                    for t in self.state.available_tools
+                    if (t.get("function", {}) or {}).get("name") not in stale_set
+                ]
         self.state.service_budget_usd = state.service_budget_usd
         self.state.service_cost_used = state.service_cost_used
         self.state.wallet_id = state.wallet_id
@@ -840,6 +909,8 @@ class AgentExecutionWorkflow:
             context_strategy=self.state.context_strategy,
             history_chunk_counter=self.state.history_chunk_counter,
             activated_tool_sources=self.state.activated_tool_sources,
+            searchable_tool_pool=self.state.searchable_tool_pool,
+            revealed_openapi_tools=self.state.revealed_openapi_tools,
             service_budget_usd=self.state.service_budget_usd,
             service_cost_used=self.state.service_cost_used,
             wallet_id=self.state.wallet_id,
@@ -1125,6 +1196,20 @@ class AgentExecutionWorkflow:
                     "the user, pass that relative file path in the shell tool's "
                     "`artifact_paths` argument so it is stored as a task artifact."
                 )
+
+            # Append OpenAPI operation catalog (load_mode=searchable, issue #115).
+            # Pool lives in workflow state; only this name+description block is
+            # sent to the LLM until it explicitly calls load_tools(...).
+            if self._disclosure_policy and self.state.searchable_tool_pool:
+                ctx = DisclosureContext(
+                    model_name=str(self.state.agent_config.get("model_id", "")),
+                    context_window=self.state.context_window,
+                    iteration=self.state.current_iteration,
+                )
+                pool = [ToolCandidate(**c) for c in self.state.searchable_tool_pool]
+                openapi_catalog_text = self._disclosure_policy.render_catalog(pool, ctx)
+                if openapi_catalog_text:
+                    agent_instruction = agent_instruction + openapi_catalog_text
 
             system_prompt = MessageBuilder.build_system_prompt(
                 agent_name=self.state.agent_config.get("name", "AI Agent"),
@@ -1466,6 +1551,7 @@ class AgentExecutionWorkflow:
         script_calls: list[ToolCall] = []
         read_output_calls: list[ToolCall] = []
         activate_source_calls: list[ToolCall] = []
+        load_tools_calls: list[ToolCall] = []
 
         for tool_call in tool_calls:
             tool_name = tool_call.function["name"]
@@ -1477,6 +1563,8 @@ class AgentExecutionWorkflow:
                 read_output_calls.append(tool_call)
             elif tool_name == "activate_tool_source":
                 activate_source_calls.append(tool_call)
+            elif tool_name == "load_tools":
+                load_tools_calls.append(tool_call)
             elif tool_name == "activate_skill":
                 skill_calls.append(tool_call)
             elif tool_name == "run_skill_script":
@@ -1496,6 +1584,10 @@ class AgentExecutionWorkflow:
         # Execute tool source activations (DYNAMIC mode — local, no activity)
         for tool_call in activate_source_calls:
             await self._execute_activate_tool_source(tool_call)
+
+        # Execute OpenAPI load_tools meta-calls (issue #115 — local, no activity)
+        for tool_call in load_tools_calls:
+            await self._execute_load_openapi_tools(tool_call)
 
         # Execute skill activations (local, no activity needed)
         for tool_call in skill_calls:
@@ -2034,6 +2126,86 @@ class AgentExecutionWorkflow:
             # Fallback: MinIO failure doesn't break agent execution
             workflow.logger.warning(f"Output offload exception for {output_id}: {e}")
             return content
+
+    async def _execute_load_openapi_tools(self, tool_call: ToolCall) -> None:
+        """Reveal OpenAPI operation schemas by exact name (issue #115 — local).
+
+        Mirrors `_execute_activate_tool_source` for the per-tool, name-based
+        case: the LLM picks names from the catalog text already in its prompt
+        and asks us to load their schemas. We dict-look up against
+        `state.searchable_tool_pool` and append matched schemas (deduped) to
+        `state.available_tools`. Names are recorded in
+        `state.revealed_openapi_tools` so continue-as-new can replay them.
+        """
+        try:
+            args = json.loads(tool_call.function["arguments"])
+        except (json.JSONDecodeError, KeyError):
+            args = {}
+
+        requested = args.get("tool_names")
+        if not isinstance(requested, list):
+            requested = []
+        requested = [str(n) for n in requested if n]
+
+        if not self._disclosure_policy or not self.state.searchable_tool_pool:
+            self.state.messages.append(
+                Message(
+                    role="tool",
+                    content="Error: no searchable OpenAPI pool available.",
+                    tool_call_id=tool_call.id,
+                    name="load_tools",
+                )
+            )
+            return
+
+        pool = [ToolCandidate(**c) for c in self.state.searchable_tool_pool]
+        ctx = DisclosureContext(
+            model_name=str(self.state.agent_config.get("model_id", "")),
+            context_window=self.state.context_window,
+            iteration=self.state.current_iteration,
+        )
+        result = self._disclosure_policy.reveal(
+            RevealRequest(tool_names=requested), pool, ctx
+        )
+
+        # Dedup against already-loaded tools by function name.
+        existing_names = {
+            (t.get("function", {}) or {}).get("name")
+            for t in self.state.available_tools
+            if t.get("type") == "function"
+        }
+        for schema in result.revealed:
+            name = (schema.get("function", {}) or {}).get("name")
+            if name and name not in existing_names:
+                self.state.available_tools.append(schema)
+                existing_names.add(name)
+
+        revealed_set = set(self.state.revealed_openapi_tools)
+        for name in result.matched_names:
+            if name not in revealed_set:
+                self.state.revealed_openapi_tools.append(name)
+                revealed_set.add(name)
+
+        self.state.messages.append(
+            Message(
+                role="tool",
+                content=result.message
+                or f"Loaded {len(result.matched_names)} OpenAPI operations.",
+                tool_call_id=tool_call.id,
+                name="load_tools",
+            )
+        )
+
+        self.event_manager.add_event(
+            EventTypes.TOOL_CALL_COMPLETED,
+            {
+                "tool_name": "load_tools",
+                "tool_call_id": tool_call.id,
+                "matched_names": result.matched_names,
+                "unknown_names": result.unknown_names,
+                "iteration": self.state.current_iteration,
+            },
+        )
 
     async def _execute_activate_tool_source(self, tool_call: ToolCall) -> None:
         """Activate a tool source (DYNAMIC mode) — load full definitions into context."""

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -477,10 +477,14 @@ class AgentExecutionWorkflow:
             available_tools.append(self._tool_catalog.get_activate_tool_source_definition())
 
         else:
-            # STATIC/HYBRID mode: load all tools upfront (current behavior)
+            # STATIC/HYBRID mode: load all tools upfront (current behavior).
+            # `result_type` is required for Temporal to deserialize the
+            # activity result into the Pydantic model — otherwise the workflow
+            # receives a plain dict and `searchable_entries` is silently dropped.
             tools_result: ToolDiscoveryResult = await workflow.execute_activity(
                 Activities.DISCOVER_AVAILABLE_TOOLS,
                 args=[tools_request],
+                result_type=ToolDiscoveryResult,
                 start_to_close_timeout=ACTIVITY_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
             )

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/models.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/models.py
@@ -108,6 +108,12 @@ class ContinueAsNewState(BaseModel):
     context_strategy: str = "hybrid"
     history_chunk_counter: int = 0
     activated_tool_sources: list[str] = Field(default_factory=list)
+    # Searchable OpenAPI pool: ToolCandidate-shaped dicts (name, description,
+    # connection_id, schema, source_type) deferred behind `load_tools`.
+    searchable_tool_pool: list[dict[str, Any]] = Field(default_factory=list)
+    # Names from the pool already revealed into available_tools — re-applied on replay
+    # so prior tool_calls keep resolving after continue-as-new.
+    revealed_openapi_tools: list[str] = Field(default_factory=list)
     # Service budget (wallet payments)
     service_budget_usd: Money | None = None
     service_cost_used: Money = ZERO
@@ -142,6 +148,13 @@ class AgentExecutionState(BaseModel):
     context_strategy: str = "hybrid"
     history_chunk_counter: int = 0
     activated_tool_sources: list[str] = Field(default_factory=list)
+    # Searchable OpenAPI pool: ToolCandidate-shaped dicts kept in workflow state
+    # only — never sent to the LLM directly. Catalog text + `load_tools` meta-tool
+    # mediate access (issue #115).
+    searchable_tool_pool: list[dict[str, Any]] = Field(default_factory=list)
+    # Names from the pool whose full schemas have been appended to
+    # `available_tools`; tracked so continue-as-new can re-reveal on replay.
+    revealed_openapi_tools: list[str] = Field(default_factory=list)
     # Service budget (wallet payments)
     service_budget_usd: Money | None = None
     service_cost_used: Money = ZERO

--- a/agentarea-platform/libs/execution/tests/unit/test_searchable_openapi_continue_as_new.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_searchable_openapi_continue_as_new.py
@@ -1,0 +1,163 @@
+"""Continue-as-new round-trip for searchable OpenAPI pool + revealed names (issue #115).
+
+Workflow methods that touch `workflow.logger` only run inside Temporal's
+event loop. We monkey-patch the module-level `workflow` symbol with a stub
+so we can exercise pure state-mutation logic in plain unit tests.
+"""
+
+import asyncio
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentarea_execution.workflows import agent_execution_workflow as wf_mod
+from agentarea_execution.workflows.agent_execution_workflow import AgentExecutionWorkflow
+from agentarea_execution.workflows.models import AgentGoal, ContinueAsNewState
+
+
+@pytest.fixture(autouse=True)
+def stub_workflow_logger(monkeypatch):
+    """Patch temporalio's workflow.logger so plain test loops don't hit the sandbox."""
+    import temporalio.workflow as _temporal_workflow
+
+    fake_logger = logging.getLogger("test_continue_as_new_stub")
+    monkeypatch.setattr(_temporal_workflow, "logger", fake_logger)
+    yield
+
+
+def _goal():
+    return AgentGoal(
+        id="g",
+        description="d",
+        success_criteria=[],
+        max_iterations=1,
+        requires_human_approval=False,
+        context={},
+    )
+
+
+def _pool_entry(name: str):
+    return {
+        "name": name,
+        "description": f"Operation {name}",
+        "connection_id": "stripe-conn",
+        "schema": {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"Operation {name}",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        "source_type": "openapi",
+    }
+
+
+def test_continue_as_new_round_trips_searchable_state():
+    """ContinueAsNewState carries pool + revealed list verbatim; _restore_from_continued_state
+    re-instantiates the disclosure policy and surfaces both fields on the new state."""
+    pool = [_pool_entry("op_01"), _pool_entry("op_02")]
+    revealed_schema = pool[0]["schema"]
+
+    cstate = ContinueAsNewState(
+        execution_id="exec-1",
+        agent_id="agent-1",
+        task_id="task-1",
+        user_id="user-1",
+        workspace_id="ws-1",
+        goal=_goal(),
+        messages=[],
+        agent_config={"model_id": "x"},
+        # available_tools carries the previously revealed schema verbatim, just like
+        # the pre-continue-as-new state did.
+        available_tools=[
+            {"type": "function", "function": {"name": "completion", "parameters": {}}},
+            revealed_schema,
+        ],
+        current_iteration=12,
+        searchable_tool_pool=pool,
+        revealed_openapi_tools=["op_01"],
+    )
+
+    wf = AgentExecutionWorkflow()
+    # _restore is async only because of workflow.logger; works synchronously here too.
+    asyncio.run(wf._restore_from_continued_state(cstate.model_dump()))
+
+    assert wf.state.searchable_tool_pool == pool
+    assert wf.state.revealed_openapi_tools == ["op_01"]
+    # Disclosure policy reinstantiated because pool is non-empty.
+    assert wf._disclosure_policy is not None
+    # The previously revealed schema is still callable as a regular tool.
+    schema_names = [
+        t["function"]["name"]
+        for t in wf.state.available_tools
+        if t.get("type") == "function"
+    ]
+    assert "op_01" in schema_names
+
+
+def test_continue_as_new_drops_stale_revealed_names_when_pool_shrinks():
+    """If a previously revealed operation is no longer in the rebuilt pool
+    (connection edited mid-task), restore must drop it from revealed_openapi_tools
+    AND from available_tools — otherwise the LLM sees a tool it can no longer call.
+    """
+    surviving = _pool_entry("op_keep")
+    cstate = ContinueAsNewState(
+        execution_id="exec-1",
+        agent_id="agent-1",
+        task_id="task-1",
+        user_id="user-1",
+        workspace_id="ws-1",
+        goal=_goal(),
+        messages=[],
+        agent_config={},
+        # available_tools carries TWO previously revealed schemas, but the new pool
+        # only contains one of them.
+        available_tools=[
+            {"type": "function", "function": {"name": "completion", "parameters": {}}},
+            surviving["schema"],
+            {
+                "type": "function",
+                "function": {
+                    "name": "op_gone",
+                    "description": "removed",
+                    "parameters": {"type": "object"},
+                },
+            },
+        ],
+        current_iteration=2,
+        searchable_tool_pool=[surviving],
+        revealed_openapi_tools=["op_keep", "op_gone"],
+    )
+    wf = AgentExecutionWorkflow()
+    asyncio.run(wf._restore_from_continued_state(cstate.model_dump()))
+
+    assert wf.state.revealed_openapi_tools == ["op_keep"]
+    schema_names = [
+        t["function"]["name"]
+        for t in wf.state.available_tools
+        if t.get("type") == "function"
+    ]
+    assert "op_keep" in schema_names
+    assert "op_gone" not in schema_names
+
+
+def test_continue_as_new_with_empty_pool_leaves_policy_unset():
+    cstate = ContinueAsNewState(
+        execution_id="exec-1",
+        agent_id="agent-1",
+        task_id="task-1",
+        user_id="user-1",
+        workspace_id="ws-1",
+        goal=_goal(),
+        messages=[],
+        agent_config={},
+        available_tools=[],
+        current_iteration=0,
+    )
+    wf = AgentExecutionWorkflow()
+    asyncio.run(wf._restore_from_continued_state(cstate.model_dump()))
+    assert wf.state.searchable_tool_pool == []
+    assert wf.state.revealed_openapi_tools == []
+    assert wf._disclosure_policy is None

--- a/agentarea-platform/libs/execution/tests/unit/test_searchable_openapi_workflow.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_searchable_openapi_workflow.py
@@ -1,0 +1,144 @@
+"""Workflow handler for `load_tools` meta-tool (issue #115).
+
+Direct-instance tests on `AgentExecutionWorkflow` — no Temporal harness needed.
+Exercises the post-discovery state shape and the load_tools dispatch path.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentarea_agents_sdk.tools.disclosure import NamedLookupPolicy
+from agentarea_execution.workflows.agent_execution_workflow import AgentExecutionWorkflow
+from agentarea_execution.workflows.models import ToolCall
+
+
+def _make_pool(num: int):
+    pool = []
+    for i in range(num):
+        name = f"op_{i:02d}"
+        pool.append(
+            {
+                "name": name,
+                "description": f"Operation {i}",
+                "connection_id": "stripe-conn",
+                "schema": {
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "description": f"Operation {i}",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+                "source_type": "openapi",
+            }
+        )
+    return pool
+
+
+def _wf_with_pool(num_ops: int = 50):
+    wf = AgentExecutionWorkflow()
+    wf.state.searchable_tool_pool = _make_pool(num_ops)
+    wf.state.available_tools = [
+        {"type": "function", "function": {"name": "completion", "parameters": {}}},
+    ]
+    wf._disclosure_policy = NamedLookupPolicy()
+    wf.event_manager = MagicMock()
+    return wf
+
+
+def _call(name: str, args: dict, call_id: str = "tc_1"):
+    return ToolCall(
+        id=call_id,
+        function={"name": name, "arguments": json.dumps(args)},
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_tools_reveals_requested_schemas():
+    wf = _wf_with_pool(50)
+    await wf._execute_load_openapi_tools(_call("load_tools", {"tool_names": ["op_05", "op_42"]}))
+
+    revealed_names = [
+        t["function"]["name"]
+        for t in wf.state.available_tools
+        if t["function"]["name"].startswith("op_")
+    ]
+    assert set(revealed_names) == {"op_05", "op_42"}
+    assert wf.state.revealed_openapi_tools == ["op_05", "op_42"]
+
+
+@pytest.mark.asyncio
+async def test_load_tools_unknown_name_does_not_pollute_state():
+    wf = _wf_with_pool(10)
+    await wf._execute_load_openapi_tools(
+        _call("load_tools", {"tool_names": ["op_00", "nonexistent"]})
+    )
+    op_names = [
+        t["function"]["name"]
+        for t in wf.state.available_tools
+        if t["function"]["name"].startswith("op_")
+    ]
+    assert op_names == ["op_00"]
+    assert wf.state.revealed_openapi_tools == ["op_00"]
+    # Tool message reports the unknown one
+    last_msg = wf.state.messages[-1]
+    assert "nonexistent" in last_msg.content
+
+
+@pytest.mark.asyncio
+async def test_load_tools_dedupes_repeat_reveal():
+    wf = _wf_with_pool(5)
+    await wf._execute_load_openapi_tools(_call("load_tools", {"tool_names": ["op_01"]}))
+    await wf._execute_load_openapi_tools(_call("load_tools", {"tool_names": ["op_01"]}, "tc_2"))
+    op_names = [
+        t["function"]["name"]
+        for t in wf.state.available_tools
+        if t["function"]["name"].startswith("op_")
+    ]
+    assert op_names == ["op_01"]
+    assert wf.state.revealed_openapi_tools == ["op_01"]
+
+
+@pytest.mark.asyncio
+async def test_load_tools_with_no_pool_returns_error_message():
+    wf = AgentExecutionWorkflow()
+    wf.event_manager = MagicMock()
+    await wf._execute_load_openapi_tools(_call("load_tools", {"tool_names": ["x"]}))
+    assert wf.state.available_tools == []
+    last_msg = wf.state.messages[-1]
+    assert "no searchable" in last_msg.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_load_tools_emits_tool_call_completed_event():
+    wf = _wf_with_pool(3)
+    await wf._execute_load_openapi_tools(_call("load_tools", {"tool_names": ["op_00", "missing"]}))
+    args, _ = wf.event_manager.add_event.call_args
+    event_type, payload = args
+    assert payload["tool_name"] == "load_tools"
+    assert payload["matched_names"] == ["op_00"]
+    assert payload["unknown_names"] == ["missing"]
+
+
+@pytest.mark.asyncio
+async def test_load_tools_handles_malformed_arguments():
+    wf = _wf_with_pool(3)
+    bad_call = ToolCall(
+        id="tc_bad",
+        function={"name": "load_tools", "arguments": "not json"},
+    )
+    await wf._execute_load_openapi_tools(bad_call)
+    # No reveals, no crash; message indicates nothing happened.
+    assert wf.state.revealed_openapi_tools == []
+    assert all(
+        not t["function"]["name"].startswith("op_") for t in wf.state.available_tools
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_tools_non_list_argument_treated_as_empty():
+    wf = _wf_with_pool(3)
+    await wf._execute_load_openapi_tools(_call("load_tools", {"tool_names": "op_00"}))
+    assert wf.state.revealed_openapi_tools == []

--- a/agentarea-platform/libs/execution/tests/unit/test_state_searchable_pool.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_state_searchable_pool.py
@@ -1,0 +1,83 @@
+"""AgentExecutionState + ContinueAsNewState carry searchable_tool_pool and revealed_openapi_tools."""
+
+from agentarea_execution.workflows.models import (
+    AgentExecutionState,
+    AgentGoal,
+    ContinueAsNewState,
+)
+
+
+def _goal():
+    return AgentGoal(
+        id="g",
+        description="d",
+        success_criteria=[],
+        max_iterations=1,
+        requires_human_approval=False,
+        context={},
+    )
+
+
+def test_agent_state_defaults_empty_pool_and_revealed():
+    s = AgentExecutionState()
+    assert s.searchable_tool_pool == []
+    assert s.revealed_openapi_tools == []
+
+
+def test_continue_as_new_state_defaults_empty_pool_and_revealed():
+    s = ContinueAsNewState(
+        execution_id="e",
+        agent_id="a",
+        task_id="t",
+        user_id="u",
+        workspace_id="w",
+        goal=_goal(),
+        messages=[],
+        agent_config={},
+        available_tools=[],
+        current_iteration=0,
+    )
+    assert s.searchable_tool_pool == []
+    assert s.revealed_openapi_tools == []
+
+
+def test_agent_state_round_trips_pool_through_pydantic():
+    pool = [
+        {
+            "name": "createCharge",
+            "description": "Create a charge.",
+            "connection_id": "conn-1",
+            "schema": {"type": "function", "function": {"name": "createCharge"}},
+            "source_type": "openapi",
+        }
+    ]
+    s = AgentExecutionState(
+        searchable_tool_pool=pool,
+        revealed_openapi_tools=["createCharge"],
+    )
+    dumped = s.model_dump()
+    rehydrated = AgentExecutionState(**dumped)
+    assert rehydrated.searchable_tool_pool == pool
+    assert rehydrated.revealed_openapi_tools == ["createCharge"]
+
+
+def test_continue_as_new_round_trips_pool():
+    pool = [{"name": "x", "description": "y", "connection_id": "c", "schema": {}, "source_type": "openapi"}]
+    s = ContinueAsNewState(
+        execution_id="e",
+        agent_id="a",
+        task_id="t",
+        user_id="u",
+        workspace_id="w",
+        goal=_goal(),
+        messages=[],
+        agent_config={},
+        available_tools=[],
+        current_iteration=0,
+        searchable_tool_pool=pool,
+        revealed_openapi_tools=["x"],
+    )
+    dumped = s.model_dump()
+    rehydrated = ContinueAsNewState(**dumped)
+    assert rehydrated.searchable_tool_pool == pool
+    assert rehydrated.revealed_openapi_tools == ["x"]

--- a/agentarea-platform/tests/e2e/api/test_openapi_searchable_loading.py
+++ b/agentarea-platform/tests/e2e/api/test_openapi_searchable_loading.py
@@ -1,0 +1,147 @@
+"""End-to-end validation of OpenAPI lazy tool loading (issue #115).
+
+Proves that:
+  1. An OpenAPI connection with `load_mode=searchable` does NOT inject every
+     operation schema into the LLM's `available_tools` upfront.
+  2. The model can fire the `load_tools` meta-tool and the workflow resolves
+     names to real schemas (visible as a `ToolCallCompleted` event with
+     `matched_names` populated).
+
+Requires a running stack (`make up-dev`) and a reachable LLM endpoint.
+Set OPENAI_COMPAT_ENDPOINT / _MODEL / _API_KEY env vars if defaults don't
+match your stack (see conftest.py).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import httpx
+import pytest
+
+from .conftest import create_agent, wait_for_workflow
+
+
+PETSTORE_SPEC = "https://petstore3.swagger.io/api/v3/openapi.json"
+PETSTORE_BASE = "https://petstore3.swagger.io/api/v3"
+
+
+def _wait_for_discovery(client: httpx.Client, conn_id: str, timeout: float = 30.0) -> dict:
+    """Poll until `available_tools` is populated on the connection record."""
+    deadline = time.time() + timeout
+    last: dict = {}
+    while time.time() < deadline:
+        last = client.get(f"/v1/openapi-connections/{conn_id}").raise_for_status().json()
+        tools = last.get("available_tools") or []
+        if isinstance(tools, list) and len(tools) > 0:
+            return last
+        time.sleep(1.0)
+    raise AssertionError(
+        f"OpenAPI discovery never populated available_tools within {timeout}s: "
+        f"{last}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_searchable_openapi_load_tools_dispatch(
+    alice_client: httpx.Client, llm_model: str
+) -> None:
+    # 1. Create a Petstore connection — the public sandbox has ~20 operations,
+    #    enough for the catalog to be meaningful but small enough for fast e2e.
+    conn = alice_client.post(
+        "/v1/openapi-connections/",
+        json={
+            "name": f"petstore-e2e-{uuid.uuid4().hex[:6]}",
+            "base_url": PETSTORE_BASE,
+            "spec_url": PETSTORE_SPEC,
+        },
+        timeout=30.0,
+    ).raise_for_status().json()
+    conn_id = conn["id"]
+    try:
+        # 2. Ensure tool discovery actually completed so the searchable catalog
+        #    in the workflow won't be empty.
+        conn_full = _wait_for_discovery(alice_client, conn_id)
+        op_count = len(conn_full.get("available_tools") or [])
+        assert op_count > 0, "Petstore connection has zero discovered operations"
+
+        # 3. Attach the connection to an agent with load_mode=searchable.
+        agent_id = create_agent(
+            alice_client,
+            llm_model,
+            name=f"petstore-agent-{uuid.uuid4().hex[:6]}",
+            instruction=(
+                "You are connected to the Swagger Petstore API. To use any "
+                "Petstore operation, you MUST first call the `load_tools` "
+                "meta-tool with the exact operation name(s) you need (e.g. "
+                "`load_tools({\"tool_names\":[\"findPetsByStatus\"]})`). "
+                "Operation names are listed under '## Available OpenAPI "
+                "Operations' in this prompt. After load_tools returns, call "
+                "the operation, then call `completion` with a short summary."
+            ),
+            tools=[
+                {
+                    "type": "openapi",
+                    "name": conn["name"],
+                    "settings": {
+                        "openapi_connection_id": conn_id,
+                        "load_mode": "searchable",
+                    },
+                }
+            ],
+        )
+
+        # 4. Submit a task that requires a real Petstore call.
+        task_id = (
+            alice_client.post(
+                f"/v1/agents/{agent_id}/tasks/sync",
+                json={
+                    "description": (
+                        "Find Petstore pets with status 'available'. "
+                        "Use load_tools to load `findPetsByStatus`, call it, "
+                        "then summarize with completion."
+                    )
+                },
+                timeout=30.0,
+            )
+            .raise_for_status()
+            .json()["id"]
+        )
+
+        # 5. Wait for workflow to terminate.
+        events = wait_for_workflow(
+            alice_client, agent_id, task_id, timeout=180.0
+        )
+
+        # 6. The hard assertion: somewhere in the event stream we must see
+        #    `load_tools` complete with at least one matched operation. This
+        #    proves the disclosure path executed end-to-end against a live LLM.
+        load_tools_events = [
+            e
+            for e in events
+            if e["event_type"] == "ToolCallCompleted"
+            and (e.get("metadata") or {}).get("tool_name") == "load_tools"
+        ]
+        assert load_tools_events, (
+            "expected at least one ToolCallCompleted for `load_tools`; got "
+            f"event types: {[e['event_type'] for e in events]}"
+        )
+
+        matched = []
+        for ev in load_tools_events:
+            md = ev.get("metadata") or {}
+            matched.extend(md.get("matched_names") or [])
+        assert matched, (
+            "load_tools fired but resolved zero operation names; metadata: "
+            f"{[e.get('metadata') for e in load_tools_events]}"
+        )
+
+        # 7. Bonus: prove the workflow didn't crash.
+        assert any(e["event_type"] == "WorkflowCompleted" for e in events), (
+            "workflow did not reach WorkflowCompleted; events: "
+            f"{[e['event_type'] for e in events]}"
+        )
+    finally:
+        alice_client.delete(f"/v1/openapi-connections/{conn_id}")

--- a/agentarea-webapp/src/app/(main)/agents/create/actions.ts
+++ b/agentarea-webapp/src/app/(main)/agents/create/actions.ts
@@ -32,6 +32,7 @@ const OpenAPIConfigSchema = z.object({
   openapi_connection_id: z.string().uuid("Invalid OpenAPI connection ID"),
   openapi_connection_name: z.string().optional(),
   allowed_tools: z.array(z.string()).optional().nullable(),
+  load_mode: z.enum(["explicit", "searchable"]).optional(),
 });
 
 // Define Zod schema for Builtin Tool Config
@@ -76,6 +77,7 @@ export interface AddAgentFormState {
         openapi_connection_id: string;
         openapi_connection_name?: string;
         allowed_tools?: string[] | null;
+        load_mode?: "explicit" | "searchable";
       }> | null;
     } | null;
     events_config?: {
@@ -148,6 +150,7 @@ export async function addAgent(
     openapi_connection_id?: string;
     openapi_connection_name?: string;
     allowed_tools?: string[];
+    load_mode?: "explicit" | "searchable";
   };
   const openapiConfigs: Record<number, OpenAPIConfigMutable> = {};
 
@@ -268,6 +271,20 @@ export async function addAgent(
       }
       openapiConfigs[index].allowed_tools!.push(value as string);
     }
+
+    const openapiLoadModeMatch = key.match(
+      /tools_config\.openapi_configs\[(\d+)\]\.load_mode/
+    );
+    if (openapiLoadModeMatch) {
+      const index = parseInt(openapiLoadModeMatch[1], 10);
+      if (!openapiConfigs[index]) {
+        openapiConfigs[index] = {};
+      }
+      const v = value as string;
+      if (v === "explicit" || v === "searchable") {
+        openapiConfigs[index].load_mode = v;
+      }
+    }
   });
 
   // Combine MCP configs with their allowed tools
@@ -297,6 +314,7 @@ export async function addAgent(
     openapi_connection_id: config.openapi_connection_id as string,
     openapi_connection_name: config.openapi_connection_name,
     allowed_tools: config.allowed_tools,
+    load_mode: config.load_mode,
   }));
 
   // Reconstruct events array using new format

--- a/agentarea-webapp/src/app/(main)/agents/create/components/ToolConfig.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/components/ToolConfig.tsx
@@ -236,11 +236,28 @@ const ToolConfig = ({
       (f) => f.openapi_connection_id === connection.id
     );
     if (alreadyAdded) return;
+    // Default new OpenAPI attachments to "searchable" — the catalog block in
+    // the system prompt + load_tools meta-tool keeps token cost flat regardless
+    // of spec size (issue #115). Existing entries without load_mode keep their
+    // legacy "explicit" behavior.
     appendOpenapiTool({
       openapi_connection_id: connection.id,
       openapi_connection_name: connection.name,
       allowed_tools: [],
+      load_mode: "searchable",
     });
+  };
+
+  const handleOpenapiLoadModeChange = (
+    connectionId: string,
+    mode: "explicit" | "searchable"
+  ) => {
+    if (!setValue || !openapiFields) return;
+    const index = openapiFields.findIndex(
+      (f) => f.openapi_connection_id === connectionId
+    );
+    if (index === -1) return;
+    setValue(`tools_config.openapi_configs.${index}.load_mode`, mode);
   };
 
   const handleRemoveOpenapiConnection = (connectionId: string) => {
@@ -878,6 +895,12 @@ const ToolConfig = ({
                       ? allTools.length
                       : allowedTools.length;
 
+                  const currentLoadMode =
+                    ((item as any).load_mode as
+                      | "explicit"
+                      | "searchable"
+                      | undefined) ?? "explicit";
+
                   return (
                     <div
                       key={`openapi-${index}`}
@@ -897,6 +920,51 @@ const ToolConfig = ({
                           </p>
                         </div>
                       </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <div
+                          className="inline-flex items-center rounded-md border text-xs"
+                          role="group"
+                          aria-label="Load mode"
+                        >
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handleOpenapiLoadModeChange(
+                                item.openapi_connection_id,
+                                "explicit"
+                              )
+                            }
+                            className={
+                              "px-2 py-0.5 rounded-l-md " +
+                              (currentLoadMode === "explicit"
+                                ? "bg-accent text-accent-foreground"
+                                : "text-muted-foreground hover:text-foreground")
+                            }
+                            aria-pressed={currentLoadMode === "explicit"}
+                            title="Send every operation schema in every LLM call (legacy behavior, larger context)."
+                          >
+                            Explicit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handleOpenapiLoadModeChange(
+                                item.openapi_connection_id,
+                                "searchable"
+                              )
+                            }
+                            className={
+                              "px-2 py-0.5 rounded-r-md border-l " +
+                              (currentLoadMode === "searchable"
+                                ? "bg-accent text-accent-foreground"
+                                : "text-muted-foreground hover:text-foreground")
+                            }
+                            aria-pressed={currentLoadMode === "searchable"}
+                            title="Defer schemas behind a load_tools meta-tool; only a name+description catalog goes into the system prompt."
+                          >
+                            Searchable
+                          </button>
+                        </div>
                       <Button
                         type="button"
                         variant="ghost"
@@ -920,6 +988,7 @@ const ToolConfig = ({
                           <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
                         </svg>
                       </Button>
+                      </div>
                     </div>
                   );
                 })}

--- a/agentarea-webapp/src/app/(main)/agents/create/types.ts
+++ b/agentarea-webapp/src/app/(main)/agents/create/types.ts
@@ -33,6 +33,10 @@ export type OpenAPIConfig = {
   openapi_connection_id: string;
   openapi_connection_name?: string;  // resolved name for backend; filled by picker
   allowed_tools?: string[];  // operation names; empty/missing = all
+  // Disclosure mode (issue #115). "searchable" defers operation schemas
+  // behind a `load_tools` meta-tool; "explicit" sends every schema every call.
+  // Absent = legacy explicit behavior preserved.
+  load_mode?: "explicit" | "searchable";
 };
 
 /**

--- a/agentarea-webapp/src/app/(main)/agents/shared/formDataUtils.ts
+++ b/agentarea-webapp/src/app/(main)/agents/shared/formDataUtils.ts
@@ -82,6 +82,12 @@ export function createAgentFormData(data: AgentFormValues): FormData {
             );
           });
         }
+        if (config.load_mode === "explicit" || config.load_mode === "searchable") {
+          formData.append(
+            `tools_config.openapi_configs[${index}].load_mode`,
+            config.load_mode
+          );
+        }
       }
     );
   }


### PR DESCRIPTION
## Summary

Adds per-OpenAPI-connection `load_mode` (`"explicit"` | `"searchable"`).
In `searchable` mode the workflow ships only a compact name+description
catalog in the system prompt plus a `load_tools(tool_names)` meta-tool;
full operation schemas are revealed on demand by exact-name lookup
against `state.searchable_tool_pool`. Closes the 30–50K token per LLM
call inflation for large OpenAPI specs without touching MCP/code/agent
tool paths.

Closes #115.

## Architecture

GoF **Strategy + Factory**:
- `ToolDisclosurePolicy` (Protocol) with concrete `ExplicitPolicy` (preserves legacy behavior) and `NamedLookupPolicy` (the new lazy path)
- `policy_from_config(name | dict)` factory; `searchable` is a YAML shorthand alias for `NamedLookupPolicy`
- Decorator slots reserved for follow-ups (truncation, threshold, metrics, tag grouping) — no workflow changes needed when they land

## Backend

- New `agentarea_agents_sdk.tools.disclosure` module
- `ToolManager.discover_available_tools_split` returns `DiscoveryResult{explicit_tools, searchable_entries}`; legacy `discover_available_tools` unchanged via shared `_discover` with `force_explicit=True`
- `OpenAPIToolFactory.get_tool_definition_by_name` for by-name reveal
- `ToolDiscoveryResult` carries `SearchableToolEntry` list
- `AgentExecutionState` + `ContinueAsNewState` carry `searchable_tool_pool` and `revealed_openapi_tools` (round-tripped on continue-as-new)
- Workflow injects `load_tools` meta-tool when pool non-empty, appends catalog block to system prompt, dispatches `load_tools` locally via `_execute_load_openapi_tools` (no Temporal activity)
- On continue-as-new restore: reconciles stale revealed names against rebuilt pool with `workflow.logger.warning`

## Frontend

- `OpenAPIConfig` type + Zod schema gain optional `load_mode`
- Form ↔ API round-trip preserves the field
- Per-connection segmented control "Explicit | Searchable" on the agent tools card; new attachments default to `searchable`

## Token-saving math

- 100-op OpenAPI spec ≈ 25K tokens of schemas every call
- Catalog text: ~30 chars/op × 100 ≈ 3K chars ≈ ~750 tokens
- Plus one `load_tools` stub (~120 tokens). LLM reveals only ops it actually uses.

## Test plan

Done in PR:
- [x] 117 unit/integration tests across SDK + platform pass (48 SDK + 69 platform)
- [x] New: disclosure protocol+factory+registry, ExplicitPolicy + NamedLookupPolicy, OpenAPIToolFactory by-name lookup, ToolManager split discovery (7 scenarios incl. allowed_tools filter, missing service, empty config), workflow handler (7 scenarios incl. dedup, malformed args, unknown name), continue-as-new round-trip + stale-pool reconciliation, state field defaults, YAML round-trip
- [x] Regression: existing ToolManager + import_export tests green (40 tests)
- [x] Frontend `tsc --noEmit` clean
- [x] Architect review (Opus) — APPROVED WITH NOTES, both MAJOR findings addressed (M1: PRD honesty on US-014 placement; M2: stale-name reconciliation on restore)
- [x] Deslop pass — fixed whitespace-only description crash in catalog rendering

Required before merge:
- [ ] **Manual e2e in dev stack**: `make up-dev`, create an OpenAPI connection against a spec with ≥50 operations (extended Petstore or Stripe-partial), attach to a new agent (UI defaults `searchable`), send a prompt that needs a specific operation. Verify via SSE:
  - Iteration 1 `available_tools` contains only `load_tools`, `completion`, `recall_history`
  - System prompt contains the catalog block
  - LLM emits `load_tools({"tool_names":[...]})`; `TOOL_CALL_COMPLETED` event reports revealed names
  - Next iteration `available_tools` now includes only the revealed schemas
  - Operation dispatch hits the real HTTP endpoint
- [ ] Smoke a multi-connection agent if available — only one OpenAPI source per agent is the common case; function-name collision across two sources is a documented follow-up (see "Out of scope")

## Pre-existing failures (NOT caused by this PR)

`libs/execution/tests/unit/test_user_facing_errors.py` — 3 tests fail on the
`main` baseline with `ConnectionRefused` against the Temporal test cluster.
Verified independent of this PR via `git stash` + rerun on baseline.

## Out of scope (follow-ups)

- Per-tool granularity inside a single MCP server (the `load_mode` field on `ToolSettingsYAML` already supports this when we extend the workflow path)
- Function-name collision when an agent attaches >1 OpenAPI source with operations that slugify identically — namespace by connection id when this becomes a real case
- Smarter retrieval (fuzzy/BM25/embeddings) inside `load_tools` — only if real usage shows the LLM struggling to pick names from the catalog text
- Token estimator UI (not needed per design discussion)
- Integration-harness extension of the continue-as-new test in `test_agent_workflow.py` (unit-level coverage in `test_searchable_openapi_continue_as_new.py` exercises the same regression)