### PR TITLE
fix(mcp): instance health by id + chore(dev): postgres 18

### DIFF
--- a/agentarea-webapp/src/app/(main)/mcp-servers/[id]/MCPInstanceDetail.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/[id]/MCPInstanceDetail.tsx
@@ -41,6 +41,13 @@ interface Props {
   memberNames?: Record<string, string>;
 }
 
+const MCP_TRANSPORT = {
+  url: "url",
+  bundle: "bundle",
+  command: "command",
+  docker: "docker",
+} as const;
+
 function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   const t = useTranslations("MCPServersPage.instanceDetail");
@@ -211,20 +218,25 @@ export default function MCPInstanceDetail({
   const derivedTransportType = ((): string => {
     const fromInstance = instance.json_spec?.type as string | undefined;
     if (fromInstance) return fromInstance;
-    if (serverSpec?.remote_url) return "url";
+    if (serverSpec?.remote_url) return MCP_TRANSPORT.url;
     const specJson = (serverSpec as any)?.json_spec as
       | Record<string, any>
       | undefined;
     if (specJson?.type) return specJson.type as string;
-    if ((serverSpec as any)?.cmd) return "command";
-    return "docker";
+    if ((serverSpec as any)?.cmd) return MCP_TRANSPORT.command;
+    return MCP_TRANSPORT.docker;
   })();
   const jsonSpecType = derivedTransportType;
+  const managerServiceName = instance.id;
   useEffect(() => {
-    if (jsonSpecType === "url" || jsonSpecType === "bundle") return;
-    if (isVerificationSucceeded && instance.name) {
+    if (
+      jsonSpecType === MCP_TRANSPORT.url ||
+      jsonSpecType === MCP_TRANSPORT.bundle
+    )
+      return;
+    if (isVerificationSucceeded && managerServiceName) {
       setIsLoadingUrl(true);
-      getMCPInstanceHealth(instance.name)
+      getMCPInstanceHealth(managerServiceName)
         .then(({ health_check }) => {
           if (health_check?.details?.proxy_url) {
             setConnectionUrl(health_check.details.proxy_url);
@@ -242,7 +254,7 @@ export default function MCPInstanceDetail({
         .catch(console.error)
         .finally(() => setIsLoadingUrl(false));
     }
-  }, [isVerificationSucceeded, instance.name, jsonSpecType]);
+  }, [isVerificationSucceeded, managerServiceName, jsonSpecType]);
 
   const plainEnvVars = (instance.json_spec?.environment ?? {}) as Record<
     string,
@@ -264,9 +276,9 @@ export default function MCPInstanceDetail({
 
   // Determine MCP type (uses derivedTransportType — see above)
   const specType = derivedTransportType;
-  const isUrlType = specType === "url";
-  const isCommandType = specType === "command";
-  const isBundleType = specType === "bundle";
+  const isUrlType = specType === MCP_TRANSPORT.url;
+  const isCommandType = specType === MCP_TRANSPORT.command;
+  const isBundleType = specType === MCP_TRANSPORT.bundle;
   const bundleMembers = (instance.json_spec?.members ?? []) as string[];
 
   // Command-type fields

--- a/agentarea-webapp/src/lib/api-factory.ts
+++ b/agentarea-webapp/src/lib/api-factory.ts
@@ -766,7 +766,7 @@ export function createApiClient(client: Client) {
     },
 
     getMCPInstanceHealth: async (
-      instanceName: string
+      managerServiceName: string
     ): Promise<{
       health_check: {
         service_name: string;
@@ -795,7 +795,7 @@ export function createApiClient(client: Client) {
         }
         const healthData = data as any;
         const healthCheck = healthData.health_checks?.find(
-          (check: any) => check.service_name === instanceName
+          (check: any) => check.service_name === managerServiceName
         );
         return { health_check: healthCheck || null };
       } catch (error) {

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -184,13 +184,13 @@ services:
       start_period: 30s
 
   db:
-    image: postgres:15
+    image: postgres:18
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=postgres  # Maintenance DB; postgres_init creates the main app DB plus aux DBs
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s


### PR DESCRIPTION
Two small unrelated dev/frontend fixes that were sitting uncommitted.

## fix(mcp): look up instance health by id, not name
The MCP manager registers its health-check service under the instance **id**, so `getMCPInstanceHealth` now resolves by `instance.id` (`managerServiceName`) instead of `instance.name`. Also extracts `MCP_TRANSPORT` constants to drop stringly-typed transport checks.

Files: `agentarea-webapp/src/lib/api-factory.ts`, `agentarea-webapp/src/app/(main)/mcp-servers/[id]/MCPInstanceDetail.tsx`

## chore(dev): upgrade dev postgres to 18
`postgres:15` → `postgres:18` in `docker-compose.dev.yaml`. The v18 image moves the `VOLUME` to `/var/lib/postgresql` (PGDATA now lives in `/var/lib/postgresql/18/docker`), so the named volume is mounted there.

⚠️ **Major version bump** — existing local `pg15` volumes are incompatible with pg18. Devs must recreate the `postgres_data` volume (`docker compose -f docker-compose.dev.yaml down -v`) after pulling.

## Validation
- `eslint` clean on both changed frontend files.
- `next build` compiles with these changes.