### PR TITLE
Preserve MCP registry icons in operator sync

### DIFF
--- a/agentarea-operator/registry_sync.py
+++ b/agentarea-operator/registry_sync.py
@@ -108,16 +108,34 @@ def _parse_standard_mcp(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     for entry in servers:
         server = entry.get("server", {})
+        meta = entry.get("_meta", {}).get("io.modelcontextprotocol.registry/official", {})
+        if not meta.get("isLatest", True):
+            continue
+
         identifier = server.get("name") or ""
         if not identifier:
             continue
-        title = server.get("title") or identifier
+        title = server.get("title") or _humanize_identifier(identifier)
         description = (server.get("description") or "")[:500]
         version = server.get("version", "latest")
         for remote in server.get("remotes", []):
             url = remote.get("url")
             if not url:
                 continue
+            transport = remote.get("type", "streamable-http")
+            raw_headers = remote.get("headers", [])
+            env_schema = (
+                [h for h in raw_headers if isinstance(h, dict)]
+                if isinstance(raw_headers, list)
+                else []
+            )
+            requires_auth = any(
+                h.get("name", "").lower() in ("authorization", "api_key", "x-api-key", "token")
+                for h in env_schema
+            )
+            tags = [transport]
+            if requires_auth:
+                tags.append("requires-auth")
             items.append(
                 {
                     "external_id": identifier,
@@ -127,10 +145,85 @@ def _parse_standard_mcp(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "spec": {
                         "connection_type": "url",
                         "url": url,
-                        "transport": remote.get("type", "streamable-http"),
+                        "transport": transport,
+                        "env_schema": env_schema,
                         "raw_spec": server,
                     },
-                    "tags": [remote.get("type", "streamable-http")],
+                    "tags": tags,
+                }
+            )
+
+        for pkg in server.get("packages", []):
+            if pkg.get("registryType") != "oci":
+                continue
+            image = pkg.get("name", "") or pkg.get("identifier", "")
+            pkg_version = pkg.get("version", version)
+            if not image:
+                continue
+            env_schema = [
+                ev for ev in pkg.get("environmentVariables", []) if isinstance(ev, dict)
+            ]
+            items.append(
+                {
+                    "external_id": f"{identifier}/docker",
+                    "name": title,
+                    "description": description,
+                    "version": pkg_version,
+                    "spec": {
+                        "connection_type": "docker",
+                        "image": f"{image}:{pkg_version}" if ":" not in image else image,
+                        "transport": "stdio",
+                        "env_schema": env_schema,
+                        "raw_spec": server,
+                    },
+                    "tags": ["docker", "oci"],
+                }
+            )
+
+        for pkg in server.get("packages", []):
+            reg_type = pkg.get("registryType", "")
+            if reg_type not in ("npm", "pypi", "nuget", "mcpb"):
+                continue
+            pkg_name = pkg.get("name", "") or pkg.get("identifier", "")
+            pkg_version = pkg.get("version", version)
+            if not pkg_name:
+                continue
+            runtime_args = pkg.get("runtimeArgs", [])
+            if runtime_args:
+                command = runtime_args[0]
+                args = runtime_args[1:]
+            elif reg_type == "npm":
+                command = "npx"
+                args = ["-y", pkg_name]
+            elif reg_type == "nuget":
+                command = "dotnet"
+                args = ["tool", "run", pkg_name]
+            elif reg_type == "mcpb":
+                command = "npx"
+                args = ["-y", pkg_name]
+            else:
+                command = "uvx"
+                args = [pkg_name]
+            env_schema = [
+                ev for ev in pkg.get("environmentVariables", []) if isinstance(ev, dict)
+            ]
+            items.append(
+                {
+                    "external_id": f"{identifier}/command",
+                    "name": title,
+                    "description": description,
+                    "version": pkg_version,
+                    "spec": {
+                        "connection_type": "command",
+                        "command": command,
+                        "args": args,
+                        "transport": "stdio",
+                        "package_registry": reg_type,
+                        "package_name": pkg_name,
+                        "env_schema": env_schema,
+                        "raw_spec": server,
+                    },
+                    "tags": ["command", reg_type],
                 }
             )
     return items
@@ -295,6 +388,7 @@ def reconcile(
     updated_count = 0
 
     for item in parsed:
+        item["registry_url"] = source_location
         existing = _get_registry_item(conn, registry_id, item["external_id"])
         if existing:
             _update_registry_item(conn, existing["id"], item)
@@ -465,7 +559,7 @@ def _create_entity(
     if registry_type == "default_agents":
         return _upsert_default_agent(conn, item, workspace_id)
     if registry_type == "mcp_servers":
-        return _upsert_mcp_server(conn, item, workspace_id)
+        return _upsert_mcp_server(conn, item, workspace_id, registry_item_id)
     if registry_type == "skills":
         return _upsert_skill(conn, item, workspace_id, registry_item_id)
     return None
@@ -647,7 +741,9 @@ def _upsert_default_agent(conn, item: dict[str, Any], workspace_id: str) -> str:
     return str(agent_id)
 
 
-def _upsert_mcp_server(conn, item: dict[str, Any], workspace_id: str) -> str:
+def _upsert_mcp_server(
+    conn, item: dict[str, Any], workspace_id: str, registry_item_id: str | None = None
+) -> str:
     spec = item.get("spec") or {}
     conn_type = spec.get("connection_type", "url")
     docker_image_url = ""
@@ -661,6 +757,11 @@ def _upsert_mcp_server(conn, item: dict[str, Any], workspace_id: str) -> str:
         if command_str:
             cmd_list = [command_str, *args]
     remote_url = spec.get("url") if conn_type == "url" else None
+    raw_spec = spec.get("raw_spec") or spec
+    tags = ["registry", conn_type]
+    for tag in item.get("tags") or []:
+        if tag and tag not in tags:
+            tags.append(tag)
 
     row = conn.execute(
         _text(
@@ -668,14 +769,18 @@ def _upsert_mcp_server(conn, item: dict[str, Any], workspace_id: str) -> str:
         ),
         {"name": item["name"], "ws": workspace_id},
     ).fetchone()
-    tags_json = json.dumps(["registry", conn_type])
+    tags_json = json.dumps(tags)
+    env_schema_json = json.dumps(spec.get("env_schema") or [])
+    json_spec_json = json.dumps(raw_spec) if raw_spec else None
     if row:
         sid = str(row[0])
         conn.execute(
             _text(
                 "UPDATE mcp_servers SET description = :desc, docker_image_url = :img, "
                 "version = :ver, tags = CAST(:tags AS JSONB), remote_url = :rurl, "
-                "cmd = CAST(:cmd AS JSONB), updated_at = now() WHERE id = :id"
+                "env_schema = CAST(:env AS JSONB), cmd = CAST(:cmd AS JSONB), "
+                "registry_item_id = :rid, json_spec = CAST(:json_spec AS JSONB), "
+                "registry_url = :registry_url, updated_at = now() WHERE id = :id"
             ),
             {
                 "id": sid,
@@ -683,28 +788,40 @@ def _upsert_mcp_server(conn, item: dict[str, Any], workspace_id: str) -> str:
                 "img": docker_image_url,
                 "ver": item.get("version") or "latest",
                 "tags": tags_json,
+                "env": env_schema_json,
                 "rurl": remote_url,
                 "cmd": json.dumps(cmd_list) if cmd_list else None,
+                "rid": registry_item_id,
+                "json_spec": json_spec_json,
+                "registry_url": item.get("registry_url"),
             },
         )
         return sid
     sid = str(uuid.uuid4())
+    slug = _unique_mcp_slug(conn, workspace_id, item["name"])
     conn.execute(
         _text(
-            "INSERT INTO mcp_servers (id, name, description, docker_image_url, version, tags, "
-            "is_public, cmd, remote_url, workspace_id, created_by, created_at, updated_at) "
-            "VALUES (:id, :name, :desc, :img, :ver, CAST(:tags AS JSONB), false, "
-            "CAST(:cmd AS JSONB), :rurl, :ws, 'system', now(), now())"
+            "INSERT INTO mcp_servers (id, name, slug, description, docker_image_url, version, "
+            "tags, is_public, env_schema, cmd, remote_url, registry_item_id, json_spec, "
+            "registry_url, workspace_id, created_by, created_at, updated_at) "
+            "VALUES (:id, :name, :slug, :desc, :img, :ver, CAST(:tags AS JSONB), false, "
+            "CAST(:env AS JSONB), CAST(:cmd AS JSONB), :rurl, :rid, "
+            "CAST(:json_spec AS JSONB), :registry_url, :ws, 'system', now(), now())"
         ),
         {
             "id": sid,
             "name": item["name"],
+            "slug": slug,
             "desc": item.get("description") or "",
             "img": docker_image_url,
             "ver": item.get("version") or "latest",
             "tags": tags_json,
+            "env": env_schema_json,
             "cmd": json.dumps(cmd_list) if cmd_list else None,
             "rurl": remote_url,
+            "rid": registry_item_id,
+            "json_spec": json_spec_json,
+            "registry_url": item.get("registry_url"),
             "ws": workspace_id,
         },
     )
@@ -721,6 +838,37 @@ def _generate_slug(name: str) -> str:
     if len(slug) > 100:
         slug = slug[:100].rstrip("-")
     return slug or "item"
+
+
+def _humanize_identifier(identifier: str) -> str:
+    name = identifier.rsplit("/", 1)[-1] if "/" in identifier else identifier
+    abbrevs = {"mcp", "api", "ai", "db", "sql", "ssh", "aws", "gcp", "cli", "sdk", "llm"}
+    parts = name.replace("-", " ").replace("_", " ").split()
+    return " ".join(p.upper() if p.lower() in abbrevs else p.capitalize() for p in parts)
+
+
+def _unique_mcp_slug(conn, workspace_id: str, name: str) -> str:
+    base = _generate_slug(name)
+
+    def _taken(candidate: str) -> bool:
+        return (
+            conn.execute(
+                _text(
+                    "SELECT 1 FROM mcp_servers "
+                    "WHERE workspace_id = :ws AND slug = :slug LIMIT 1"
+                ),
+                {"ws": workspace_id, "slug": candidate},
+            ).fetchone()
+            is not None
+        )
+
+    if not _taken(base):
+        return base
+    for suffix in range(2, 1000):
+        candidate = f"{base}-{suffix}"
+        if not _taken(candidate):
+            return candidate
+    raise ValueError(f"Exhausted collision suffixes (-2..-999) for slug base '{base}'")
 
 
 def _unique_skill_slug(conn, workspace_id: str, name: str) -> str:

--- a/agentarea-operator/tests/test_registry_sync_parsers.py
+++ b/agentarea-operator/tests/test_registry_sync_parsers.py
@@ -5,7 +5,7 @@ Pure-function tests — no DB, no K8s, no network.
 
 import pytest
 
-from registry_sync import parse_source, VALID_TYPES
+from registry_sync import _upsert_mcp_server, parse_source, VALID_TYPES
 
 
 class TestValidTypes:
@@ -106,6 +106,99 @@ class TestMCPServerParser:
             },
         )
         assert items[0]["external_id"] == "io.example/echo"
+
+    def test_standard_format_preserves_raw_spec_icons(self):
+        items = parse_source(
+            "mcp_servers",
+            {
+                "servers": [
+                    {
+                        "server": {
+                            "name": "io.example/echo",
+                            "title": "Echo",
+                            "description": "Echo server",
+                            "version": "1.2.3",
+                            "icons": [{"src": "/api/static/icons/mcp/echo.svg"}],
+                            "remotes": [{"url": "https://example.com/mcp"}],
+                            "packages": [
+                                {
+                                    "registryType": "npm",
+                                    "name": "@example/echo",
+                                    "version": "1.2.3",
+                                }
+                            ],
+                        }
+                    }
+                ]
+            },
+        )
+
+        assert [item["external_id"] for item in items] == [
+            "io.example/echo",
+            "io.example/echo/command",
+        ]
+        assert items[0]["spec"]["raw_spec"]["icons"][0]["src"] == (
+            "/api/static/icons/mcp/echo.svg"
+        )
+        assert items[1]["spec"]["raw_spec"]["icons"][0]["src"] == (
+            "/api/static/icons/mcp/echo.svg"
+        )
+
+    def test_upsert_writes_raw_spec_to_mcp_server_json_spec(self):
+        class Result:
+            def __init__(self, row=None):
+                self.row = row
+
+            def fetchone(self):
+                return self.row
+
+        class FakeConn:
+            def __init__(self):
+                self.calls = []
+
+            def execute(self, statement, params=None):
+                sql = str(statement)
+                self.calls.append((sql, params or {}))
+                if sql.startswith("SELECT id FROM mcp_servers"):
+                    return Result(None)
+                if sql.startswith("SELECT 1 FROM mcp_servers"):
+                    return Result(None)
+                return Result(None)
+
+        raw_spec = {
+            "name": "io.example/echo",
+            "icons": [{"src": "https://cdn.example.com/echo.svg"}],
+        }
+        conn = FakeConn()
+        _upsert_mcp_server(
+            conn,
+            {
+                "name": "Echo",
+                "description": "Echo server",
+                "version": "1.2.3",
+                "registry_url": "https://registry.example.com",
+                "spec": {
+                    "connection_type": "url",
+                    "url": "https://example.com/mcp",
+                    "transport": "streamable-http",
+                    "raw_spec": raw_spec,
+                },
+                "tags": ["streamable-http"],
+            },
+            "workspace-1",
+            "registry-item-1",
+        )
+
+        insert_params = next(
+            params for sql, params in conn.calls if sql.startswith("INSERT INTO mcp_servers")
+        )
+        assert insert_params["json_spec"] == (
+            '{"name": "io.example/echo", "icons": [{"src": "https://cdn.example.com/echo.svg"}]}'
+        )
+        assert insert_params["registry_url"] == "https://registry.example.com"
+        assert insert_params["rid"] == "registry-item-1"
+        assert insert_params["rurl"] == "https://example.com/mcp"
+        assert insert_params["slug"] == "echo"
 
 
 class TestSkillsParser:


### PR DESCRIPTION
## Summary
- preserve raw MCP ServerJSON in operator registry sync so mcp_servers.json_spec carries registry icons
- persist registry_url and registry_item_id on operator-created MCP server specs
- align official MCP registry parsing with remote, docker, and command package shapes

## Tests
- uv run pytest tests/test_registry_sync_parsers.py
- uv run python -m compileall registry_sync.py tests/test_registry_sync_parsers.py
- git diff --check