### PR TITLE
Fix workflow event publishing and Alembic migration heads

### DIFF
--- a/agentarea-platform/apps/api/alembic/versions/tt1_merge_skill_slug_and_artifact_events.py
+++ b/agentarea-platform/apps/api/alembic/versions/tt1_merge_skill_slug_and_artifact_events.py
@@ -1,0 +1,21 @@
+"""merge skill slug and artifact event migration heads
+
+Revision ID: tt1_merge_heads
+Revises: qq1_add_skill_slug, ss1_add_artifact_events
+Create Date: 2026-06-02
+"""
+
+from collections.abc import Sequence
+
+revision: str = "tt1_merge_heads"
+down_revision: tuple[str, str] | None = ("qq1_add_skill_slug", "ss1_add_artifact_events")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
@@ -1081,26 +1081,13 @@ def make_agent_activities(dependencies: ActivityDependencies):
             from uuid import uuid4
 
             from agentarea_common.events.base_events import DomainEvent
-            from agentarea_common.events.router import create_event_broker_from_router
 
             from ..handlers import handle_llm_error_event
+            from .event_publisher import resolve_event_broker
 
             logger.info(f"Publishing {len(request.events_json)} workflow events via EventBroker")
 
-            # Convert RedisRouter to RedisEventBroker for publishing
-            # dependencies.event_broker is a RedisRouter, we need RedisEventBroker to publish
-            if not hasattr(dependencies.event_broker, "broker"):
-                logger.error(
-                    f"Event broker {type(dependencies.event_broker)} "
-                    "does not have 'broker' attribute"
-                )
-                return WorkflowEventsResult(
-                    success=False,
-                    events_published=0,
-                    errors=["Event broker configuration error"],
-                )
-
-            redis_event_broker = create_event_broker_from_router(dependencies.event_broker)  # type: ignore
+            event_publisher = resolve_event_broker(dependencies.event_broker)
             events_published = 0
             errors = []
 
@@ -1158,7 +1145,7 @@ def make_agent_activities(dependencies: ActivityDependencies):
 
                     # 1. Publish via RedisEventBroker (uses FastStream
                     # infrastructure) for real-time SSE
-                    await redis_event_broker.publish(domain_event)
+                    await event_publisher.publish(domain_event)
                     logger.debug(
                         f"Published workflow event: {event['event_type']} for task {task_id}"
                     )

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/event_publisher.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/event_publisher.py
@@ -2,12 +2,28 @@
 
 import logging
 from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 from agentarea_common.events.base_events import DomainEvent
+from agentarea_common.events.broker import EventBroker
 from agentarea_common.events.router import create_event_broker_from_router
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_event_broker(event_broker: Any) -> EventBroker:
+    """Return the publish-capable EventBroker from worker/API event dependencies."""
+    if isinstance(event_broker, EventBroker):
+        return event_broker
+
+    if hasattr(event_broker, "broker"):
+        return create_event_broker_from_router(event_broker)
+
+    raise TypeError(
+        "event_broker must implement EventBroker or expose a RedisRouter-style "
+        f"'broker' attribute, got {type(event_broker).__name__}"
+    )
 
 
 def create_event_publisher(event_broker, task_id: str):
@@ -28,7 +44,7 @@ def create_event_publisher(event_broker, task_id: str):
             chunk_type: "text" for regular content, "thinking" for reasoning blocks.
         """
         try:
-            redis_event_broker = create_event_broker_from_router(event_broker)
+            publisher = resolve_event_broker(event_broker)
 
             chunk_event = {
                 "event_type": "LLMCallChunk",
@@ -56,7 +72,7 @@ def create_event_publisher(event_broker, task_id: str):
             )
 
             # Publish via RedisEventBroker for real-time SSE
-            await redis_event_broker.publish(domain_event)
+            await publisher.publish(domain_event)
             logger.debug(f"Published LLM chunk event {chunk_index} for task {task_id}")
 
         except Exception as e:
@@ -85,7 +101,7 @@ async def publish_a2ui_event(
         event_broker: FastStream event broker/router.
     """
     try:
-        redis_event_broker = create_event_broker_from_router(event_broker)
+        publisher = resolve_event_broker(event_broker)
 
         a2ui_event = {
             "event_type": event_type,
@@ -105,7 +121,7 @@ async def publish_a2ui_event(
             original_data=a2ui_event["data"],
         )
 
-        await redis_event_broker.publish(domain_event)
+        await publisher.publish(domain_event)
         logger.debug(f"Published {event_type} event for task {task_id}")
 
     except Exception as e:
@@ -123,7 +139,7 @@ async def publish_enriched_llm_error_event(
 ):
     """Publish enriched LLM error event with detailed error information."""
     try:
-        redis_event_broker = create_event_broker_from_router(event_broker)
+        publisher = resolve_event_broker(event_broker)
 
         error_type = type(error).__name__
         error_message = str(error)
@@ -175,7 +191,7 @@ async def publish_enriched_llm_error_event(
         )
 
         # Publish via RedisEventBroker for real-time SSE
-        await redis_event_broker.publish(domain_event)
+        await publisher.publish(domain_event)
         logger.info(f"Published enriched LLM error event for task {task_id}: {error_type}")
 
     except Exception as e:

--- a/agentarea-platform/libs/execution/tests/unit/test_event_publisher.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_event_publisher.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from agentarea_common.events.base_events import DomainEvent
+from agentarea_common.events.broker import EventBroker
+from agentarea_execution.activities.event_publisher import create_event_publisher
+
+
+class CapturingEventBroker(EventBroker):
+    def __init__(self) -> None:
+        self.events: list[DomainEvent] = []
+
+    async def publish(self, event: DomainEvent) -> None:
+        self.events.append(event)
+
+
+async def test_create_event_publisher_accepts_event_broker_instance() -> None:
+    broker = CapturingEventBroker()
+    publish_chunk = create_event_publisher(broker, "task-1")
+
+    await publish_chunk("pong", 0, is_final=True)
+
+    assert len(broker.events) == 1
+    assert broker.events[0].event_type == "workflow.LLMCallChunk"
+    assert broker.events[0].data["original_data"]["task_id"] == "task-1"
+    assert broker.events[0].data["original_data"]["chunk"] == "pong"


### PR DESCRIPTION
## Summary
- allow workflow event publishing activities to use an injected EventBroker directly instead of assuming a RedisRouter `.broker` attribute
- add a regression test for EventBroker-backed chunk event publishing
- add a no-op Alembic merge revision for the skill slug and artifact event migration heads

## Verification
- `uv run pytest libs/execution/tests/unit/test_event_publisher.py libs/execution/tests/unit/test_policy_approval.py libs/governance/tests/test_policies.py libs/governance/tests/test_temporal_bridge.py libs/governance/tests/test_engines_and_filters.py -q`
- deployed worker image to dev cluster and verified an agent task completed with workflow events persisted: WorkflowStarted, IterationStarted, LLMCallStarted, LLMCallCompleted, IterationCompleted, WorkflowCompleted
- verified governance policy preview/upsert/rejection flow in dev cluster
- verified cluster migrations complete successfully after the merge revision
