### PR TITLE
Add structured human input workflow

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
@@ -12,6 +13,7 @@ from agentarea_agents.application.temporal_workflow_service import (
 )
 from agentarea_api.api.deps.database import ReadDatabaseSessionDep
 from agentarea_api.api.deps.services import (
+    BaseSecretManagerDep,
     get_agent_service,
     get_event_stream_service,
     get_model_instance_service,
@@ -45,6 +47,25 @@ class A2UIActionPayload(BaseModel):
     model_config = {"extra": "forbid"}
 
 
+class InputSecretValue(BaseModel):
+    """Secret value submitted through the protected input endpoint."""
+
+    value: str = Field(..., min_length=1)
+    secret_name: str | None = Field(default=None, max_length=256)
+
+    model_config = {"extra": "forbid"}
+
+
+class TaskInputSubmission(BaseModel):
+    """Structured user input submission for a pending workflow input request."""
+
+    input_request_id: str = Field(..., min_length=1, max_length=128)
+    answers: dict[str, Any] = Field(default_factory=dict)
+    secrets: dict[str, str | InputSecretValue] = Field(default_factory=dict)
+
+    model_config = {"extra": "forbid"}
+
+
 router = APIRouter(prefix="/agents/{agent_id}/tasks", tags=["agent-tasks"])
 
 # Global tasks router (not agent-specific)
@@ -71,6 +92,17 @@ class TaskCommandPayload(BaseModel):
     budget_usd: float | None = None
     message: str | None = None
     message_id: str | None = None
+
+
+_SECRET_NAME_SAFE_RE = re.compile(r"[^A-Za-z0-9_.:/-]+")
+
+
+def _default_input_secret_name(task_id: UUID, field_name: str) -> str:
+    """Build a stable workspace secret name for a submitted input field."""
+    sanitized = _SECRET_NAME_SAFE_RE.sub("_", field_name).strip("._:/-")
+    if not sanitized:
+        sanitized = "secret"
+    return f"task-input/{task_id}/{sanitized}"
 
 
 class TaskResponse(BaseModel):
@@ -984,6 +1016,82 @@ async def send_a2ui_action(
         raise
     except Exception as e:
         logger.error(f"Failed to send A2UI action for task {task_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/{task_id}/input")
+async def submit_task_input(
+    agent_id: UUID,
+    task_id: UUID,
+    submission: TaskInputSubmission,
+    user_context: UserContextDep,
+    secret_manager: BaseSecretManagerDep,
+    agent_service: AgentService = Depends(get_agent_service),
+    workflow_task_service: TemporalWorkflowService = Depends(get_temporal_workflow_service),
+):
+    """Submit structured user input to a workflow waiting on request_user_input.
+
+    Secret values are written to the workspace secret manager at the API boundary.
+    Only secret refs are sent to Temporal/LLM context.
+    """
+    agent = await agent_service.get(agent_id)
+    if not agent:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    execution_id = f"task-{task_id}"
+
+    try:
+        status = await workflow_task_service.get_workflow_status(execution_id)
+        if status.get("status") == "unknown":
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        current_status = status.get("status", "").lower()
+        if current_status in ["completed", "failed", "cancelled"]:
+            raise HTTPException(
+                status_code=400, detail=f"Cannot submit input to task in '{current_status}' state"
+            )
+
+        secret_refs: dict[str, dict[str, str]] = {}
+        for field_name, raw_secret in submission.secrets.items():
+            if isinstance(raw_secret, InputSecretValue):
+                secret_value = raw_secret.value
+                secret_name = raw_secret.secret_name or _default_input_secret_name(
+                    task_id, field_name
+                )
+            else:
+                secret_value = str(raw_secret)
+                secret_name = _default_input_secret_name(task_id, field_name)
+
+            await secret_manager.set_secret(secret_name, secret_value)
+            secret_refs[field_name] = {
+                "secret_name": secret_name,
+                "secret_ref": f"secret:{secret_name}",
+            }
+
+        payload = {
+            "input_request_id": submission.input_request_id,
+            "answers": submission.answers,
+            "secret_refs": secret_refs,
+            "submitted_by": str(user_context.user_id),
+        }
+        success = await workflow_task_service.send_workflow_command(
+            execution_id, "submit_user_input", payload
+        )
+        if not success:
+            raise HTTPException(status_code=500, detail="Failed to submit input to workflow")
+
+        return {
+            "status": "accepted",
+            "task_id": str(task_id),
+            "input_request_id": submission.input_request_id,
+            "answer_keys": sorted(list(submission.answers.keys())),
+            "secret_keys": sorted(list(secret_refs.keys())),
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to submit input for task {task_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/inbox.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/inbox.py
@@ -20,6 +20,7 @@ router = APIRouter(prefix="/inbox", tags=["inbox"])
 
 INBOX_STATUSES = [
     "waiting_for_approval",
+    "waiting_for_input",
     "completed",
     "failed",
 ]

--- a/agentarea-platform/apps/api/agentarea_api/tools/inbox_toolset.py
+++ b/agentarea-platform/apps/api/agentarea_api/tools/inbox_toolset.py
@@ -8,7 +8,7 @@ from agentarea_agents_sdk.tools.tool_definition import toolset
 
 from .base import platform_read_context
 
-INBOX_STATUSES = ["waiting_for_approval", "completed", "failed"]
+INBOX_STATUSES = ["waiting_for_approval", "waiting_for_input", "completed", "failed"]
 
 
 @toolset(
@@ -18,7 +18,7 @@ INBOX_STATUSES = ["waiting_for_approval", "completed", "failed"]
     category="platform",
 )
 class InboxToolset(Toolset):
-    """List tasks awaiting user action (waiting_for_approval, completed, failed)."""
+    """List tasks awaiting user action (waiting_for_approval, waiting_for_input, completed, failed)."""
 
     @tool_method
     async def list(

--- a/agentarea-platform/apps/api/tests/test_task_input_api.py
+++ b/agentarea-platform/apps/api/tests/test_task_input_api.py
@@ -1,0 +1,107 @@
+"""Tests for structured task input submission."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from agentarea_api.api.deps.services import get_secret_manager
+from agentarea_api.api.v1 import agents_tasks
+from agentarea_common.auth.context import UserContext
+from agentarea_common.auth.dependencies import get_user_context
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+def _app_for(agent_service, workflow_service, secret_manager, context: UserContext) -> FastAPI:
+    app = FastAPI()
+    app.include_router(agents_tasks.router, prefix="/v1")
+
+    async def override_agent_service():
+        return agent_service
+
+    async def override_workflow_service():
+        return workflow_service
+
+    async def override_secret_manager():
+        return secret_manager
+
+    async def override_user_context():
+        return context
+
+    app.dependency_overrides[agents_tasks.get_agent_service] = override_agent_service
+    app.dependency_overrides[agents_tasks.get_temporal_workflow_service] = (
+        override_workflow_service
+    )
+    app.dependency_overrides[get_secret_manager] = override_secret_manager
+    app.dependency_overrides[get_user_context] = override_user_context
+    return app
+
+
+@pytest.mark.asyncio
+async def test_task_input_submit_stores_secrets_and_signals_refs_only():
+    agent_id = uuid4()
+    task_id = uuid4()
+    context = UserContext(user_id="user-a", workspace_id="workspace-a")
+    agent_service = SimpleNamespace(get=AsyncMock(return_value=SimpleNamespace(id=agent_id)))
+    workflow_service = SimpleNamespace(
+        get_workflow_status=AsyncMock(return_value={"status": "running"}),
+        send_workflow_command=AsyncMock(return_value=True),
+    )
+    secret_manager = SimpleNamespace(set_secret=AsyncMock())
+    app = _app_for(agent_service, workflow_service, secret_manager, context)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            f"/v1/agents/{agent_id}/tasks/{task_id}/input",
+            json={
+                "input_request_id": "input-1",
+                "answers": {"environment": "dev"},
+                "secrets": {
+                    "api_token": {
+                        "value": "raw-secret-token",
+                        "secret_name": "service/api_token",
+                    }
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["secret_keys"] == ["api_token"]
+    secret_manager.set_secret.assert_awaited_once_with("service/api_token", "raw-secret-token")
+
+    workflow_service.send_workflow_command.assert_awaited_once()
+    _, command, payload = workflow_service.send_workflow_command.await_args.args
+    assert command == "submit_user_input"
+    assert payload["answers"] == {"environment": "dev"}
+    assert payload["secret_refs"] == {
+        "api_token": {
+            "secret_name": "service/api_token",
+            "secret_ref": "secret:service/api_token",
+        }
+    }
+    assert "raw-secret-token" not in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_task_input_submit_rejects_completed_task():
+    agent_id = uuid4()
+    task_id = uuid4()
+    context = UserContext(user_id="user-a", workspace_id="workspace-a")
+    agent_service = SimpleNamespace(get=AsyncMock(return_value=SimpleNamespace(id=agent_id)))
+    workflow_service = SimpleNamespace(
+        get_workflow_status=AsyncMock(return_value={"status": "completed"}),
+        send_workflow_command=AsyncMock(return_value=True),
+    )
+    secret_manager = SimpleNamespace(set_secret=AsyncMock())
+    app = _app_for(agent_service, workflow_service, secret_manager, context)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            f"/v1/agents/{agent_id}/tasks/{task_id}/input",
+            json={"input_request_id": "input-1", "answers": {"environment": "dev"}},
+        )
+
+    assert response.status_code == 400
+    secret_manager.set_secret.assert_not_called()
+    workflow_service.send_workflow_command.assert_not_called()

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -139,6 +139,7 @@ class AgentExecutionWorkflow:
         # Stateless wrt the policy itself — pool lives in state.searchable_tool_pool.
         self._disclosure_policy: ToolDisclosurePolicy | None = None
         self._pending_escalations: dict[str, PendingEscalation] = {}
+        self._pending_input_requests: dict[str, dict[str, Any]] = {}
         # Generic message queue — queued user messages drained before each LLM call
         self._message_queue: list[dict[str, Any]] = []
         # Track if completion event has been published (to avoid double-publish at termination)
@@ -253,6 +254,7 @@ class AgentExecutionWorkflow:
             "change_model": self._handle_change_model,
             "update_budget": self._handle_update_budget,
             "queue_message": self._handle_queue_message,
+            "submit_user_input": self._handle_submit_user_input,
             "remove_message": self._handle_remove_message,
         }
         handler = handlers.get(command)
@@ -310,10 +312,36 @@ class AgentExecutionWorkflow:
                 "MessageQueued",
                 {
                     "message_id": msg_id,
-                    "content": text,
+                    "content_length": len(text),
                 },
             )
         workflow.logger.info(f"Message queued: {msg_id}")
+
+    def _handle_submit_user_input(self, payload: dict) -> None:
+        """Resolve a pending structured user-input request."""
+        input_request_id = str(payload.get("input_request_id") or "")
+        pending = self._pending_input_requests.get(input_request_id)
+        if not pending:
+            workflow.logger.warning(
+                f"submit_user_input ignored for unknown input_request_id={input_request_id!r}"
+            )
+            return
+
+        pending["resolved"] = True
+        pending["submission"] = {
+            "answers": payload.get("answers") or {},
+            "secret_refs": payload.get("secret_refs") or {},
+        }
+        if self.event_manager:
+            self.event_manager.add_event(
+                "UserInputSubmitted",
+                {
+                    "input_request_id": input_request_id,
+                    "answer_keys": sorted(list((payload.get("answers") or {}).keys())),
+                    "secret_keys": sorted(list((payload.get("secret_refs") or {}).keys())),
+                },
+            )
+        workflow.logger.info(f"User input submitted: {input_request_id}")
 
     def _handle_remove_message(self, payload: dict) -> None:
         """Remove a queued message by ID before the agent sees it."""
@@ -590,6 +618,99 @@ class AgentExecutionWorkflow:
             not in {"completion", "task_complete"}
         ]
         available_tools.insert(0, completion_tool_definition)
+
+        # request_user_input — pause the workflow until the user provides a reply.
+        available_tools.insert(
+            1,
+            {
+                "type": "function",
+                "function": {
+                    "name": "request_user_input",
+                    "description": (
+                        "Ask the user for missing information and pause this task until "
+                        "they reply. Use this instead of completion when the task cannot "
+                        "continue without user input. Optional choices may be supplied for "
+                        "single-select questions; free-text replies are allowed by default."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "question": {
+                                "type": "string",
+                                "description": (
+                                    "The exact question to show to the user for a simple "
+                                    "single-question prompt. For rich forms, use questions."
+                                ),
+                            },
+                            "options": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": (
+                                    "Optional answer choices. Omit for a free-text question."
+                                ),
+                            },
+                            "questions": {
+                                "type": "array",
+                                "description": (
+                                    "Optional structured form fields. Use this when you need "
+                                    "multiple answers, typed inputs, or secret inputs."
+                                ),
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "description": (
+                                                "Stable field identifier returned with the answer."
+                                            ),
+                                        },
+                                        "question": {
+                                            "type": "string",
+                                            "description": "Field label/question shown to the user.",
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "text",
+                                                "textarea",
+                                                "select",
+                                                "multiselect",
+                                                "boolean",
+                                                "number",
+                                                "secret",
+                                            ],
+                                            "description": (
+                                                "Input type. Use secret for API keys, tokens, "
+                                                "passwords, and session strings."
+                                            ),
+                                        },
+                                        "required": {"type": "boolean"},
+                                        "options": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                        },
+                                        "secret_name": {
+                                            "type": "string",
+                                            "description": (
+                                                "Suggested workspace secret name for secret fields."
+                                            ),
+                                        },
+                                    },
+                                    "required": ["id", "question"],
+                                },
+                            },
+                            "allow_custom_response": {
+                                "type": "boolean",
+                                "description": (
+                                    "Whether the user may provide a free-text answer outside "
+                                    "the supplied options. Defaults to true."
+                                ),
+                            },
+                        },
+                    },
+                },
+            },
+        )
 
         # recall_history — query past execution context
         available_tools.append(
@@ -1593,11 +1714,14 @@ class AgentExecutionWorkflow:
         read_output_calls: list[ToolCall] = []
         activate_source_calls: list[ToolCall] = []
         load_tools_calls: list[ToolCall] = []
+        input_calls: list[ToolCall] = []
 
         for tool_call in tool_calls:
             tool_name = tool_call.function["name"]
             if tool_name in {"completion", "task_complete"}:
                 completion_call = tool_call
+            elif tool_name == "request_user_input":
+                input_calls.append(tool_call)
             elif tool_name == "recall_history":
                 recall_calls.append(tool_call)
             elif tool_name == "read_tool_output":
@@ -1614,6 +1738,36 @@ class AgentExecutionWorkflow:
                 agent_calls.append(tool_call)
             else:
                 regular_calls.append(tool_call)
+
+        # User-input requests are exclusive: the workflow must pause and get a
+        # reply before any further side effects or final completion happen.
+        if input_calls:
+            await self._execute_request_user_input(input_calls[0])
+            skipped_calls = [
+                *input_calls[1:],
+                *recall_calls,
+                *read_output_calls,
+                *activate_source_calls,
+                *load_tools_calls,
+                *skill_calls,
+                *script_calls,
+                *agent_calls,
+                *regular_calls,
+            ]
+            for skipped in skipped_calls:
+                skipped_name = skipped.function.get("name", "unknown")
+                self.state.messages.append(
+                    Message(
+                        role="tool",
+                        content=(
+                            "Skipped because the workflow requested user input. "
+                            "Call this tool again after the user reply if it is still needed."
+                        ),
+                        tool_call_id=skipped.id,
+                        name=skipped_name,
+                    )
+                )
+            return
 
         # Run recall_history and read_tool_output calls (can run in parallel with agent calls)
         for tool_call in recall_calls:
@@ -1689,6 +1843,174 @@ class AgentExecutionWorkflow:
             start_to_close_timeout=ACTIVITY_TIMEOUT,
             retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
         )
+
+    async def _execute_request_user_input(self, tool_call: ToolCall) -> None:
+        """Pause execution until the user replies via the queue_message command."""
+        from datetime import timedelta
+
+        try:
+            tool_args = json.loads(tool_call.function["arguments"])
+        except (json.JSONDecodeError, KeyError):
+            tool_args = {}
+
+        questions = self._normalize_user_input_questions(tool_args)
+        question = str(tool_args.get("question") or "").strip()
+        if not question:
+            question = questions[0]["question"] if questions else "Please provide input."
+        allow_custom_response = bool(tool_args.get("allow_custom_response", True))
+        input_request_id = str(workflow.uuid4())
+        pending_request = {
+            "resolved": False,
+            "submission": None,
+            "questions": questions,
+        }
+        self._pending_input_requests[input_request_id] = pending_request
+
+        self.state.status = ExecutionStatus.WAITING_FOR_INPUT
+        await workflow.execute_activity(
+            Activities.UPDATE_TASK_STATUS,
+            args=[
+                UpdateTaskStatusRequest(
+                    task_id=self.state.task_id,
+                    status="waiting_for_input",
+                    workspace_id=self.state.workspace_id,
+                )
+            ],
+            start_to_close_timeout=ACTIVITY_TIMEOUT,
+            retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
+        )
+
+        self.event_manager.add_event(
+            EventTypes.HUMAN_INPUT_REQUESTED,
+            {
+                "input_request_id": input_request_id,
+                "tool_call_id": tool_call.id,
+                "iteration": self.state.current_iteration,
+                "question": question,
+                "questions": questions,
+                "allow_custom_response": allow_custom_response,
+                "input_mode": "form" if len(questions) > 1 else questions[0]["type"],
+            },
+        )
+        await self._publish_events_immediately()
+
+        try:
+            await workflow.wait_condition(
+                lambda: pending_request["resolved"],
+                timeout=timedelta(minutes=30),
+            )
+        except TimeoutError:
+            self.state.messages.append(
+                Message(
+                    role="tool",
+                    content="No user response was received before the input request timed out.",
+                    tool_call_id=tool_call.id,
+                    name="request_user_input",
+                )
+            )
+            self._pending_input_requests.pop(input_request_id, None)
+            return
+
+        submission = pending_request.get("submission") or {}
+
+        self.event_manager.add_event(
+            EventTypes.HUMAN_INPUT_RECEIVED,
+            {
+                "input_request_id": input_request_id,
+                "tool_call_id": tool_call.id,
+                "answer_keys": sorted(list((submission.get("answers") or {}).keys())),
+                "secret_keys": sorted(list((submission.get("secret_refs") or {}).keys())),
+                "iteration": self.state.current_iteration,
+            },
+        )
+        await self._publish_events_immediately()
+
+        self.state.status = ExecutionStatus.EXECUTING
+        await workflow.execute_activity(
+            Activities.UPDATE_TASK_STATUS,
+            args=[
+                UpdateTaskStatusRequest(
+                    task_id=self.state.task_id,
+                    status="running",
+                    workspace_id=self.state.workspace_id,
+                )
+            ],
+            start_to_close_timeout=ACTIVITY_TIMEOUT,
+            retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
+        )
+
+        self.state.messages.append(
+            Message(
+                role="tool",
+                content=json.dumps(
+                    {
+                        "input_request_id": input_request_id,
+                        "answers": submission.get("answers") or {},
+                        "secret_refs": submission.get("secret_refs") or {},
+                    },
+                    ensure_ascii=False,
+                ),
+                tool_call_id=tool_call.id,
+                name="request_user_input",
+            )
+        )
+        self._pending_input_requests.pop(input_request_id, None)
+
+    def _normalize_user_input_questions(self, tool_args: dict[str, Any]) -> list[dict[str, Any]]:
+        """Normalize legacy question/options and rich questions[] into form fields."""
+        raw_questions = tool_args.get("questions")
+        if isinstance(raw_questions, list) and raw_questions:
+            questions = []
+            for idx, raw in enumerate(raw_questions):
+                if not isinstance(raw, dict):
+                    continue
+                field_id = str(raw.get("id") or f"field_{idx + 1}").strip()
+                label = str(raw.get("question") or raw.get("label") or field_id).strip()
+                field_type = str(raw.get("type") or "text").strip().lower()
+                if field_type not in {
+                    "text",
+                    "textarea",
+                    "select",
+                    "multiselect",
+                    "boolean",
+                    "number",
+                    "secret",
+                }:
+                    field_type = "text"
+                options = [
+                    str(option)
+                    for option in (raw.get("options") or [])
+                    if str(option).strip()
+                ]
+                question = {
+                    "id": field_id,
+                    "question": label,
+                    "type": field_type,
+                    "required": bool(raw.get("required", True)),
+                }
+                if options:
+                    question["options"] = options
+                if field_type == "secret" and raw.get("secret_name"):
+                    question["secret_name"] = str(raw["secret_name"])
+                questions.append(question)
+            if questions:
+                return questions
+
+        question = str(tool_args.get("question") or "").strip()
+        if not question:
+            question = "Please provide the missing information so I can continue."
+        raw_options = tool_args.get("options") or []
+        options = [str(option) for option in raw_options if str(option).strip()]
+        field_type = "select" if options else "text"
+        normalized = {
+            "id": "answer",
+            "question": question,
+            "type": field_type,
+            "required": True,
+        }
+        if options:
+            normalized["options"] = options
+        return [normalized]
 
     async def _execute_mcp_tool(self, tool_call: ToolCall) -> None:
         """Execute a single MCP tool call using Pydantic models."""
@@ -3171,6 +3493,13 @@ class AgentExecutionWorkflow:
                     "resolved": e.resolved,
                 }
                 for eid, e in self._pending_escalations.items()
+            },
+            "pending_input_requests": {
+                input_id: {
+                    "resolved": bool(pending.get("resolved")),
+                    "questions": pending.get("questions") or [],
+                }
+                for input_id, pending in self._pending_input_requests.items()
             },
             "context": self.context_manager.get_status() if self.context_manager else None,
         }

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/constants.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/constants.py
@@ -83,6 +83,8 @@ class EventTypes:
     HUMAN_APPROVAL_REQUESTED: Final[str] = "HumanApprovalRequested"
     HUMAN_APPROVAL_RECEIVED: Final[str] = "HumanApprovalReceived"
     HUMAN_APPROVAL_DENIED: Final[str] = "HumanApprovalDenied"
+    HUMAN_INPUT_REQUESTED: Final[str] = "HumanInputRequested"
+    HUMAN_INPUT_RECEIVED: Final[str] = "HumanInputReceived"
 
     MODEL_CHANGED: Final[str] = "ModelChanged"
     MODEL_RESOLUTION_FALLBACK: Final[str] = "ModelResolutionFallback"
@@ -131,6 +133,7 @@ class ExecutionStatus:
     PLANNING: Final[str] = "planning"
     EXECUTING: Final[str] = "executing"
     WAITING_FOR_APPROVAL: Final[str] = "waiting_for_approval"
+    WAITING_FOR_INPUT: Final[str] = "waiting_for_input"
     BLOCKED: Final[str] = "blocked"
     TOOL_EXECUTION: Final[str] = "tool_execution"
     EVALUATING: Final[str] = "evaluating"

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/visibility.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/visibility.py
@@ -13,7 +13,12 @@ class EventVisibility:
     RESULT: Final[set[str]] = {"WorkflowCompleted", "WorkflowFailed", "WorkflowCancelled"}
 
     # Agent needs human input — shown on interactive channels
-    INTERACTION: Final[set[str]] = {"HumanApprovalRequested", "HumanApprovalReceived"}
+    INTERACTION: Final[set[str]] = {
+        "HumanApprovalRequested",
+        "HumanApprovalReceived",
+        "HumanInputRequested",
+        "HumanInputReceived",
+    }
 
     # Progress indicators — shown on concise channels
     STATUS: Final[set[str]] = {

--- a/agentarea-platform/libs/execution/tests/integration/test_workflow_signals.py
+++ b/agentarea-platform/libs/execution/tests/integration/test_workflow_signals.py
@@ -51,6 +51,8 @@ from temporalio.worker import Worker
 
 _llm_release = threading.Event()
 _published: list[dict[str, Any]] = []
+_status_updates: list[str] = []
+_request_input_llm_calls = 0
 
 
 @activity.defn(name="build_agent_config_activity")
@@ -115,6 +117,76 @@ def _mock_call_llm(request: LLMCallRequest) -> dict[str, Any]:
     }
 
 
+@activity.defn(name="call_llm_activity")
+def _mock_call_llm_request_input(request: LLMCallRequest) -> dict[str, Any]:
+    """First ask for user input, then complete after the queued reply."""
+    global _request_input_llm_calls
+    _request_input_llm_calls += 1
+    if _request_input_llm_calls == 1:
+        return {
+            "content": "",
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_input_1",
+                    "type": "function",
+                    "function": {
+                        "name": "request_user_input",
+                        "arguments": json.dumps(
+                            {
+                                "question": "Which environment should I use?",
+                                "questions": [
+                                    {
+                                        "id": "environment",
+                                        "question": "Which environment should I use?",
+                                        "type": "select",
+                                        "options": ["dev", "prod"],
+                                        "required": True,
+                                    },
+                                    {
+                                        "id": "api_token",
+                                        "question": "API token",
+                                        "type": "secret",
+                                        "secret_name": "service/api_token",
+                                        "required": True,
+                                    },
+                                ],
+                            }
+                        ),
+                    },
+                }
+            ],
+            "finish_reason": "tool_calls",
+        "cost": 0.001,
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    tool_payload = None
+    for message in request.messages:
+        if message.get("name") == "request_user_input":
+            tool_payload = json.loads(message["content"])
+            break
+    assert tool_payload is not None
+    assert tool_payload["answers"] == {"environment": "dev"}
+    assert tool_payload["secret_refs"]["api_token"]["secret_ref"] == "secret:service/api_token"
+    return {
+        "content": "",
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_done_1",
+                "type": "function",
+                "function": {
+                    "name": "completion",
+                    "arguments": json.dumps({"result": "continued with input"}),
+                },
+            }
+        ],
+        "finish_reason": "tool_calls",
+        "cost": 0.001,
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
 @activity.defn(name="execute_mcp_tool_activity")
 async def _mock_execute_mcp(request: MCPToolRequest) -> dict[str, Any]:
     return {"success": True, "result": "Mock", "tool_name": request.tool_name}
@@ -134,6 +206,7 @@ async def _mock_publish_events(request: WorkflowEventsRequest) -> WorkflowEvents
 
 @activity.defn(name="update_task_status_activity")
 async def _mock_update_status(request: UpdateTaskStatusRequest) -> bool:
+    _status_updates.append(request.status)
     return True
 
 
@@ -191,10 +264,24 @@ async def _wait_until_initialized(handle, attempts: int = 100) -> None:
     )
 
 
+async def _wait_for_status(handle, status: str, attempts: int = 100) -> None:
+    import asyncio
+
+    for _ in range(attempts):
+        state = await handle.query(AgentExecutionWorkflow.get_current_state)
+        if state.get("status") == status:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"workflow never reached {status!r}; last state={state!r}")
+
+
 @pytest.fixture(autouse=True)
 def _reset_globals():
+    global _request_input_llm_calls
     _llm_release.clear()
     _published.clear()
+    _status_updates.clear()
+    _request_input_llm_calls = 0
     yield
     # Always release on teardown so a failing test doesn't strand a worker.
     _llm_release.set()
@@ -203,6 +290,83 @@ def _reset_globals():
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_user_input_waits_for_queued_reply_then_continues():
+    """The built-in request_user_input tool pauses until structured input resumes it."""
+    env = await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter,
+    )
+    async with env:
+        task_queue = f"test-{uuid.uuid4()}"
+        activities = [
+            _mock_build_config,
+            _mock_discover_tools,
+            _mock_resolve_model,
+            _mock_call_llm_request_input,
+            _mock_execute_mcp,
+            _mock_publish_events,
+            _mock_update_status,
+        ]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            worker = Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[AgentExecutionWorkflow],
+                activities=activities,
+                activity_executor=executor,
+            )
+            async with worker:
+                handle = await env.client.start_workflow(
+                    AgentExecutionWorkflow.run,
+                    _make_request(),
+                    id=f"test-{uuid.uuid4()}",
+                    task_queue=task_queue,
+                    execution_timeout=timedelta(hours=1),
+                )
+
+                await _wait_for_status(handle, "waiting_for_input")
+                assert "waiting_for_input" in _status_updates
+                state = await handle.query(AgentExecutionWorkflow.get_current_state)
+                pending = state["pending_input_requests"]
+                assert len(pending) == 1
+                input_request_id = next(iter(pending))
+                questions = pending[input_request_id]["questions"]
+                assert questions[0]["id"] == "environment"
+                assert questions[1]["type"] == "secret"
+
+                published_types = {e.get("event_type") for e in _published}
+                assert "HumanInputRequested" in published_types, published_types
+                assert "WorkflowCompleted" not in published_types, published_types
+
+                await handle.signal(
+                    AgentExecutionWorkflow.workflow_command,
+                    args=[
+                        "submit_user_input",
+                        {
+                            "input_request_id": input_request_id,
+                            "answers": {"environment": "dev"},
+                            "secret_refs": {
+                                "api_token": {
+                                    "secret_name": "service/api_token",
+                                    "secret_ref": "secret:service/api_token",
+                                }
+                            },
+                        },
+                    ],
+                )
+
+                result = await handle.result()
+
+                assert result.success is True
+                assert result.final_response == "continued with input"
+                assert _request_input_llm_calls == 2
+                published_types = {e.get("event_type") for e in _published}
+                assert "HumanInputReceived" in published_types, published_types
+                assert "WorkflowCompleted" in published_types, published_types
+                assert "running" in _status_updates
+                assert "completed" in _status_updates
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a built-in `request_user_input` workflow tool with structured form fields and secret field support
- add `waiting_for_input`, `HumanInputRequested`, and `HumanInputReceived` flow
- add `/v1/agents/{agent_id}/tasks/{task_id}/input` to submit answers and store secret values in the workspace secret manager before signaling the workflow
- include waiting tasks in inbox surfaces

## Tests
- `uv run pytest libs/execution/tests/unit/test_policy_approval.py libs/execution/tests/integration/test_workflow_signals.py apps/api/tests/test_task_input_api.py -q`
