### PR TITLE
Add paginated skill browsing filters

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/skills.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/skills.py
@@ -18,7 +18,8 @@ from agentarea_agents.schemas.skills_dto import (
 from agentarea_common.auth.dependencies import UserContextDep
 from agentarea_common.auth.permission import require_permission
 from agentarea_common.base import RepositoryFactoryDep
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from agentarea_common.base.pagination import PaginatedResponse, PaginationParams
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
 
@@ -82,6 +83,7 @@ class SkillResponse(BaseModel):
     source_type: str
     source_url: str | None
     has_files: bool
+    network_scope: str
     workspace_id: str
     created_at: str
     updated_at: str
@@ -89,6 +91,10 @@ class SkillResponse(BaseModel):
     @classmethod
     def from_skill(cls, skill: Skill) -> "SkillResponse":
         """Create response from Skill entity."""
+        network_scope = getattr(skill, "network_scope", "private")
+        if not isinstance(network_scope, str):
+            network_scope = "private"
+
         return cls(
             id=str(skill.id),
             name=skill.name,
@@ -96,6 +102,7 @@ class SkillResponse(BaseModel):
             source_type=skill.source_type,
             source_url=skill.source_url,
             has_files=skill.s3_path is not None,
+            network_scope=network_scope,
             workspace_id=skill.workspace_id,
             created_at=skill.created_at.isoformat() if skill.created_at else "",
             updated_at=skill.updated_at.isoformat() if skill.updated_at else "",
@@ -212,13 +219,32 @@ async def upload_skill(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-@router.get("", response_model=list[SkillResponse])
+@router.get("", response_model=PaginatedResponse[SkillResponse])
 async def list_skills(
     skill_service: SkillServiceDep,
+    pagination: PaginationParams = Depends(),
+    source_type: str | None = Query(None, description="Filter by source type"),
+    has_files: bool | None = Query(None, description="Filter by package-backed skills"),
+    network_scope: str | None = Query(None, description="Filter by network scope"),
+    from_registry: bool | None = Query(None, description="Filter registry-created skills"),
 ):
-    """List all skills in the workspace."""
-    skills = await skill_service.list()
-    return [SkillResponse.from_skill(skill) for skill in skills]
+    """List skills in the workspace."""
+    skills, total = await skill_service.list_paginated(
+        limit=pagination.limit,
+        offset=pagination.offset,
+        search=pagination.search,
+        source_type=source_type,
+        has_files=has_files,
+        network_scope=network_scope,
+        from_registry=from_registry,
+    )
+    return PaginatedResponse(
+        items=[SkillResponse.from_skill(skill) for skill in skills],
+        total=total,
+        page=pagination.page,
+        page_size=pagination.page_size,
+        has_next=(pagination.offset + pagination.page_size) < total,
+    )
 
 
 @router.get("/{skill_id}", response_model=SkillResponse)

--- a/agentarea-platform/apps/api/tests/test_skills_api.py
+++ b/agentarea-platform/apps/api/tests/test_skills_api.py
@@ -56,6 +56,7 @@ async def test_list_skills_returns_metadata_only(async_client, mock_skill_servic
     skill_one.source_type = "github"
     skill_one.source_url = "https://github.com/owner/repo"
     skill_one.s3_path = "s3://bucket/skills/test"
+    skill_one.network_scope = "private"
     skill_one.workspace_id = "test_workspace"
     skill_one.created_at = now
     skill_one.updated_at = now
@@ -68,25 +69,31 @@ async def test_list_skills_returns_metadata_only(async_client, mock_skill_servic
     skill_two.source_type = "zip"
     skill_two.source_url = None
     skill_two.s3_path = "s3://bucket/skills/second"
+    skill_two.network_scope = "egress"
     skill_two.workspace_id = "test_workspace"
     skill_two.created_at = now
     skill_two.updated_at = now
     skill_two.content = "# Second Skill"
 
-    mock_skill_service.list.return_value = [skill_one, skill_two]
+    mock_skill_service.list_paginated.return_value = ([skill_one, skill_two], 2)
 
     response = await async_client.get("/v1/skills")
 
     assert response.status_code == 200
     data = response.json()
-    assert len(data) == 2
-    first = data[0]
-    second = data[1]
+    assert data["total"] == 2
+    assert data["page"] == 1
+    assert data["page_size"] == 50
+    assert data["has_next"] is False
+    assert len(data["items"]) == 2
+    first = data["items"][0]
+    second = data["items"][1]
     assert first["name"] == "Test Skill"
     assert first["description"] == "Test Description"
     assert first["source_type"] == "github"
     assert first["source_url"] == "https://github.com/owner/repo"
     assert first["has_files"] is True
+    assert first["network_scope"] == "private"
     assert first["workspace_id"] == "test_workspace"
     assert "content" not in first
     assert second["name"] == "Second Skill"
@@ -94,8 +101,47 @@ async def test_list_skills_returns_metadata_only(async_client, mock_skill_servic
     assert second["source_type"] == "zip"
     assert second["source_url"] is None
     assert second["has_files"] is True
+    assert second["network_scope"] == "egress"
     assert second["workspace_id"] == "test_workspace"
     assert "content" not in second
+    mock_skill_service.list_paginated.assert_called_once_with(
+        limit=50,
+        offset=0,
+        search=None,
+        source_type=None,
+        has_files=None,
+        network_scope=None,
+        from_registry=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_skills_accepts_pagination_and_search(async_client, mock_skill_service):
+    mock_skill_service.list_paginated.return_value = ([], 21)
+
+    response = await async_client.get(
+        "/v1/skills?page=2&page_size=10&search=github"
+        "&source_type=github&has_files=true&network_scope=egress&from_registry=false"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "items": [],
+        "total": 21,
+        "page": 2,
+        "page_size": 10,
+        "has_next": True,
+    }
+    mock_skill_service.list_paginated.assert_called_once_with(
+        limit=10,
+        offset=10,
+        search="github",
+        source_type="github",
+        has_files=True,
+        network_scope="egress",
+        from_registry=False,
+    )
 
 
 @pytest.mark.asyncio

--- a/agentarea-platform/libs/agents/agentarea_agents/application/skill_service.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/application/skill_service.py
@@ -354,6 +354,28 @@ class SkillService:
         repo = self._get_repository()
         return await repo.list_all()
 
+    async def list_paginated(
+        self,
+        limit: int,
+        offset: int = 0,
+        search: str | None = None,
+        source_type: str | None = None,
+        has_files: bool | None = None,
+        network_scope: str | None = None,
+        from_registry: bool | None = None,
+    ) -> tuple[list[Skill], int]:
+        """List skills with pagination metadata."""
+        repo = self._get_repository()
+        return await repo.list_paginated(
+            limit=limit,
+            offset=offset,
+            search=search,
+            source_type=source_type,
+            has_files=has_files,
+            network_scope=network_scope,
+            from_registry=from_registry,
+        )
+
     @audited("skill.update", resource_type="skill", resource_id_param="skill_id")
     async def update(
         self,

--- a/agentarea-platform/libs/agents/agentarea_agents/infrastructure/skill_repository.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/infrastructure/skill_repository.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from agentarea_common.auth.context import UserContext
 from agentarea_common.base.workspace_scoped_repository import WorkspaceScopedRepository
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -68,6 +68,53 @@ class SkillRepository(WorkspaceScopedRepository[Skill]):
             List of skills with the specified source type.
         """
         return await self.list_all(source_type=source_type)
+
+    async def list_paginated(
+        self,
+        limit: int,
+        offset: int,
+        search: str | None = None,
+        source_type: str | None = None,
+        has_files: bool | None = None,
+        network_scope: str | None = None,
+        from_registry: bool | None = None,
+    ) -> tuple[list[Skill], int]:
+        """List skills with pagination and optional name/description search."""
+        filters = [self._get_workspace_filter()]
+        if search:
+            search_term = f"%{search.strip()}%"
+            filters.append(
+                or_(
+                    self.model_class.name.ilike(search_term),
+                    self.model_class.description.ilike(search_term),
+                    self.model_class.source_url.ilike(search_term),
+                )
+            )
+        if source_type:
+            filters.append(self.model_class.source_type == source_type)
+        if has_files is True:
+            filters.append(self.model_class.s3_path.is_not(None))
+        elif has_files is False:
+            filters.append(self.model_class.s3_path.is_(None))
+        if network_scope:
+            filters.append(self.model_class.network_scope == network_scope)
+        if from_registry is True:
+            filters.append(self.model_class.registry_item_id.is_not(None))
+        elif from_registry is False:
+            filters.append(self.model_class.registry_item_id.is_(None))
+
+        count_query = select(func.count(self.model_class.id)).where(*filters)
+        total = (await self.session.execute(count_query)).scalar_one()
+
+        query = (
+            select(self.model_class)
+            .where(*filters)
+            .order_by(self.model_class.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all()), total
 
     async def add_agent_association(self, skill_id: UUID, agent_id: UUID) -> None:
         """Add an agent-skill association.

--- a/agentarea-webapp/messages/en.json
+++ b/agentarea-webapp/messages/en.json
@@ -823,6 +823,27 @@
       "deleteSkillTitle": "Delete Skill",
       "deleteSkill": "Delete \"{skillName}\"?"
     },
+    "pagination": {
+      "previous": "Previous page",
+      "next": "Next page",
+      "pageStatus": "Page {page} of {totalPages}"
+    },
+    "filters": {
+      "source": "Source",
+      "allSources": "All sources",
+      "files": "Files",
+      "allFiles": "All files",
+      "withFiles": "With files",
+      "withoutFiles": "Content only",
+      "scope": "Scope",
+      "allScopes": "All scopes",
+      "clear": "Clear",
+      "scopeValues": {
+        "private": "Private",
+        "ingress": "Ingress",
+        "egress": "Egress"
+      }
+    },
     "table": {
       "name": "Name",
       "description": "Description",
@@ -848,6 +869,8 @@
     },
     "source": {
       "github": "GitHub",
+      "zip": "Uploaded",
+      "path": "Path",
       "uploaded": "Uploaded",
       "content": "Content"
     },

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -2431,7 +2431,7 @@ export interface paths {
         };
         /**
          * List Skills
-         * @description List all skills in the workspace.
+         * @description List skills in the workspace.
          */
         get: operations["list_skills_v1_skills_get"];
         put?: never;
@@ -5274,6 +5274,19 @@ export interface components {
             /** Total */
             total: number;
         };
+        /** PaginatedResponse[SkillResponse] */
+        PaginatedResponse_SkillResponse_: {
+            /** Has Next */
+            has_next: boolean;
+            /** Items */
+            items: components["schemas"]["SkillResponse"][];
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+            /** Total */
+            total: number;
+        };
         /** PaymentRecordResponse */
         PaymentRecordResponse: {
             /** Agent Id */
@@ -5875,6 +5888,8 @@ export interface components {
             id: string;
             /** Name */
             name: string;
+            /** Network Scope */
+            network_scope: string;
             /** Source Type */
             source_type: string;
             /** Source Url */
@@ -11871,7 +11886,19 @@ export interface operations {
     };
     list_skills_v1_skills_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Filter by source type */
+                source_type?: string | null;
+                /** @description Filter by package-backed skills */
+                has_files?: boolean | null;
+                /** @description Filter by network scope */
+                network_scope?: string | null;
+                /** @description Filter registry-created skills */
+                from_registry?: boolean | null;
+                page?: number;
+                page_size?: number;
+                search?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -11884,7 +11911,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SkillResponse"][];
+                    "application/json": components["schemas"]["PaginatedResponse_SkillResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsCard.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsCard.tsx
@@ -1,8 +1,8 @@
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { FileCode, Github, Sparkles, Upload } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
 import { HoverLink } from "@/components/ui/hover-link";
 import { cn } from "@/lib/utils";
 import type { Skill } from "@/types/skill";
@@ -15,7 +15,7 @@ function SourceIcon({ sourceType }: { sourceType: string }) {
   switch (sourceType) {
     case "github":
       return <Github className="h-3 w-3" />;
-    case "upload":
+    case "zip":
       return <Upload className="h-3 w-3" />;
     default:
       return <FileCode className="h-3 w-3" />;
@@ -29,8 +29,10 @@ export default function SkillsCard({ skill }: SkillsCardProps) {
     switch (sourceType) {
       case "github":
         return t("github");
-      case "upload":
-        return t("uploaded");
+      case "zip":
+        return t("zip");
+      case "path":
+        return t("path");
       default:
         return t("content");
     }

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsContent.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsContent.tsx
@@ -1,20 +1,38 @@
 import { getTranslations } from "next-intl/server";
 import { listSkills } from "@/lib/api";
+import type { PaginatedSkills } from "@/types/skill";
 import SkillsList from "./SkillsList";
-import type { Skill } from "@/types/skill";
+
+const PAGE_SIZE = 20;
 
 interface SkillsContentProps {
   viewMode: "grid" | "table";
   searchQuery: string;
+  page: number;
+  sourceType: string;
+  hasFiles?: boolean;
+  networkScope: string;
 }
 
 export default async function SkillsContent({
   viewMode,
   searchQuery,
+  page,
+  sourceType,
+  hasFiles,
+  networkScope,
 }: SkillsContentProps) {
   const t = await getTranslations("SkillsPage");
 
-  const { data, error } = await listSkills();
+  const { data, error } = await listSkills({
+    page,
+    page_size: PAGE_SIZE,
+    search: searchQuery.trim() || undefined,
+    source_type: sourceType || undefined,
+    has_files: hasFiles,
+    network_scope: networkScope || undefined,
+    paginated: true,
+  });
 
   if (error) {
     return (
@@ -24,22 +42,22 @@ export default async function SkillsContent({
     );
   }
 
-  const skills = (data as Skill[]) || [];
-
-  // Filter skills based on search query
-  const filteredSkills = searchQuery.trim()
-    ? skills.filter(
-        (skill) =>
-          skill.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          (skill.description && skill.description.toLowerCase().includes(searchQuery.toLowerCase()))
-      )
-    : skills;
+  const result = (data as PaginatedSkills | null) || {
+    items: [],
+    total: 0,
+    page,
+    page_size: PAGE_SIZE,
+    has_next: false,
+  };
 
   return (
     <SkillsList
-      skills={filteredSkills}
+      skills={result.items}
       viewMode={viewMode}
       searchQuery={searchQuery}
+      page={result.page}
+      pageSize={result.page_size}
+      total={result.total}
     />
   );
 }

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsFilters.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsFilters.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Filter, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface SkillsFiltersProps {
+  sourceType: string;
+  filesFilter: string;
+  networkScope: string;
+}
+
+const SOURCE_TYPES = ["content", "github", "zip", "path"] as const;
+const NETWORK_SCOPES = ["private", "ingress", "egress"] as const;
+
+export default function SkillsFilters({
+  sourceType,
+  filesFilter,
+  networkScope,
+}: SkillsFiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const t = useTranslations("SkillsPage.filters");
+  const tSource = useTranslations("SkillsPage.source");
+
+  const hasActiveFilters =
+    Boolean(sourceType) || filesFilter !== "all" || Boolean(networkScope);
+
+  const updateParam = (name: string, value: string, emptyValue = "all") => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("page");
+
+    if (value && value !== emptyValue) {
+      params.set(name, value);
+    } else {
+      params.delete(name);
+    }
+
+    const query = params.toString();
+    router.replace(query ? `/skills?${query}` : "/skills", { scroll: false });
+  };
+
+  const clearFilters = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("page");
+    params.delete("source_type");
+    params.delete("files");
+    params.delete("network_scope");
+
+    const query = params.toString();
+    router.replace(query ? `/skills?${query}` : "/skills", { scroll: false });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Select
+        value={sourceType || "all"}
+        onValueChange={(value) => updateParam("source_type", value)}
+      >
+        <SelectTrigger className="h-9 w-[150px]">
+          <div className="flex items-center gap-2">
+            <Filter className="h-4 w-4 text-muted-foreground" />
+            <SelectValue placeholder={t("source")} />
+          </div>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t("allSources")}</SelectItem>
+          {SOURCE_TYPES.map((type) => (
+            <SelectItem key={type} value={type}>
+              {tSource(type)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={filesFilter}
+        onValueChange={(value) => updateParam("files", value)}
+      >
+        <SelectTrigger className="h-9 w-[145px]">
+          <SelectValue placeholder={t("files")} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t("allFiles")}</SelectItem>
+          <SelectItem value="with_files">{t("withFiles")}</SelectItem>
+          <SelectItem value="without_files">{t("withoutFiles")}</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={networkScope || "all"}
+        onValueChange={(value) => updateParam("network_scope", value)}
+      >
+        <SelectTrigger className="h-9 w-[150px]">
+          <SelectValue placeholder={t("scope")} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{t("allScopes")}</SelectItem>
+          {NETWORK_SCOPES.map((scope) => (
+            <SelectItem key={scope} value={scope}>
+              {t(`scopeValues.${scope}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {hasActiveFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 gap-2"
+          onClick={clearFilters}
+        >
+          <X className="h-4 w-4" />
+          {t("clear")}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsList.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsList.tsx
@@ -1,27 +1,48 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import EmptyState from "@/components/EmptyState";
-import SkillsTable from "./SkillsTable";
-import SkillsCard from "./SkillsCard";
+import { Button } from "@/components/ui/button";
 import type { Skill } from "@/types/skill";
+import SkillsCard from "./SkillsCard";
+import SkillsTable from "./SkillsTable";
 
 interface SkillsListProps {
   skills: Skill[];
   viewMode: "grid" | "table";
   searchQuery: string;
+  page: number;
+  pageSize: number;
+  total: number;
 }
 
 export default function SkillsList({
   skills,
   viewMode,
   searchQuery,
+  page,
+  pageSize,
+  total,
 }: SkillsListProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const t = useTranslations("SkillsPage");
 
   const hasSkills = skills.length > 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const goToPage = (nextPage: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextPage <= 1) {
+      params.delete("page");
+    } else {
+      params.set("page", String(nextPage));
+    }
+    const query = params.toString();
+    router.push(query ? `/skills?${query}` : "/skills");
+  };
 
   if (!hasSkills && !searchQuery) {
     return (
@@ -61,6 +82,31 @@ export default function SkillsList({
         </div>
       ) : (
         <SkillsTable skills={skills} />
+      )}
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-center gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goToPage(page - 1)}
+            disabled={page <= 1}
+            aria-label={t("pagination.previous")}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {t("pagination.pageStatus", { page, totalPages })}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => goToPage(page + 1)}
+            disabled={page >= totalPages}
+            aria-label={t("pagination.next")}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
       )}
     </>
   );

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsTable.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsTable.tsx
@@ -16,7 +16,7 @@ function getSourceIcon(sourceType: string) {
   switch (sourceType) {
     case "github":
       return <Github className="h-4 w-4" />;
-    case "upload":
+    case "zip":
       return <Upload className="h-4 w-4" />;
     default:
       return <FileCode className="h-4 w-4" />;
@@ -32,8 +32,10 @@ export default function SkillsTable({ skills }: SkillsTableProps) {
     switch (sourceType) {
       case "github":
         return tSource("github");
-      case "upload":
-        return tSource("uploaded");
+      case "zip":
+        return tSource("zip");
+      case "path":
+        return tSource("path");
       default:
         return tSource("content");
     }

--- a/agentarea-webapp/src/app/(main)/skills/page.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/page.tsx
@@ -4,9 +4,10 @@ import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
-import SkillsContent from "./components/SkillsContent";
-import SkillsHeaderTabs from "./components/SkillsHeaderTabs";
 import CreateSkillButton from "./components/CreateSkillButton";
+import SkillsContent from "./components/SkillsContent";
+import SkillsFilters from "./components/SkillsFilters";
+import SkillsHeaderTabs from "./components/SkillsHeaderTabs";
 
 export const metadata = {
   title: "Skills",
@@ -27,10 +28,33 @@ export default async function SkillsPage({
     typeof resolvedSearchParams.tab === "string"
       ? (resolvedSearchParams.tab as "grid" | "table")
       : (cookieTab as "grid" | "table") || "grid";
-  
+
   const searchQuery =
     typeof resolvedSearchParams.search === "string"
       ? resolvedSearchParams.search
+      : "";
+  const rawPage =
+    typeof resolvedSearchParams.page === "string"
+      ? Number.parseInt(resolvedSearchParams.page, 10)
+      : 1;
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+  const sourceType =
+    typeof resolvedSearchParams.source_type === "string"
+      ? resolvedSearchParams.source_type
+      : "";
+  const filesFilter =
+    typeof resolvedSearchParams.files === "string"
+      ? resolvedSearchParams.files
+      : "all";
+  const hasFiles =
+    filesFilter === "with_files"
+      ? true
+      : filesFilter === "without_files"
+        ? false
+        : undefined;
+  const networkScope =
+    typeof resolvedSearchParams.network_scope === "string"
+      ? resolvedSearchParams.network_scope
       : "";
 
   return (
@@ -42,19 +66,35 @@ export default async function SkillsPage({
       }}
       subheader={
         <>
-          <SearchInput urlParamName="search" urlPath="/skills" />
+          <SearchInput
+            urlParamName="search"
+            urlPath="/skills"
+            resetParamNames={["page"]}
+          />
+          <SkillsFilters
+            sourceType={sourceType}
+            filesFilter={filesFilter}
+            networkScope={networkScope}
+          />
           <SkillsHeaderTabs currentTab={viewMode} />
         </>
       }
     >
-      <Suspense key={`${viewMode}-${searchQuery}`} fallback={
-        <div className="flex h-64 items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }>
+      <Suspense
+        key={`${viewMode}-${searchQuery}-${sourceType}-${filesFilter}-${networkScope}-${page}`}
+        fallback={
+          <div className="flex h-64 items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        }
+      >
         <SkillsContent
           viewMode={viewMode}
           searchQuery={searchQuery}
+          page={page}
+          sourceType={sourceType}
+          hasFiles={hasFiles}
+          networkScope={networkScope}
         />
       </Suspense>
     </ContentBlock>

--- a/agentarea-webapp/src/components/SearchInput/SearchInput.tsx
+++ b/agentarea-webapp/src/components/SearchInput/SearchInput.tsx
@@ -19,6 +19,8 @@ interface SearchInputProps {
   urlParamName?: string;
   /** Путь для обновления URL (используется только с urlParamName) */
   urlPath?: string;
+  /** URL параметры, которые нужно сбросить при изменении поиска */
+  resetParamNames?: string[];
 }
 
 export default function SearchInput({
@@ -28,6 +30,7 @@ export default function SearchInput({
   placeholder,
   urlParamName,
   urlPath,
+  resetParamNames,
 }: SearchInputProps) {
   const commonT = useTranslations("Common");
   const router = useRouter();
@@ -55,6 +58,7 @@ export default function SearchInput({
       } else {
         params.delete(urlParamName);
       }
+      resetParamNames?.forEach((paramName) => params.delete(paramName));
 
       const currentString = searchParams.toString();
       const newString = params.toString();
@@ -65,7 +69,14 @@ export default function SearchInput({
         router.replace(newUrl, { scroll: false });
       }
     }
-  }, [debouncedQuery, urlParamName, urlPath, router, searchParams]);
+  }, [
+    debouncedQuery,
+    urlParamName,
+    urlPath,
+    resetParamNames,
+    router,
+    searchParams,
+  ]);
 
   // Вызываем callback если он указан
   useEffect(() => {

--- a/agentarea-webapp/src/lib/api-factory.ts
+++ b/agentarea-webapp/src/lib/api-factory.ts
@@ -774,9 +774,59 @@ export function createApiClient(client: Client) {
     },
 
     // Skills API
-    listSkills: async () => {
-      const { data, error } = await client.GET("/v1/skills" as any, {});
-      return { data, error };
+    listSkills: async (options: {
+      page?: number;
+      page_size?: number;
+      search?: string;
+      source_type?: string;
+      has_files?: boolean;
+      network_scope?: string;
+      from_registry?: boolean;
+      paginated?: boolean;
+    } = {}) => {
+      const pageSize = options.page_size || (options.paginated ? 50 : 100);
+      const query = (page: number) => ({
+        page,
+        page_size: pageSize,
+        ...(options.search ? { search: options.search } : {}),
+        ...(options.source_type ? { source_type: options.source_type } : {}),
+        ...(options.has_files !== undefined ? { has_files: options.has_files } : {}),
+        ...(options.network_scope ? { network_scope: options.network_scope } : {}),
+        ...(options.from_registry !== undefined ? { from_registry: options.from_registry } : {}),
+      });
+
+      const { data, error } = await client.GET("/v1/skills" as any, {
+        params: { query: query(options.page || 1) } as any,
+      });
+
+      if (options.paginated) {
+        return { data, error };
+      }
+
+      const items = Array.isArray(data) ? data : (data as any)?.items || [];
+      if (error || Array.isArray(data) || !(data as any)?.has_next) {
+        return { data: items, error };
+      }
+
+      const allItems = [...items];
+      let page = (data as any).page || 1;
+      let hasNext = Boolean((data as any).has_next);
+      while (hasNext) {
+        page += 1;
+        const next = await client.GET("/v1/skills" as any, {
+          params: { query: query(page) } as any,
+        });
+        if (next.error) {
+          return { data: allItems, error: next.error };
+        }
+
+        const nextData = next.data as any;
+        const nextItems = Array.isArray(nextData) ? nextData : nextData?.items || [];
+        allItems.push(...nextItems);
+        hasNext = !Array.isArray(nextData) && Boolean(nextData?.has_next);
+      }
+
+      return { data: allItems, error: null };
     },
 
     getSkill: async (skillId: string) => {

--- a/agentarea-webapp/src/types/skill.ts
+++ b/agentarea-webapp/src/types/skill.ts
@@ -1,4 +1,5 @@
-export type SkillSourceType = 'content' | 'github' | 'upload';
+export type SkillSourceType = "content" | "github" | "zip" | "path";
+export type SkillNetworkScope = "private" | "ingress" | "egress";
 
 export interface Skill {
   id: string;
@@ -7,9 +8,18 @@ export interface Skill {
   source_type: SkillSourceType;
   source_url: string | null;
   has_files: boolean;
+  network_scope: SkillNetworkScope;
   workspace_id: string;
   created_at: string;
   updated_at: string;
+}
+
+export interface PaginatedSkills {
+  items: Skill[];
+  total: number;
+  page: number;
+  page_size: number;
+  has_next: boolean;
 }
 
 export interface SkillContent {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -55,7 +55,8 @@
           "temporal-workflows",
           "warm-pool",
           "skill-sandboxing",
-          "feature-flags"
+          "feature-flags",
+          "engineering-principles"
         ]
       },
       {

--- a/docs/engineering-principles.md
+++ b/docs/engineering-principles.md
@@ -1,0 +1,106 @@
+---
+title: "Engineering Principles"
+description: "AgentArea code principles for humans and LLM coding agents"
+---
+
+# Engineering Principles
+
+This page is the start of AgentArea's LLM wiki: a compact, durable reference for
+how we want code to be written, reviewed, and extended. Treat it as the shared
+contract for humans and coding agents working in this repository.
+
+## Prefer Existing Shapes
+
+Before adding a new pattern, find the closest existing implementation and match
+it unless there is a concrete reason not to. AgentArea is a polyglot monorepo;
+consistency matters more than local cleverness.
+
+Examples:
+
+- Collection endpoints should use the shared pagination envelope when possible:
+  `PaginatedResponse[T]` with `items`, `total`, `page`, `page_size`, and
+  `has_next`.
+- Query parameters that represent common list behavior should reuse
+  `PaginationParams` before introducing endpoint-specific pagination.
+- Frontend API helpers should preserve existing call-site contracts when a
+  backend response shape changes.
+
+## Server-Side Lists First
+
+Large collections should be paginated, counted, searched, and filtered on the
+server. Client-side filtering over a full collection is acceptable only for small
+or already-loaded local views.
+
+For list endpoints:
+
+- Include a total count that matches the active filters.
+- Keep filters URL-addressable in the UI when they affect page content.
+- Reset `page` when filters or search change.
+- Prefer explicit query parameters such as `status`, `source_type`, `has_files`,
+  or `network_scope` over overloaded free-form filters.
+- Preserve backward compatibility for existing consumers when feasible, but make
+  new paginated use cases opt into pagination metadata clearly.
+
+## Compatibility Is a Feature
+
+When changing a public or shared contract, identify all existing consumers before
+editing. If a migration cannot be completed in the same change, provide a
+compatibility layer with a clear path forward.
+
+Good compatibility behavior:
+
+- Old helper calls keep returning the same shape when downstream screens rely on
+  it.
+- New callers can request richer metadata without duplicating fetch logic.
+- Tests cover both default behavior and the new filtered or paginated path.
+
+## Workspace Boundaries Are Not Optional
+
+Backend data access must preserve workspace scoping. Services and repositories
+should carry `UserContext` through existing factories and scoped repositories.
+Do not bypass repository filters for convenience.
+
+When adding repository methods:
+
+- Start from `WorkspaceScopedRepository` behavior or copy the existing workspace
+  filter into custom queries.
+- Apply count and list queries with the same filters.
+- Keep authorization checks on mutations close to existing endpoint/service
+  patterns.
+
+## Small Changes, Fresh Evidence
+
+Every meaningful code change should have targeted verification. Match the test
+size to the blast radius:
+
+- API behavior: focused endpoint/service tests.
+- Frontend state or routing: lint plus focused UI or component checks when
+  available.
+- Shared contracts: tests for old and new behavior.
+- Repo-wide checks: run them when available; if blocked by unrelated existing
+  failures, record the blocker explicitly.
+
+Do not claim a full typecheck or build passed when it did not. A known unrelated
+blocker is still useful evidence, but it must be named.
+
+## Documentation Is Part of the Change
+
+Add documentation when a change establishes or clarifies a pattern that future
+contributors should repeat. Prefer short, principle-level docs over verbose
+implementation walkthroughs.
+
+Document:
+
+- Cross-cutting API shapes.
+- UI routing and state conventions.
+- Security, workspace, and compatibility constraints.
+- Rejected alternatives that future contributors might otherwise re-explore.
+
+## Pull Request Notes
+
+PR descriptions should tell reviewers what changed, why it changed, and how it
+was verified. Include known gaps directly rather than hiding them in comments.
+
+For commits, use the repository's Lore protocol when writing commit messages:
+state the intent first, then add trailers for constraints, rejected alternatives,
+confidence, scope risk, directives, tested evidence, and known verification gaps.


### PR DESCRIPTION
## Summary
- Add MCP-style paginated response support to the skills list endpoint
- Add server-side skill filters for search, source type, package files, network scope, and registry origin
- Add URL-backed filters and pagination controls to the skills page while preserving full-list compatibility for existing selectors
- Add docs/engineering-principles.md as the first lightweight LLM-wiki page for recurring code-shape principles

## Validation
- uv run pytest apps/api/tests/test_skills_api.py -q
- pnpm exec eslint . --quiet
- pnpm exec prettier --check touched frontend files
- bash validate-docs.sh
- npx prettier --check engineering-principles.md
- git diff --check

## Known gap
- pnpm exec tsc --noEmit is currently blocked by existing missing SVG module declarations in packages/elements-react.
- docs validate passed Mintlify and broken-link checks, but its local preview server probe could not be verified.