### PR TITLE
docs: overhaul README for accuracy and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [📖 Documentation](https://docs.agentarea.ai) •
 [🚀 Quick Start](#-quick-start) •
-[💬 Discord](https://discord.gg/93jVZ4Kx) •
+[💬 Discord](https://discord.gg/5tduPwheYQ) •
 [🐛 Report Bug](https://github.com/agentarea/agentarea/issues/new?template=bug_report.md) •
 [✨ Request Feature](https://github.com/agentarea/agentarea/issues/new?template=feature_request.md)
 
@@ -24,17 +24,19 @@
 
 ## 🚀 What is AgentArea?
 
-AgentArea is an open-core platform purpose-built for **agentic networks** and **agent governance**. Unlike single-agent frameworks, AgentArea provides the infrastructure to build, govern, and scale multi-agent systems with VPC-inspired network architecture and built-in compliance controls.
+AgentArea is an open-source platform for building **agentic networks** — multi-agent systems with governance, isolation, and approval controls built in.
+
+Most agent tools are **libraries**: you import them and orchestrate agents inside your own app. AgentArea is **infrastructure**: a self-hosted runtime where agents run durably, in isolated networks, under governance and approval policy. Reach for it when "an agent in a script" has outgrown what a library can safely run — when you need many agents, scoped permissions between them, human-in-the-loop approvals, audit trails, and a runtime built for long-running work.
 
 ## 🎯 Why AgentArea?
 
-Traditional agent frameworks focus on individual agents. AgentArea is different:
+Traditional agent frameworks focus on individual agents. AgentArea is built for networks of them:
 
-- **🌐 Agentic Networks First**: VPC-inspired architecture with granular network permissions between agents
-- **🛡️ Governance Built-In**: Tool approvals, permission boundaries, ReBAC authorization, and audit trails from day one
-- **🔗 A2A Protocol**: Native agent-to-agent communication standard for multi-agent orchestration
-- **⚡ Production-Ready**: Temporal-based execution, Kubernetes-native, edge deployment, enterprise authentication
-- **🏗️ Open-Core Model**: Core platform is open source (EPLv2), enterprise features available for compliance-critical deployments
+- **🌐 Agentic Networks First** — VPC-inspired architecture with granular network permissions between agents
+- **🛡️ Governance Built-In** — tool approvals, permission boundaries, ReBAC authorization, and audit trails from day one
+- **⚡ Production-Ready** — Temporal-based execution, Kubernetes-native, edge deployment, enterprise authentication
+- **🔌 Provider-Agnostic** — any LLM via LiteLLM proxy, any tool via MCP, multiple secret backends
+- **📖 Truly Open Source** — Apache 2.0 licensed, no feature gates
 
 ### ✨ Core Capabilities
 
@@ -48,11 +50,11 @@ VPC-inspired network architecture with isolated agent groups. Configure granular
 #### 🛡️ Agent Governance
 Granular tool permissions with approval workflows. Select which tools agents can use, require human approval for sensitive operations, and maintain full audit trails for compliance.
 
-#### 🔗 A2A Protocol
-Native agent-to-agent communication protocol. Agents can discover, connect, and collaborate with each other. Supports agent teams, task delegation, and hierarchical agent structures.
+#### 🤝 Agent Collaboration
+Agents discover, delegate to, and coordinate with each other. Direct delegation is the default; the [A2A protocol](https://docs.agentarea.ai) is also supported for interoperability with external agent systems.
 
 #### ⚡ Event-Driven Triggers
-Fire agents on timers, webhooks, or third-party events. Build reactive agent systems that respond to external stimuli in real-time.
+Fire agents on timers, webhooks, or third-party events. Build reactive agent systems that respond to external stimuli in real time.
 
 </td>
 <td width="50%">
@@ -66,95 +68,137 @@ Build agents with custom instructions and tool configurations. Long-running task
 #### 🏗️ Production Infrastructure
 Temporal for distributed execution and edge deployment. Kubernetes-native architecture. Multi-LLM support via LiteLLM proxy. Multiple secret backends (database, Infisical, AWS).
 
-#### 🔐 Enterprise Authorization
-Built-in Keto integration for fine-grained access control. Relationship-based access control (ReBAC) coming soon for advanced permission modeling.
+#### 🔐 Fine-Grained Authorization
+Relationship-based access control (ReBAC) via Ory Keto. Model who can see and act on which agents, networks, and tools — down to the individual resource.
 
 </td>
 </tr>
 </table>
 
-### 🎬 See It In Action
+### 🧩 What You Can Build
 
-> 📸 *Screenshots and demo GIFs coming soon! [Contribute yours](https://github.com/agentarea/agentarea/discussions)*
+- **Research networks** — a coordinator agent delegates to specialist agents (search, summarize, fact-check), each with its own scoped tool access, then merges the results.
+- **Governed ops automation** — agents triggered by webhooks or schedules that can act on real systems, with human approval required before any sensitive tool runs.
+- **Long-running task agents** — durable agents that work for minutes or hours toward a goal, surviving restarts via Temporal, stopping on goal achievement, budget, or timeout.
+- **Tool-rich assistants** — agents backed by your own MCP servers (internal APIs, databases, SaaS), hosted and version-checked by the platform.
 
-## 🏃‍♂️ Quick Start
+## 🏃 Quick Start
 
 ### Prerequisites
 
 - Docker & Docker Compose
 
-### Installation
+### 1. Start the platform
 
 ```bash
-# Clone the repository
 git clone https://github.com/agentarea/agentarea.git
 cd agentarea
-
-# Start the platform
 make up
-
-# Access the platform at http://localhost:3000
 ```
 
-That's it! The platform will start all necessary services and be ready to use.
+This starts every service via Docker Compose. Once it's up, open the web UI at **http://localhost:3000**.
+
+### 2. Create your first agent
+
+1. Open http://localhost:3000 and add an **LLM provider** (e.g. an OpenAI or Anthropic API key) under Settings.
+2. Create an **agent** — give it instructions and pick the tools it can use.
+3. Send it a task and watch it run.
+
+Full walkthrough: **[Getting Started →](docs/getting-started.md)**
 
 ## 📚 Documentation
 
-- **[Getting Started](docs/getting-started.md)** - Complete setup guide
-- **[Building Agents](docs/building-agents.md)** - Create and customize AI agents
-- **[Agent Communication](docs/agent-communication.md)** - Multi-agent workflows
-- **[MCP Integration](docs/mcp-integration.md)** - External tool integration
-- **[Deployment](docs/deployment.md)** - Production deployment guide
-- **[API Reference](docs/api-reference.md)** - Complete API documentation
+- **[Getting Started](docs/getting-started.md)** — complete setup guide
+- **[Building Agents](docs/building-agents.md)** — create and customize agents
+- **[Agent Communication](docs/agent-communication.md)** — multi-agent workflows
+- **[Agentic Networks](docs/agentic-networks.md)** — network isolation and permissions
+- **[Agent Governance](docs/agent-governance.md)** — approvals, permissions, audit
+- **[MCP Integration](docs/mcp-integration.md)** — external tool integration
+- **[Deployment](docs/deployment.md)** — production deployment guide
+- **[Architecture](docs/architecture.md)** — system design deep dive
+- **[API Reference](docs/api-reference.md)** — complete API documentation
 
 ## 🛠️ Project Structure
 
 ```
 agentarea/
-├── agentarea-platform/     # Backend API and services (Python)
-│   ├── apps/               # Applications (API, Worker, CLI)
-│   └── libs/               # Shared libraries
-├── agentarea-webapp/       # Web interface (React/Next.js)
-├── agentarea-mcp-manager/  # MCP server management (Go)
-├── agent-placement/        # Agent orchestration (Node.js)
-├── docs/                   # Documentation (Mintlify)
-└── scripts/               # Development and deployment scripts
+├── agentarea-platform/      # Backend API, Temporal worker, domain libs (Python)
+├── agentarea-webapp/        # Web interface (Next.js / React)
+├── agentarea-mcp-manager/   # MCP server orchestration (Go)
+├── agentarea-operator/      # Kubernetes operator (catalog, LLM providers)
+├── agentarea-event-service/ # Event ingestion and triggers
+├── agentarea-cli/           # Command-line interface (Node.js)
+├── charts/                  # Helm charts
+├── docs/                    # Documentation (Mintlify)
+└── scripts/                 # Build and deployment utilities
 ```
-
 
 ## 🏗️ Architecture
 
-AgentArea is built for production agentic workloads with:
+```mermaid
+flowchart TB
+    User([User / API client])
 
-- **Agent Networks**: VPC-inspired isolation with granular permissions
-- **A2A Protocol**: Native agent-to-agent communication
-- **Temporal**: Distributed workflow orchestration for long-running agent tasks
-- **Multi-LLM Support**: Provider-agnostic through LiteLLM proxy
-- **MCP Infrastructure**: Extensible tool system with custom server support
+    subgraph CP["Control plane"]
+        UI["Web UI<br/>(Next.js)"]
+        API["API<br/>(FastAPI)"]
+        Keto["Authorization<br/>(Ory Keto · ReBAC)"]
+    end
 
-For detailed architecture documentation, see [docs/architecture.md](docs/architecture.md).
+    subgraph RT["Agent runtime"]
+        Worker["Temporal Worker<br/>(agent workflows)"]
+        LiteLLM["LiteLLM proxy<br/>(any LLM)"]
+        MCPMgr["MCP Manager<br/>(Go)"]
+        MCP["MCP servers<br/>(containerized tools)"]
+    end
 
-See our [full roadmap](docs/roadmap.md) for more details.
+    subgraph DATA["State & events"]
+        PG[("PostgreSQL")]
+        Redis[("Redis<br/>pub/sub + events")]
+    end
+
+    User --> UI --> API
+    User -->|REST / SSE| API
+    API --> Keto
+    API --> PG
+    API -->|start / signal| Worker
+    Worker --> LiteLLM
+    Worker --> MCPMgr --> MCP
+    Worker --> PG
+    Worker -->|events| Redis
+    Redis -->|stream| API
+    API -.->|SSE| UI
+```
+
+AgentArea is built for production agentic workloads:
+
+- **Agent Networks** — VPC-inspired isolation with granular inter-agent permissions
+- **Temporal** — distributed workflow orchestration for long-running, durable agent tasks
+- **Event Flow** — workflows publish to Redis pub/sub + DB, streamed to the UI over SSE
+- **Multi-LLM Support** — provider-agnostic through the LiteLLM proxy
+- **MCP Infrastructure** — extensible tool system with custom and remote server support
+- **ReBAC Authorization** — fine-grained access control via Ory Keto
+
+For details, see [docs/architecture.md](docs/architecture.md) and the [full roadmap](docs/roadmap.md).
+
+## 🤝 Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) to get started, and please review our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## 🌟 Community
 
 Join our community of AI developers:
 
-- **💬 Discord**: [Get help and share ideas](https://discord.gg/93jVZ4Kx)
-- **💭 GitHub Discussions**: [Q&A and feature requests](https://github.com/agentarea/agentarea/discussions)
-- **🐛 Issues**: [Bug reports and feature requests](https://github.com/agentarea/agentarea/issues)
-- **🐦 Twitter/X**: [Follow for updates](https://twitter.com/agentarea_hq)
+- **💬 Discord** — [get help and share ideas](https://discord.gg/5tduPwheYQ)
+- **💭 GitHub Discussions** — [Q&A and feature requests](https://github.com/agentarea/agentarea/discussions)
+- **🐛 Issues** — [bug reports and feature requests](https://github.com/agentarea/agentarea/issues)
+- **🐦 Twitter/X** — [follow for updates](https://twitter.com/agentarea_hq)
 
 ## 📄 License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE.md) file for details.
-
+Licensed under the Apache License 2.0 — see [LICENSE.md](LICENSE.md) for details.
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fagentarea%2Fagentarea.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fagentarea%2Fagentarea?ref=badge_large)
-
-## 🙏 Acknowledgments
-
-AgentArea is built on top of many excellent open-source projects. See our [NOTICE](NOTICE) file for complete attribution.
 
 ---
 
@@ -164,13 +208,9 @@ AgentArea is built on top of many excellent open-source projects. See our [NOTIC
 
 [![Star History Chart](https://api.star-history.com/svg?repos=agentarea/agentarea&type=Date)](https://star-history.com/#agentarea/agentarea&Date)
 
-### 🙌 Built With AgentArea
-
-*Showcase your project here! [Submit via PR](https://github.com/agentarea/agentarea/pulls) or [Discussion](https://github.com/agentarea/agentarea/discussions)*
-
 ---
 
-**[⭐ Star us on GitHub](https://github.com/agentarea/agentarea) • [📖 Read the Docs](https://docs.agentarea.ai) • [💬 Join Discord](https://discord.gg/93jVZ4Kx) • [🐦 Follow on Twitter](https://twitter.com/agentarea_hq)**
+**[⭐ Star us on GitHub](https://github.com/agentarea/agentarea) • [📖 Read the Docs](https://docs.agentarea.ai) • [💬 Join Discord](https://discord.gg/5tduPwheYQ) • [🐦 Follow on Twitter](https://twitter.com/agentarea_hq)**
 
 Made with ❤️ by the AgentArea community
 


### PR DESCRIPTION
## Summary
- Fix factual drift: license (Apache 2.0, removed stray EPLv2), ReBAC (was contradictory / "coming soon"), single Discord invite, accurate project structure, removed dead NOTICE link
- Reframe positioning as **library vs infrastructure** (no competitor names)
- Demote A2A from headline differentiator to a supported feature
- Extend Quick Start to "create your first agent"
- Add architecture Mermaid diagram (renders natively on GitHub) and concrete "What You Can Build" use-cases

## Notes
- Discord invite standardized to `5tduPwheYQ` — the old README had two different codes; please confirm it's the live one.
- Demo GIF/screenshot still TODO (needs an asset).

## Test plan
- [ ] README renders correctly on GitHub (Mermaid diagram, table, badges)
- [ ] All docs/*.md links resolve