### PR TITLE
Move inbound channel events to Redis Streams

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,38 +2,33 @@ kube_context = os.getenv("AGENTAREA_KUBE_CONTEXT", "agentarea-dev-timeweb")
 namespace = os.getenv("AGENTAREA_NAMESPACE", "agentarea")
 push_registry = os.getenv("AGENTAREA_REGISTRY", "agentarea-ru.registry.twcstorage.ru")
 cluster_registry = os.getenv("AGENTAREA_CLUSTER_REGISTRY", push_registry)
+image_pull_secret = os.getenv("AGENTAREA_IMAGE_PULL_SECRET", "")
 
 allow_k8s_contexts(kube_context)
 default_registry(push_registry, host_from_cluster=cluster_registry)
 
-k8s_yaml(local(
+helm_args = (
     "helm repo add valkey https://valkey.io/valkey-helm/ >/dev/null 2>&1 || true && "
     + "helm dependency build charts/agentarea >/dev/null && "
     + "helm template agentarea charts/agentarea "
     + "--namespace " + namespace + " "
     + "-f deploy/tilt/timeweb-dev-values.yaml"
-))
+)
+if image_pull_secret:
+    helm_args = helm_args + " --set global.image.pullSecrets[0].name=" + image_pull_secret
+
+k8s_yaml(local(helm_args + " | python3 deploy/tilt/add-namespace.py " + namespace))
 
 docker_build(
     "agentarea/agentarea-api",
     "agentarea-platform",
     dockerfile="agentarea-platform/apps/api/Dockerfile",
-    live_update=[
-        sync("agentarea-platform/apps/api", "/app/apps/api"),
-        sync("agentarea-platform/libs", "/app/libs"),
-        restart_container(),
-    ],
 )
 
 docker_build(
     "agentarea/agentarea-worker",
     "agentarea-platform",
     dockerfile="agentarea-platform/apps/worker/Dockerfile",
-    live_update=[
-        sync("agentarea-platform/apps/worker", "/app/apps/worker"),
-        sync("agentarea-platform/libs", "/app/libs"),
-        restart_container(),
-    ],
 )
 
 docker_build(
@@ -64,7 +59,16 @@ docker_build(
     live_update=[
         sync("agentarea-mcp-manager", "/app"),
         run("go mod download", trigger=["agentarea-mcp-manager/go.mod", "agentarea-mcp-manager/go.sum"]),
-        restart_container(),
+    ],
+)
+
+docker_build(
+    "agentarea/agentarea-events",
+    "agentarea-event-service",
+    dockerfile="agentarea-event-service/Dockerfile.dev",
+    live_update=[
+        sync("agentarea-event-service", "/app"),
+        run("go mod download", trigger=["agentarea-event-service/go.mod", "agentarea-event-service/go.sum"]),
     ],
 )
 
@@ -72,3 +76,4 @@ k8s_resource("agentarea-backend", port_forwards=8000)
 k8s_resource("agentarea-frontend", port_forwards=3000)
 k8s_resource("agentarea-mcp-manager")
 k8s_resource("agentarea-worker")
+k8s_resource("agentarea-event-service")

--- a/agentarea-event-service/.dockerignore
+++ b/agentarea-event-service/.dockerignore
@@ -1,0 +1,5 @@
+.git
+bin
+tmp
+vendor
+.DS_Store

--- a/agentarea-event-service/Dockerfile.dev
+++ b/agentarea-event-service/Dockerfile.dev
@@ -7,6 +7,7 @@ WORKDIR /app
 
 COPY go.mod go.sum ./
 RUN go mod download
+COPY . .
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["air", "-c", ".air.toml"]

--- a/agentarea-event-service/cmd/server/main.go
+++ b/agentarea-event-service/cmd/server/main.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/redis/go-redis/v9"
 
+	"github.com/agentarea/event-service/internal/broker"
 	"github.com/agentarea/event-service/internal/channels"
 	"github.com/agentarea/event-service/internal/channels/telegram"
 	"github.com/agentarea/event-service/internal/claim"
@@ -31,8 +34,11 @@ func main() {
 
 	slog.Info("event-service starting",
 		"worker_id", cfg.WorkerID,
+		"inbound_stream", cfg.InboundStream,
+		"enable_telegram_polling", cfg.EnableTelegramPolling,
 		"poll_interval", cfg.PollInterval,
 		"max_pollers", cfg.MaxPollers,
+		"port", cfg.Port,
 	)
 
 	// Connect to PostgreSQL
@@ -67,17 +73,31 @@ func main() {
 	}
 	slog.Info("redis connected")
 
-	// Register channel pollers
-	channels.Register("telegram_polling", telegram.NewPoller)
+	// Register dev-only polling channel adapters.
+	if cfg.EnableTelegramPolling {
+		channels.Register("telegram_polling", telegram.NewPoller)
+		slog.Info("telegram getUpdates polling enabled")
+	} else {
+		slog.Info("telegram getUpdates polling disabled")
+	}
 
 	// Build dependencies
-	submitter := submit.NewRedisSubmitter(redisClient)
+	streamBroker := broker.NewRedisStreams(redisClient)
+	submitter := submit.NewStreamSubmitter(streamBroker, cfg.InboundStream)
 	claimer := claim.NewRedisClaimer(redisClient, cfg.WorkerID)
 
 	mgr := polling.NewManager(db, submitter, claimer, cfg.PollInterval, cfg.MaxPollers)
 
 	// Run polling manager (outbound delivery handled by Python worker)
 	errCh := make(chan error, 1)
+
+	healthServer := newHealthServer(cfg.Port)
+	go func() {
+		slog.Info("starting health server", "addr", healthServer.Addr)
+		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
 
 	go func() {
 		slog.Info("starting polling manager")
@@ -91,5 +111,25 @@ func main() {
 		os.Exit(1)
 	}
 
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := healthServer.Shutdown(shutdownCtx); err != nil {
+		slog.Warn("health server shutdown failed", "error", err)
+	}
+
 	slog.Info("event-service stopped")
+}
+
+func newHealthServer(port string) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	return &http.Server{
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 }

--- a/agentarea-event-service/internal/config/config.go
+++ b/agentarea-event-service/internal/config/config.go
@@ -1,23 +1,30 @@
 package config
 
 import (
+	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
 // Config holds all configuration for the Event Service.
 type Config struct {
-	DatabaseURL  string
-	RedisURL     string
-	WorkerID     string
-	PollInterval time.Duration
-	MaxPollers   int
+	DatabaseURL           string
+	RedisURL              string
+	WorkerID              string
+	InboundStream         string
+	EnableTelegramPolling bool
+	PollInterval          time.Duration
+	MaxPollers            int
+	Port                  string
 }
 
 // Load reads configuration from environment variables with sensible defaults.
 func Load() *Config {
-	workerID := os.Getenv("WORKER_ID")
+	workerID := os.Getenv("AGENTAREA_EVENTS_WORKER_ID")
 	if workerID == "" {
 		if hostname, err := os.Hostname(); err == nil {
 			workerID = hostname
@@ -27,24 +34,101 @@ func Load() *Config {
 	}
 
 	pollInterval := 5 * time.Second
-	if v := os.Getenv("POLL_INTERVAL"); v != "" {
+	if v := os.Getenv("AGENTAREA_EVENTS_POLL_INTERVAL"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			pollInterval = d
 		}
 	}
 
 	maxPollers := 200
-	if v := os.Getenv("MAX_POLLERS"); v != "" {
+	if v := os.Getenv("AGENTAREA_EVENTS_MAX_POLLERS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			maxPollers = n
 		}
 	}
 
-	return &Config{
-		DatabaseURL:  os.Getenv("DATABASE_URL"),
-		RedisURL:     os.Getenv("REDIS_URL"),
-		WorkerID:     workerID,
-		PollInterval: pollInterval,
-		MaxPollers:   maxPollers,
+	inboundStream := os.Getenv("AGENTAREA_EVENTS_INBOUND_STREAM")
+	if inboundStream == "" {
+		inboundStream = "agentarea.channel.inbound"
 	}
+
+	enableTelegramPolling := false
+	if v := os.Getenv("AGENTAREA_EVENTS_TELEGRAM_POLLING_ENABLED"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			enableTelegramPolling = parsed
+		}
+	}
+
+	port := os.Getenv("AGENTAREA_EVENTS_PORT")
+	if port == "" {
+		port = "8002"
+	}
+
+	return &Config{
+		DatabaseURL:           databaseURL(),
+		RedisURL:              redisURL(),
+		WorkerID:              workerID,
+		InboundStream:         inboundStream,
+		EnableTelegramPolling: enableTelegramPolling,
+		PollInterval:          pollInterval,
+		MaxPollers:            maxPollers,
+		Port:                  port,
+	}
+}
+
+func databaseURL() string {
+	host := os.Getenv("POSTGRES_HOST")
+	port := os.Getenv("POSTGRES_PORT")
+	db := os.Getenv("POSTGRES_DB")
+	user := os.Getenv("POSTGRES_USER")
+	password := os.Getenv("POSTGRES_PASSWORD")
+	if host == "" || db == "" || user == "" || password == "" {
+		return os.Getenv("DATABASE_URL")
+	}
+
+	sslMode := os.Getenv("POSTGRES_SSLMODE")
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		pqConnValue(host),
+		pqConnValue(port),
+		pqConnValue(user),
+		pqConnValue(password),
+		pqConnValue(db),
+		pqConnValue(sslMode),
+	)
+}
+
+func redisURL() string {
+	host := os.Getenv("REDIS_HOST")
+	port := os.Getenv("REDIS_PORT")
+	password := os.Getenv("REDIS_PASSWORD")
+	if host == "" {
+		return os.Getenv("REDIS_URL")
+	}
+
+	dsn := url.URL{
+		Scheme: "redis",
+		Host:   hostPort(host, port),
+	}
+	if password != "" {
+		dsn.User = url.UserPassword("", password)
+	}
+	return dsn.String()
+}
+
+func hostPort(host, port string) string {
+	if port == "" {
+		return host
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func pqConnValue(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	return "'" + escaped + "'"
 }

--- a/agentarea-event-service/internal/config/config_test.go
+++ b/agentarea-event-service/internal/config/config_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadReadsAgentareaEventsEnv(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://agentarea:test@localhost:5432/agentarea")
+	t.Setenv("REDIS_URL", "redis://localhost:6379/0")
+	t.Setenv("AGENTAREA_EVENTS_WORKER_ID", "worker-test")
+	t.Setenv("AGENTAREA_EVENTS_POLL_INTERVAL", "17s")
+	t.Setenv("AGENTAREA_EVENTS_MAX_POLLERS", "7")
+	t.Setenv("AGENTAREA_EVENTS_INBOUND_STREAM", "events.inbound.test")
+	t.Setenv("AGENTAREA_EVENTS_TELEGRAM_POLLING_ENABLED", "true")
+	t.Setenv("AGENTAREA_EVENTS_PORT", "18002")
+
+	cfg := Load()
+
+	if cfg.DatabaseURL != "postgres://agentarea:test@localhost:5432/agentarea" {
+		t.Fatalf("DatabaseURL = %q", cfg.DatabaseURL)
+	}
+	if cfg.RedisURL != "redis://localhost:6379/0" {
+		t.Fatalf("RedisURL = %q", cfg.RedisURL)
+	}
+	if cfg.WorkerID != "worker-test" {
+		t.Fatalf("WorkerID = %q", cfg.WorkerID)
+	}
+	if cfg.PollInterval != 17*time.Second {
+		t.Fatalf("PollInterval = %s", cfg.PollInterval)
+	}
+	if cfg.MaxPollers != 7 {
+		t.Fatalf("MaxPollers = %d", cfg.MaxPollers)
+	}
+	if cfg.InboundStream != "events.inbound.test" {
+		t.Fatalf("InboundStream = %q", cfg.InboundStream)
+	}
+	if !cfg.EnableTelegramPolling {
+		t.Fatal("EnableTelegramPolling = false")
+	}
+	if cfg.Port != "18002" {
+		t.Fatalf("Port = %q", cfg.Port)
+	}
+}
+
+func TestLoadBuildsEscapedServiceURLsFromComponentEnvs(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgresql://raw:raw@raw/raw")
+	t.Setenv("POSTGRES_HOST", "agentarea-postgresql")
+	t.Setenv("POSTGRES_PORT", "5432")
+	t.Setenv("POSTGRES_DB", "agentarea")
+	t.Setenv("POSTGRES_USER", "agentarea")
+	t.Setenv("POSTGRES_PASSWORD", "p@ss/with:chars")
+	t.Setenv("POSTGRES_SSLMODE", "disable")
+	t.Setenv("REDIS_URL", "redis://raw:6379")
+	t.Setenv("REDIS_HOST", "agentarea-valkey")
+	t.Setenv("REDIS_PORT", "6379")
+	t.Setenv("REDIS_PASSWORD", "redis@pass/with:chars")
+
+	cfg := Load()
+
+	if cfg.DatabaseURL != "host='agentarea-postgresql' port='5432' user='agentarea' password='p@ss/with:chars' dbname='agentarea' sslmode='disable'" {
+		t.Fatalf("DatabaseURL = %q", cfg.DatabaseURL)
+	}
+	if cfg.RedisURL != "redis://:redis%40pass%2Fwith%3Achars@agentarea-valkey:6379" {
+		t.Fatalf("RedisURL = %q", cfg.RedisURL)
+	}
+}
+
+func TestLoadEscapesPostgresConnStringValues(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "agentarea-postgresql")
+	t.Setenv("POSTGRES_PORT", "5432")
+	t.Setenv("POSTGRES_DB", "agentarea")
+	t.Setenv("POSTGRES_USER", "agent'area")
+	t.Setenv("POSTGRES_PASSWORD", `p\ass'word`)
+
+	cfg := Load()
+
+	if cfg.DatabaseURL != `host='agentarea-postgresql' port='5432' user='agent\'area' password='p\\ass\'word' dbname='agentarea' sslmode='disable'` {
+		t.Fatalf("DatabaseURL = %q", cfg.DatabaseURL)
+	}
+}

--- a/agentarea-event-service/internal/submit/client.go
+++ b/agentarea-event-service/internal/submit/client.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
-	"github.com/redis/go-redis/v9"
+	"github.com/agentarea/event-service/internal/broker"
 )
 
 // Event is the normalized event payload to submit. It mirrors channels/telegram.Event
@@ -20,28 +21,31 @@ type Event struct {
 	Raw       map[string]any `json:"raw"`
 }
 
-// InboundMessage is the payload published to Redis for the Python worker to consume.
+// InboundMessage is the normalized payload written to the inbound stream.
 type InboundMessage struct {
 	TriggerID     string         `json:"trigger_id"`
 	Event         Event          `json:"event"`
 	ChannelOrigin map[string]any `json:"channel_origin"`
 }
 
-// InboundChannel is the Redis pub/sub channel the Python worker subscribes to.
-const InboundChannel = "agentarea.channel.message.received"
+const DefaultInboundStream = "agentarea.channel.inbound"
 
-// RedisSubmitter publishes inbound channel messages to Redis for the Python worker.
-type RedisSubmitter struct {
-	client *redis.Client
+// StreamSubmitter appends inbound channel events to a durable broker stream.
+type StreamSubmitter struct {
+	broker broker.Client
+	stream string
 }
 
-// NewRedisSubmitter creates a new Redis-based submitter.
-func NewRedisSubmitter(client *redis.Client) *RedisSubmitter {
-	return &RedisSubmitter{client: client}
+// NewStreamSubmitter creates a stream-backed submitter.
+func NewStreamSubmitter(broker broker.Client, stream string) *StreamSubmitter {
+	if stream == "" {
+		stream = DefaultInboundStream
+	}
+	return &StreamSubmitter{broker: broker, stream: stream}
 }
 
-// SubmitEvent publishes a trigger event to Redis.
-func (s *RedisSubmitter) SubmitEvent(ctx context.Context, triggerID string, event Event, channelOrigin map[string]any) error {
+// SubmitEvent appends a trigger event to the inbound stream.
+func (s *StreamSubmitter) SubmitEvent(ctx context.Context, triggerID string, event Event, channelOrigin map[string]any) error {
 	msg := InboundMessage{
 		TriggerID:     triggerID,
 		Event:         event,
@@ -53,8 +57,31 @@ func (s *RedisSubmitter) SubmitEvent(ctx context.Context, triggerID string, even
 		return fmt.Errorf("marshal inbound message: %w", err)
 	}
 
-	if err := s.client.Publish(ctx, InboundChannel, data).Err(); err != nil {
-		return fmt.Errorf("redis publish: %w", err)
+	eventJSON, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+	originJSON, err := json.Marshal(channelOrigin)
+	if err != nil {
+		return fmt.Errorf("marshal channel origin: %w", err)
+	}
+
+	dedupKey := fmt.Sprintf("%s:%s:%d", triggerID, event.Type, event.MessageID)
+	if event.MessageID == 0 {
+		dedupKey = fmt.Sprintf("%s:%s:%x", triggerID, event.Type, data)
+	}
+
+	_, err = s.broker.Submit(ctx, s.stream, map[string]string{
+		"trigger_id":      triggerID,
+		"event":           string(eventJSON),
+		"channel_origin":  string(originJSON),
+		"dedup_key":       dedupKey,
+		"received_at":     time.Now().UTC().Format(time.RFC3339Nano),
+		"schema_version":  "1",
+		"inbound_message": string(data),
+	})
+	if err != nil {
+		return fmt.Errorf("submit inbound stream: %w", err)
 	}
 
 	return nil

--- a/agentarea-event-service/internal/submit/client_test.go
+++ b/agentarea-event-service/internal/submit/client_test.go
@@ -1,0 +1,71 @@
+package submit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fakeBroker struct {
+	stream string
+	fields map[string]string
+}
+
+func (f *fakeBroker) Submit(ctx context.Context, stream string, fields map[string]string) (string, error) {
+	f.stream = stream
+	f.fields = fields
+	return "1-0", nil
+}
+
+func (f *fakeBroker) EnsureGroup(ctx context.Context, stream, group, start string) error {
+	return nil
+}
+
+func TestStreamSubmitterWritesInboundStream(t *testing.T) {
+	b := &fakeBroker{}
+	s := NewStreamSubmitter(b, "agentarea.channel.inbound")
+
+	err := s.SubmitEvent(
+		context.Background(),
+		"trigger-1",
+		Event{
+			Type:      "message",
+			ChatID:    42,
+			UserID:    99,
+			Username:  "alice",
+			Text:      "hello",
+			MessageID: 7,
+			Raw:       map[string]any{"update_id": float64(1001)},
+		},
+		map[string]any{"type": "telegram", "chat_id": "42"},
+	)
+	if err != nil {
+		t.Fatalf("SubmitEvent returned error: %v", err)
+	}
+
+	if b.stream != "agentarea.channel.inbound" {
+		t.Fatalf("stream = %q", b.stream)
+	}
+	if b.fields["trigger_id"] != "trigger-1" {
+		t.Fatalf("trigger_id = %q", b.fields["trigger_id"])
+	}
+	if b.fields["dedup_key"] != "trigger-1:message:7" {
+		t.Fatalf("dedup_key = %q", b.fields["dedup_key"])
+	}
+
+	var event Event
+	if err := json.Unmarshal([]byte(b.fields["event"]), &event); err != nil {
+		t.Fatalf("event json invalid: %v", err)
+	}
+	if event.Text != "hello" || event.ChatID != 42 {
+		t.Fatalf("event = %+v", event)
+	}
+
+	var origin map[string]any
+	if err := json.Unmarshal([]byte(b.fields["channel_origin"]), &origin); err != nil {
+		t.Fatalf("channel_origin json invalid: %v", err)
+	}
+	if origin["type"] != "telegram" || origin["chat_id"] != "42" {
+		t.Fatalf("origin = %+v", origin)
+	}
+}

--- a/agentarea-platform/apps/worker/agentarea_worker/main.py
+++ b/agentarea-platform/apps/worker/agentarea_worker/main.py
@@ -82,10 +82,12 @@ class AgentAreaWorker:
         self.worker = None
         self.trigger_worker = None
         self.inbound_subscriber = None
+        self.inbound_autoclaimer = None
         self.delivery_consumer = None
         self.delivery_autoclaimer = None
         self._broker = None
         self._dedup = None
+        self._inbound_dedup = None
         self.container_monitor = None
         self.worker_shutdown_event = asyncio.Event()
 
@@ -205,19 +207,19 @@ class AgentAreaWorker:
             max_concurrent_activities=5,
         )
 
-        # Wire inbound channel message subscriber (Go → Redis → Python)
+        # Wire inbound channel message consumer (event-service → Redis Streams → Python)
         # Wire outbound channel event subscriber (workflow events → Telegram/Slack/Discord)
         await self._setup_channel_subscribers(dependencies)
 
         logger.info("Worker created and configured")
 
     async def _setup_channel_subscribers(self, dependencies) -> None:
-        """Wire inbound subscriber + outbound delivery consumer.
+        """Wire inbound stream consumer + outbound delivery consumer.
 
         The router-via-pub/sub bridge is gone: `publish_workflow_events_activity`
         now enqueues channel deliveries directly via `dependencies.broker_client`.
         This method only wires the *consumer side* (delivery loop +
-        autoclaimer) and the inbound polling subscriber.
+        autoclaimer) and the inbound channel event consumer.
         """
         from agentarea_common.broker import DedupCache
         from agentarea_triggers.channels import get_adapter
@@ -226,7 +228,7 @@ class AgentAreaWorker:
         from agentarea_triggers.channels.delivery_consumer import (
             ChannelDeliveryConsumer,
         )
-        from agentarea_triggers.channels.inbound_subscriber import InboundMessageSubscriber
+        from agentarea_triggers.channels.inbound_subscriber import InboundMessageStreamConsumer
         from agentarea_triggers.channels.lazy_secret_manager import LazySecretReader
 
         settings = get_settings()
@@ -243,12 +245,32 @@ class AgentAreaWorker:
             prefix="channel-delivery",
             ttl_seconds=delivery_cfg.DEDUP_TTL_SECONDS,
         )
+        self._inbound_dedup = DedupCache(
+            redis_url,
+            prefix="channel-inbound",
+            ttl_seconds=delivery_cfg.DEDUP_TTL_SECONDS,
+        )
 
-        # Inbound: Go polling → Redis → Python task execution
-        self.inbound_subscriber = InboundMessageSubscriber(
-            redis_url=redis_url,
+        # Inbound: event-service webhook/polling → Redis Streams → Python task execution
+        self.inbound_subscriber = InboundMessageStreamConsumer(
+            broker=self._broker,
+            dedup=self._inbound_dedup,
             event_broker=dependencies.event_broker,
             workflow_executor=dependencies.workflow_executor,
+            stream=delivery_cfg.INBOUND_STREAM,
+            group=delivery_cfg.INBOUND_GROUP,
+            dlq_stream=delivery_cfg.INBOUND_DLQ,
+            block_ms=delivery_cfg.CONSUMER_BLOCK_MS,
+            batch_size=delivery_cfg.CONSUMER_BATCH_SIZE,
+            max_delivery_attempts=delivery_cfg.MAX_DELIVERY_ATTEMPTS,
+        )
+        self.inbound_autoclaimer = StreamAutoclaimer(
+            broker=self._broker,
+            stream=delivery_cfg.INBOUND_STREAM,
+            group=delivery_cfg.INBOUND_GROUP,
+            consumer_id="inbound-autoclaimer",
+            min_idle_ms=delivery_cfg.AUTOCLAIM_MIN_IDLE_MS,
+            interval_seconds=delivery_cfg.AUTOCLAIM_INTERVAL_SECONDS,
         )
 
         # Register adapters; they raise typed Retryable/Fatal errors that the
@@ -286,6 +308,8 @@ class AgentAreaWorker:
         # Start channel subscribers and delivery pipeline
         if self.inbound_subscriber:
             await self.inbound_subscriber.start()
+        if self.inbound_autoclaimer:
+            await self.inbound_autoclaimer.start()
         if self.delivery_consumer:
             await self.delivery_consumer.start()
         if self.delivery_autoclaimer:
@@ -341,6 +365,9 @@ class AgentAreaWorker:
         if self.inbound_subscriber:
             await self.inbound_subscriber.stop()
             self.inbound_subscriber = None
+        if self.inbound_autoclaimer:
+            await self.inbound_autoclaimer.stop()
+            self.inbound_autoclaimer = None
         if self.delivery_autoclaimer:
             await self.delivery_autoclaimer.stop()
             self.delivery_autoclaimer = None
@@ -353,6 +380,9 @@ class AgentAreaWorker:
         if self._dedup:
             await self._dedup.aclose()
             self._dedup = None
+        if self._inbound_dedup:
+            await self._inbound_dedup.aclose()
+            self._inbound_dedup = None
 
         if self.worker:
             self.worker = None

--- a/agentarea-platform/libs/common/agentarea_common/config/channels.py
+++ b/agentarea-platform/libs/common/agentarea_common/config/channels.py
@@ -10,7 +10,22 @@ from pydantic_settings import BaseSettings
 
 
 class ChannelDeliverySettings(BaseSettings):
-    """Configuration for the durable outbound channel delivery pipeline."""
+    """Configuration for durable channel pipelines."""
+
+    INBOUND_STREAM: str = Field(
+        default="agentarea.channel.inbound",
+        description="Broker stream that carries normalized inbound channel events.",
+    )
+
+    INBOUND_GROUP: str = Field(
+        default="inbound",
+        description="Consumer group on INBOUND_STREAM. All worker replicas share one group.",
+    )
+
+    INBOUND_DLQ: str = Field(
+        default="agentarea.channel.inbound.dlq",
+        description="Stream that catches inbound events that exhausted retries or are malformed.",
+    )
 
     OUTBOUND_STREAM: str = Field(
         default="agentarea.channel.outbound",

--- a/agentarea-platform/libs/triggers/agentarea_triggers/channels/inbound_subscriber.py
+++ b/agentarea-platform/libs/triggers/agentarea_triggers/channels/inbound_subscriber.py
@@ -1,7 +1,8 @@
-"""Redis subscriber for inbound channel messages from Go event service.
+"""Durable inbound channel event consumer backed by Redis Streams.
 
-Listens to `agentarea.channel.message.received` and calls trigger execution
-logic to create and submit agent tasks.
+Go event-service writes normalized channel events to an inbound stream. This
+consumer claims them with a shared consumer group and creates trigger
+executions. Messages are ACKed only after trigger execution succeeds.
 """
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-import redis.asyncio as redis
+from agentarea_common.broker import BrokerClient, BrokerMessage, DedupCache
 
 if TYPE_CHECKING:
     from agentarea_common.events.base import EventBroker
@@ -19,35 +20,54 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-INBOUND_CHANNEL = "agentarea.channel.message.received"
 
-
-class InboundMessageSubscriber:
-    """Subscribes to Redis for inbound channel messages and triggers task execution.
-
-    The Go event service publishes messages here when Telegram (or other channels)
-    receive new messages. This subscriber picks them up and calls
-    TriggerService.execute_trigger() to create and run agent tasks.
-    """
+class InboundMessageStreamConsumer:
+    """Consumes normalized inbound channel events from a durable stream."""
 
     def __init__(
         self,
-        redis_url: str,
+        broker: BrokerClient,
+        dedup: DedupCache,
+        *,
         event_broker: EventBroker,
         workflow_executor: WorkflowExecutor | None = None,
+        stream: str,
+        group: str,
+        dlq_stream: str,
+        consumer_id: str = "c1",
+        block_ms: int = 5000,
+        batch_size: int = 10,
+        max_delivery_attempts: int = 20,
     ) -> None:
-        self._redis_url = redis_url
+        self._broker = broker
+        self._dedup = dedup
         self._event_broker = event_broker
         self._workflow_executor = workflow_executor
+        self._stream = stream
+        self._group = group
+        self._dlq_stream = dlq_stream
+        self._consumer_id = consumer_id
+        self._block_ms = block_ms
+        self._batch_size = batch_size
+        self._max_delivery_attempts = max_delivery_attempts
         self._task: asyncio.Task[None] | None = None
         self._running = False
 
     async def start(self) -> None:
         if self._running:
             return
+        await self._broker.ensure_group(self._stream, self._group, start="0")
         self._running = True
-        self._task = asyncio.create_task(self._run_loop(), name="inbound-message-subscriber")
-        logger.info("InboundMessageSubscriber started (channel=%s)", INBOUND_CHANNEL)
+        self._task = asyncio.create_task(
+            self._run_loop(),
+            name="inbound-message-stream-consumer",
+        )
+        logger.info(
+            "InboundMessageStreamConsumer started (stream=%s group=%s consumer=%s)",
+            self._stream,
+            self._group,
+            self._consumer_id,
+        )
 
     async def stop(self) -> None:
         self._running = False
@@ -56,16 +76,23 @@ class InboundMessageSubscriber:
             try:
                 await self._task
             except asyncio.CancelledError:
-                # Expected during shutdown - task cancellation is normal
                 pass
             self._task = None
-        logger.info("InboundMessageSubscriber stopped")
+        logger.info("InboundMessageStreamConsumer stopped (stream=%s)", self._stream)
 
     async def _run_loop(self) -> None:
         backoff = 1.0
         while self._running:
             try:
-                await self._subscribe_and_dispatch()
+                msgs = await self._broker.consume(
+                    self._stream,
+                    self._group,
+                    self._consumer_id,
+                    count=self._batch_size,
+                    block_ms=self._block_ms,
+                )
+                for msg in msgs:
+                    await self._handle(msg)
                 backoff = 1.0
             except asyncio.CancelledError:
                 raise
@@ -73,7 +100,7 @@ class InboundMessageSubscriber:
                 if not self._running:
                     break
                 logger.error(
-                    "InboundMessageSubscriber error (retrying in %.0fs): %s",
+                    "InboundMessageStreamConsumer loop error (retry in %.0fs): %s",
                     backoff,
                     exc,
                     exc_info=True,
@@ -81,61 +108,73 @@ class InboundMessageSubscriber:
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60.0)
 
-    async def _subscribe_and_dispatch(self) -> None:
-        client: redis.Redis = redis.from_url(self._redis_url, decode_responses=True)
-        pubsub = client.pubsub()
+    async def _handle(self, msg: BrokerMessage) -> None:
+        fields = msg.fields
+        dedup_key = fields.get("dedup_key") or msg.id
 
-        try:
-            await pubsub.subscribe(INBOUND_CHANNEL)
-            logger.debug("subscribed to %s", INBOUND_CHANNEL)
-
-            async for raw_message in pubsub.listen():
-                if not self._running:
-                    break
-                if raw_message.get("type") != "message":
-                    continue
-                await self._handle_message(raw_message)
-        finally:
-            try:
-                await pubsub.unsubscribe(INBOUND_CHANNEL)
-                await pubsub.close()
-            except Exception as exc:
-                logger.debug("Pubsub cleanup error suppressed: %s", exc)
-            try:
-                await client.aclose()
-            except Exception as exc:
-                logger.debug("Redis client close error suppressed: %s", exc)
-
-    async def _handle_message(self, raw_message: dict[str, Any]) -> None:
-        try:
-            payload: str = raw_message.get("data", "")
-            if not payload:
-                return
-
-            msg = json.loads(payload)
-            trigger_id = msg.get("trigger_id")
-            event = msg.get("event", {})
-            channel_origin = msg.get("channel_origin", {})
-
-            if not trigger_id:
-                logger.warning("Inbound message missing trigger_id, skipping")
-                return
-
-            logger.info(
-                "Inbound message received for trigger %s (text=%s)",
-                trigger_id,
-                (event.get("text") or "")[:50],
+        if msg.delivery_count > self._max_delivery_attempts:
+            await self._dead_letter(
+                msg,
+                f"max delivery attempts ({msg.delivery_count}) exceeded",
             )
+            return
 
-            trigger_data: dict[str, Any] = {
-                "events": [event],
-                "channel_origin": channel_origin,
-            }
+        if not await self._dedup.claim(dedup_key):
+            logger.debug("inbound dedup hit on %s, acking", dedup_key)
+            await self._broker.ack(self._stream, self._group, msg.id)
+            return
 
+        try:
+            trigger_id, trigger_data = self._parse_fields(fields)
+        except ValueError as exc:
+            await self._dead_letter(msg, str(exc))
+            return
+
+        try:
             await self._execute_trigger(trigger_id, trigger_data)
-
+        except ValueError as exc:
+            await self._dead_letter(msg, str(exc))
+            return
         except Exception:
-            logger.exception("Failed to handle inbound channel message")
+            logger.exception("inbound trigger execution failed for %s", trigger_id)
+            await self._dedup.release(dedup_key)
+            return
+
+        await self._broker.ack(self._stream, self._group, msg.id)
+        logger.info("Inbound trigger %s executed from stream message %s", trigger_id, msg.id)
+
+    def _parse_fields(self, fields: dict[str, str]) -> tuple[str, dict[str, Any]]:
+        trigger_id = fields.get("trigger_id")
+        if not trigger_id:
+            raise ValueError("missing trigger_id")
+
+        event_raw = fields.get("event", "{}")
+        origin_raw = fields.get("channel_origin", "{}")
+
+        try:
+            event = json.loads(event_raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"bad event json: {exc}") from exc
+        try:
+            channel_origin = json.loads(origin_raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"bad channel_origin json: {exc}") from exc
+
+        if not isinstance(event, dict):
+            raise ValueError("event must be a JSON object")
+        if not isinstance(channel_origin, dict):
+            raise ValueError("channel_origin must be a JSON object")
+
+        return trigger_id, {"events": [event], "channel_origin": channel_origin}
+
+    async def _dead_letter(self, msg: BrokerMessage, reason: str) -> None:
+        dlq_fields = {**msg.fields, "fatal_reason": reason[:500]}
+        try:
+            await self._broker.submit(self._dlq_stream, dlq_fields)
+        except Exception:
+            logger.exception("failed to write inbound DLQ for %s", msg.id)
+        await self._broker.ack(self._stream, self._group, msg.id)
+        logger.error("inbound channel event DLQ'd: %s (reason=%s)", msg.id, reason)
 
     async def _execute_trigger(self, trigger_id: str, trigger_data: dict[str, Any]) -> None:
         """Execute the trigger using TriggerService with a fresh DB session."""
@@ -153,11 +192,9 @@ class InboundMessageSubscriber:
 
         database = get_database()
         async with database.async_session_factory() as session:
-            # Resolve workspace context from trigger
             trigger_orm = await session.get(TriggerORM, UUID(trigger_id))
             if not trigger_orm:
-                logger.error("Trigger %s not found, cannot execute", trigger_id)
-                return
+                raise ValueError(f"trigger {trigger_id} not found")
 
             user_context = UserContext(
                 user_id=str(trigger_orm.created_by),
@@ -167,7 +204,6 @@ class InboundMessageSubscriber:
             repository_factory = RepositoryFactory(session, user_context)
             task_repository = repository_factory.create_repository(TaskRepository)
 
-            # Wire task manager with the shared Temporal executor
             if self._workflow_executor is not None:
                 task_manager = TemporalTaskManager.__new__(TemporalTaskManager)
                 task_manager.task_repository = task_repository
@@ -188,7 +224,6 @@ class InboundMessageSubscriber:
             )
 
             execution = await trigger_service.execute_trigger(UUID(trigger_id), trigger_data)
-
             if execution:
                 logger.info(
                     "Trigger %s executed, task_id=%s",

--- a/agentarea-platform/libs/triggers/tests/test_inbound_stream_consumer.py
+++ b/agentarea-platform/libs/triggers/tests/test_inbound_stream_consumer.py
@@ -1,0 +1,134 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from agentarea_common.broker import BrokerMessage
+from agentarea_triggers.channels.inbound_subscriber import InboundMessageStreamConsumer
+
+
+class FakeBroker:
+    def __init__(self):
+        self.acked: list[tuple[str, str, str]] = []
+        self.submitted: list[tuple[str, dict[str, str]]] = []
+
+    async def ensure_group(self, stream: str, group: str, start: str = "$") -> None:
+        pass
+
+    async def consume(self, *args, **kwargs):
+        return []
+
+    async def ack(self, stream: str, group: str, message_id: str) -> None:
+        self.acked.append((stream, group, message_id))
+
+    async def submit(self, stream: str, fields: dict[str, str]) -> str:
+        self.submitted.append((stream, fields))
+        return "dlq-id"
+
+
+class FakeDedup:
+    def __init__(self, claimed: bool = True):
+        self.claimed = claimed
+        self.claim_calls: list[str] = []
+        self.release_calls: list[str] = []
+
+    async def claim(self, key: str) -> bool:
+        self.claim_calls.append(key)
+        return self.claimed
+
+    async def release(self, key: str) -> None:
+        self.release_calls.append(key)
+
+
+class InboundConsumerHarness(InboundMessageStreamConsumer):
+    def __init__(self, broker, dedup):
+        super().__init__(
+            broker,
+            dedup,
+            event_broker=AsyncMock(),
+            stream="inbound",
+            group="workers",
+            dlq_stream="inbound.dlq",
+        )
+        self.executed: list[tuple[str, dict]] = []
+        self.fail_execute = False
+
+    async def _execute_trigger(self, trigger_id: str, trigger_data: dict) -> None:
+        self.executed.append((trigger_id, trigger_data))
+        if self.fail_execute:
+            raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_inbound_stream_message_executes_and_acks():
+    broker = FakeBroker()
+    dedup = FakeDedup()
+    consumer = InboundConsumerHarness(broker, dedup)
+    msg = BrokerMessage(
+        id="1-0",
+        fields={
+            "trigger_id": "trigger-1",
+            "event": json.dumps({"type": "message", "text": "hello"}),
+            "channel_origin": json.dumps({"type": "telegram", "chat_id": "42"}),
+            "dedup_key": "tg:42:7",
+        },
+    )
+
+    await consumer._handle(msg)
+
+    assert consumer.executed == [
+        (
+            "trigger-1",
+            {
+                "events": [{"type": "message", "text": "hello"}],
+                "channel_origin": {"type": "telegram", "chat_id": "42"},
+            },
+        )
+    ]
+    assert broker.acked == [("inbound", "workers", "1-0")]
+    assert broker.submitted == []
+
+
+@pytest.mark.asyncio
+async def test_inbound_stream_malformed_message_goes_to_dlq():
+    broker = FakeBroker()
+    dedup = FakeDedup()
+    consumer = InboundConsumerHarness(broker, dedup)
+    msg = BrokerMessage(
+        id="1-0",
+        fields={
+            "trigger_id": "trigger-1",
+            "event": "{bad",
+            "channel_origin": "{}",
+            "dedup_key": "bad",
+        },
+    )
+
+    await consumer._handle(msg)
+
+    assert consumer.executed == []
+    assert broker.acked == [("inbound", "workers", "1-0")]
+    assert broker.submitted[0][0] == "inbound.dlq"
+    assert "fatal_reason" in broker.submitted[0][1]
+
+
+@pytest.mark.asyncio
+async def test_inbound_stream_execution_failure_releases_dedup_without_ack():
+    broker = FakeBroker()
+    dedup = FakeDedup()
+    consumer = InboundConsumerHarness(broker, dedup)
+    consumer.fail_execute = True
+    msg = BrokerMessage(
+        id="1-0",
+        fields={
+            "trigger_id": "trigger-1",
+            "event": json.dumps({"type": "message"}),
+            "channel_origin": json.dumps({}),
+            "dedup_key": "retry-me",
+        },
+    )
+
+    await consumer._handle(msg)
+
+    assert broker.acked == []
+    assert broker.submitted == []
+    assert dedup.release_calls == ["retry-me"]

--- a/charts/agentarea/templates/agentarea-event-service/deployment.yaml
+++ b/charts/agentarea/templates/agentarea-event-service/deployment.yaml
@@ -68,10 +68,16 @@ spec:
             {{- include "agentarea.redis.secrets.envs" . | nindent 12 }}
             {{- include "agentarea.redis.envs" . | nindent 12 }}
             {{- include "agentarea.redis.urlEnv" . | nindent 12 }}
-            - name: POLL_INTERVAL
+            - name: AGENTAREA_EVENTS_PORT
+              value: {{ .Values.eventService.port | quote }}
+            - name: AGENTAREA_EVENTS_POLL_INTERVAL
               value: {{ .Values.eventService.pollInterval | quote }}
-            - name: MAX_POLLERS
+            - name: AGENTAREA_EVENTS_MAX_POLLERS
               value: {{ .Values.eventService.maxPollers | quote }}
+            - name: AGENTAREA_EVENTS_INBOUND_STREAM
+              value: {{ .Values.eventService.inboundStream | quote }}
+            - name: AGENTAREA_EVENTS_TELEGRAM_POLLING_ENABLED
+              value: {{ .Values.eventService.telegramPolling.enabled | quote }}
             {{- if .Values.eventService.extraEnv }}
             {{- toYaml .Values.eventService.extraEnv | nindent 12 }}
             {{- end }}

--- a/charts/agentarea/templates/jobs/create-kratos-db-job.yaml
+++ b/charts/agentarea/templates/jobs/create-kratos-db-job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.kratos.enabled .Values.postgresql.enabled }}
+{{- if and .Values.kratos.enabled .Values.postgresql.enabled .Values.kratos.database.createJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/agentarea/templates/jobs/create-temporal-db-job.yaml
+++ b/charts/agentarea/templates/jobs/create-temporal-db-job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.temporal.enabled .Values.postgresql.enabled }}
+{{- if and .Values.temporal.enabled .Values.postgresql.enabled .Values.temporal.database.createJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -460,6 +460,11 @@ eventService:
   # Polling configuration
   pollInterval: "30s"
   maxPollers: 10
+  inboundStream: "agentarea.channel.inbound"
+  telegramPolling:
+    # Dev-only fallback for Telegram getUpdates. Production Telegram ingress
+    # should use webhooks.
+    enabled: false
   # Resource limits and requests
   resources: {}
   #   limits:
@@ -613,6 +618,8 @@ temporal:
   # Database configuration
   database:
     name: "temporal"
+    createJob:
+      enabled: true
   
   service:
     type: ClusterIP
@@ -738,6 +745,8 @@ kratos:
   
   database:
     name: "kratos"
+    createJob:
+      enabled: true
 
   configMapOverrideName: ""
   files: {}

--- a/deploy/tilt/add-namespace.py
+++ b/deploy/tilt/add-namespace.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Add a Kubernetes namespace to namespaced Helm-rendered resources."""
+
+from __future__ import annotations
+
+import sys
+
+import yaml
+
+
+CLUSTER_SCOPED_KINDS = {
+    "ClusterRole",
+    "ClusterRoleBinding",
+    "CustomResourceDefinition",
+    "GatewayClass",
+    "Namespace",
+    "Node",
+    "PersistentVolume",
+    "PriorityClass",
+    "StorageClass",
+}
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: add-namespace.py <namespace>")
+
+    namespace = sys.argv[1]
+    docs = []
+    for doc in yaml.safe_load_all(sys.stdin):
+        if not doc:
+            continue
+        if doc.get("kind") not in CLUSTER_SCOPED_KINDS:
+            metadata = doc.setdefault("metadata", {})
+            metadata.setdefault("namespace", namespace)
+        docs.append(doc)
+
+    yaml.safe_dump_all(docs, sys.stdout, explicit_start=True, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/tilt/timeweb-dev-values.yaml
+++ b/deploy/tilt/timeweb-dev-values.yaml
@@ -4,8 +4,7 @@ global:
   image:
     registry: ""
     pullPolicy: Always
-    pullSecrets:
-      - name: timeweb-registry
+    pullSecrets: []
   security:
     podSecurityContext: null
     containerSecurityContext: null
@@ -68,7 +67,22 @@ mcpManager:
       memory: 256Mi
 
 eventService:
-  enabled: false
+  enabled: true
+  image:
+    repository: agentarea/agentarea-events
+    tag: "tilt-dev"
+  telegramPolling:
+    enabled: false
+
+temporal:
+  database:
+    createJob:
+      enabled: false
+
+kratos:
+  database:
+    createJob:
+      enabled: false
 
 jobs:
   dbMigration:


### PR DESCRIPTION
## Summary
- move inbound channel events from direct/pubsub-style handling to durable Redis Streams
- wire Go event-service submitter to Redis Streams and Python worker inbound consumer/autoclaimer
- add event-service health endpoint, unified `AGENTAREA_EVENTS_*` config, and safer DB/Redis URL construction
- make Tilt dev deployment actually include event-service, namespace rendered resources explicitly, and keep dev bootstrap jobs/pull secrets configurable

## Verification
- `go test ./...` in `agentarea-event-service`
- Python ruff/pytest for inbound stream and webhook paths
- Helm render checks for `AGENTAREA_EVENTS_*`, disabled Tilt bootstrap jobs, and no hardcoded dev pull secret
- live Redis Streams smoke against dev Valkey: consume/ack valid message, DLQ malformed message, pending=0
- dev cluster `agentarea-event-service` rollout healthy with `/health` returning `ok`
