### PR TITLE
fix llm provider and model creation

### DIFF
--- a/agentarea-platform/apps/api/tests/test_mcp_proxy.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_proxy.py
@@ -3,13 +3,11 @@
 from types import SimpleNamespace
 
 import pytest
-
 from agentarea_api.api.v1.mcp_proxy import (
     _filter_inbound_headers,
     _filter_outbound_headers,
     _resolve_upstream_url,
 )
-
 
 # ----- _resolve_upstream_url -----
 

--- a/agentarea-platform/libs/common/tests/test_system_entity_visibility.py
+++ b/agentarea-platform/libs/common/tests/test_system_entity_visibility.py
@@ -3,14 +3,16 @@
 The AuthorizationService resolves accessible_workspaces on UserContext during auth.
 The base WorkspaceScopedRepository uses accessible_workspaces for query filtering.
 """
-import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
+import pytest
 from agentarea_common.auth.context import UserContext
 from agentarea_common.auth.simple_authorization import SimpleAuthorizationService
+from agentarea_llm.domain.models import ModelInstance, ProviderConfig
 from agentarea_llm.infrastructure.model_instance_repository import ModelInstanceRepository
-from agentarea_llm.infrastructure.provider_config_repository import ProviderConfigRepository
 from agentarea_llm.infrastructure.model_spec_repository import ModelSpecRepository
+from agentarea_llm.infrastructure.provider_config_repository import ProviderConfigRepository
 
 
 def _user_context_with_system(workspace_id: str = "ws-1") -> UserContext:
@@ -50,6 +52,56 @@ def test_model_spec_repo_includes_system():
     compiled = str(ws_filter.compile(compile_kwargs={"literal_binds": True}))
     assert "system" in compiled
     assert "ws-1" in compiled
+
+
+@pytest.mark.asyncio
+async def test_provider_config_repo_create_scopes_to_current_workspace(monkeypatch):
+    session = MagicMock()
+    session.commit = AsyncMock()
+    user_context = _user_context_with_system()
+    repo = ProviderConfigRepository(session, user_context)
+    monkeypatch.setattr(repo, "get_with_relations", AsyncMock(return_value=None))
+
+    config = ProviderConfig(
+        provider_spec_id=uuid4(),
+        name="Test provider",
+        api_key="secret-ref",
+        workspace_id="wrong-workspace",
+        created_by="",
+    )
+
+    created = await repo.create_config(config)
+
+    assert created is config
+    assert config.workspace_id == "ws-1"
+    assert config.created_by == "user-1"
+    session.add.assert_called_once_with(config)
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_model_instance_repo_create_scopes_to_current_workspace(monkeypatch):
+    session = MagicMock()
+    session.commit = AsyncMock()
+    user_context = _user_context_with_system()
+    repo = ModelInstanceRepository(session, user_context)
+    monkeypatch.setattr(repo, "get_with_relations", AsyncMock(return_value=None))
+
+    instance = ModelInstance(
+        provider_config_id=uuid4(),
+        model_spec_id=uuid4(),
+        name="Test model",
+        workspace_id="wrong-workspace",
+        created_by="",
+    )
+
+    created = await repo.create_instance(instance)
+
+    assert created is instance
+    assert instance.workspace_id == "ws-1"
+    assert instance.created_by == "user-1"
+    session.add.assert_called_once_with(instance)
+    session.commit.assert_awaited_once()
 
 
 def test_default_user_context_only_own_workspace():

--- a/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_instance_repository.py
+++ b/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_instance_repository.py
@@ -13,6 +13,16 @@ class ModelInstanceRepository(WorkspaceScopedRepository[ModelInstance]):
     def __init__(self, session: AsyncSession, user_context: UserContext):
         super().__init__(session, ModelInstance, user_context)
 
+    async def create_instance(self, instance: ModelInstance) -> ModelInstance:
+        """Create a model instance from a domain object."""
+        instance.workspace_id = self.user_context.workspace_id
+        if not instance.created_by:
+            instance.created_by = self.user_context.user_id
+
+        self.session.add(instance)
+        await self.session.commit()
+        return await self.get_with_relations(instance.id) or instance
+
     async def get_with_relations(self, id: UUID) -> ModelInstance | None:
         """Get model instance by ID with relationships loaded."""
         instance = await self.get_by_id(id)

--- a/agentarea-platform/libs/llm/agentarea_llm/infrastructure/provider_config_repository.py
+++ b/agentarea-platform/libs/llm/agentarea_llm/infrastructure/provider_config_repository.py
@@ -13,6 +13,16 @@ class ProviderConfigRepository(WorkspaceScopedRepository[ProviderConfig]):
     def __init__(self, session: AsyncSession, user_context: UserContext):
         super().__init__(session, ProviderConfig, user_context)
 
+    async def create_config(self, config: ProviderConfig) -> ProviderConfig:
+        """Create a provider config from a domain object."""
+        config.workspace_id = self.user_context.workspace_id
+        if not config.created_by:
+            config.created_by = self.user_context.user_id
+
+        self.session.add(config)
+        await self.session.commit()
+        return await self.get_with_relations(config.id) or config
+
     async def get_with_relations(self, id: UUID) -> ProviderConfig | None:
         """Get provider config by ID with relationships loaded."""
         config = await self.get_by_id(id)


### PR DESCRIPTION
Fixes provider config/model instance creation on fresh workspaces.\n\nWhat changed:\n- add ProviderConfigRepository.create_config\n- add ModelInstanceRepository.create_instance\n- add regression tests for workspace scoping/audit fields\n- fix ruff import formatting in test_mcp_proxy\n\nValidation:\n- uv run pytest apps/api/tests/test_mcp_proxy.py apps/api/tests/test_task_policy_api.py libs/execution/tests/unit/test_policy_propagation_models.py libs/agentarea-agents-sdk/tests/test_workspace_files_toolset.py libs/common/tests/test_system_entity_visibility.py -q\n- uv run ruff check apps/api/tests/test_mcp_proxy.py libs/common/tests/test_system_entity_visibility.py libs/llm/agentarea_llm/infrastructure/provider_config_repository.py libs/llm/agentarea_llm/infrastructure/model_instance_repository.py

---
Refs #175 (provider config create path), #84 (model discovery foundation).