### PR TITLE
ci: build docker images on native arm64 runners instead of QEMU

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -44,8 +44,22 @@ on:
         required: false
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  # Build each platform on its NATIVE runner (no QEMU emulation). When pushing,
+  # each platform is pushed by digest (untagged); the merge job stitches them
+  # into the final multi-arch manifest. amd64 -> ubuntu-latest, arm64 ->
+  # ubuntu-24.04-arm (free GitHub-hosted ARM runner for public repos).
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       packages: write
       contents: read
@@ -131,7 +145,12 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Extract Docker metadata
+          # Per-arch images are pushed by digest to the primary (public) repo.
+          # The merge step then tags every target repo (incl. private mirror)
+          # from that source, so we only need the primary here.
+          echo "primary=$PUBLIC_IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata (labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -141,26 +160,176 @@ jobs:
           flavor: |
             latest=false
 
-      - name: Build and push Docker image
+      # When pushing: build the single platform and push it by digest (untagged).
+      - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        if: ${{ inputs.push }}
+        uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=${{ inputs.component }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.component }}
+          cache-from: type=gha,scope=${{ inputs.component }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.component }}-${{ matrix.arch }}
+          outputs: type=image,name=${{ steps.image.outputs.primary }},push-by-digest=true,name-canonical=true,push=true
           provenance: false
 
-      - name: Image digest
+      # When not pushing (PR / build-only validation): just build natively to
+      # validate the image compiles on each architecture. No registry needed.
+      - name: Build only (validation)
+        if: ${{ !inputs.push }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          push: false
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+          cache-from: type=gha,scope=${{ inputs.component }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.component }}-${{ matrix.arch }}
+          provenance: false
+
+      - name: Export digest
+        if: ${{ inputs.push }}
         run: |
-          if [ "${{ inputs.push }}" == "true" ]; then
-            echo "Built and pushed ${{ inputs.component }} image with digest ${{ steps.build.outputs.digest }}"
-          else
-            echo "Built ${{ inputs.component }} image (build-only, no push)"
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: ${{ inputs.push }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.component }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitch the per-architecture digests into a single multi-arch manifest with
+  # the real tags. Only runs when images were actually pushed.
+  merge:
+    if: ${{ inputs.push }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read VERSION file
+        id: version
+        run: |
+          VERSION=$(cat VERSION | tr -d '\n')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ inputs.component }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Log in to Private Registry
+        if: ${{ inputs.use-private-registry }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY_MIRROR }}
+          username: ${{ secrets.DOCKER_REGISTRY_MIRROR_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_MIRROR_PASSWORD }}
+
+      - name: Compute image paths
+        id: image
+        env:
+          INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+          INPUT_COMPONENT: ${{ inputs.component }}
+          INPUT_USE_PRIVATE_REGISTRY: ${{ inputs.use-private-registry }}
+          SECRET_REGISTRY_MIRROR: ${{ secrets.DOCKER_REGISTRY_MIRROR }}
+          SECRET_REGISTRY_PATH: ${{ secrets.DOCKER_REGISTRY_MIRROR_PATH }}
+        run: |
+          IMAGE="$INPUT_IMAGE_NAME"
+          if [ -z "$IMAGE" ]; then
+            IMAGE="agentarea-$INPUT_COMPONENT"
           fi
+
+          if [[ "$IMAGE" == *:* ]]; then
+            echo "Error: image-name must not include a tag"
+            exit 1
+          fi
+
+          if [[ "$IMAGE" == */* ]]; then
+            PUBLIC_IMAGE="$IMAGE"
+          else
+            PUBLIC_IMAGE="agentarea/$IMAGE"
+          fi
+
+          if [ "$INPUT_USE_PRIVATE_REGISTRY" = "true" ]; then
+            REGISTRY="$SECRET_REGISTRY_MIRROR"
+            REGISTRY="${REGISTRY%/}"
+
+            REGISTRY_PATH="$SECRET_REGISTRY_PATH"
+            REGISTRY_PATH="${REGISTRY_PATH#/}"
+            REGISTRY_PATH="${REGISTRY_PATH%/}"
+
+            if [ -n "$REGISTRY_PATH" ]; then
+              PRIVATE_IMAGE="$REGISTRY/$REGISTRY_PATH/$IMAGE"
+            else
+              PRIVATE_IMAGE="$REGISTRY/$IMAGE"
+            fi
+
+            {
+              echo "images<<EOF"
+              echo "$PUBLIC_IMAGE"
+              echo "$PRIVATE_IMAGE"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "images<<EOF"
+              echo "$PUBLIC_IMAGE"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "primary=$PUBLIC_IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.images }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}-{{sha}}
+          flavor: |
+            latest=false
+
+      - name: Create multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          PRIMARY_IMAGE: ${{ steps.image.outputs.primary }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${PRIMARY_IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        env:
+          PRIMARY_IMAGE: ${{ steps.image.outputs.primary }}
+        run: |
+          docker buildx imagetools inspect "${PRIMARY_IMAGE}:${{ steps.version.outputs.version }}-${{ github.sha }}"


### PR DESCRIPTION
## Problem

The frontend arm64 image build on main was failing intermittently:

```
✓ Compiled successfully in 4.3min
Finished TypeScript in 4.0min
Generating static pages (11/47) ...
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
⨯ Next.js build worker exited with code: null and signal: SIGILL
```

arm64 images were cross-built on amd64 runners via **QEMU emulation**. Next.js (Turbopack) static page generation crashes the emulator with `SIGILL` non-deterministically — compilation and TypeScript both pass, only the emulated render workers die. Retries were a coin flip (the last red run on main went green on a plain re-run).

This is an emulation defect, not a code bug — it landed on the model-badge commit by coincidence.

## Fix

Rework the reusable `docker-build-push.yml` to the canonical Docker multi-runner pattern:

- **`build`** job runs as a matrix, each platform on its **native** runner:
  - `linux/amd64` → `ubuntu-latest`
  - `linux/arm64` → `ubuntu-24.04-arm` (free GitHub-hosted ARM runner, public repo)
  Each pushes its image **by digest** (untagged); cache scoped per component+arch.
- **`merge`** job stitches the per-arch digests into the final multi-arch manifest with the real `${version}-{{sha}}` tags via `docker buildx imagetools create`.

No QEMU, faster builds, and the `SIGILL` failure mode is gone structurally.

## Compatibility

- Reusable workflow **inputs/secrets are unchanged** → no edits needed in `ci.yml` callers.
- `push: false` (PR / build-only validation) builds each arch natively and skips the merge job.
- Private-registry path preserved: merge tags every target repo from the primary digest source.
- No required status checks reference the old job name, so the rename (`build-and-push` → `build`/`merge`) is safe.

## Validation

- `actionlint` clean on the changed file.
- Affects all components (api, worker, frontend, operator, mcp-manager, mcp-runner, events) — all gain native builds.