### PR TITLE
Add bundle import (analyze + install)

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/bundles.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/bundles.py
@@ -1,0 +1,105 @@
+"""Bundle import endpoints: analyze a source and install a bundle."""
+
+from typing import Annotated, Any
+
+from agentarea_api.api.deps.services import (
+    AgentServiceDep,
+    MCPServerInstanceServiceDep,
+    MCPServerServiceDep,
+    SkillServiceDep,
+    get_trigger_service,
+)
+from agentarea_bundles.application.analyzer import BundleParseError
+from agentarea_bundles.application.installer import BundleInstallError
+from agentarea_bundles.application.service import BundleService
+from agentarea_bundles.schemas.bundle import Bundle
+from agentarea_bundles.schemas.preview import ImportPreview
+from agentarea_bundles.schemas.result import InstallResult
+from agentarea_common.base import RepositoryFactoryDep
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/bundles", tags=["bundles"])
+
+
+# ============================================================================
+# Service Dependency
+# ============================================================================
+
+
+async def get_bundle_service(
+    repository_factory: RepositoryFactoryDep,
+    agent_service: AgentServiceDep,
+    mcp_server_service: MCPServerServiceDep,
+    mcp_instance_service: MCPServerInstanceServiceDep,
+    skill_service: SkillServiceDep,
+    trigger_service: Annotated[Any, Depends(get_trigger_service)],
+) -> BundleService:
+    """Compose BundleService from the existing domain services."""
+    return BundleService(
+        repository_factory=repository_factory,
+        agent_service=agent_service,
+        mcp_server_service=mcp_server_service,
+        mcp_instance_service=mcp_instance_service,
+        skill_service=skill_service,
+        trigger_service=trigger_service,
+    )
+
+
+BundleServiceDep = Annotated[BundleService, Depends(get_bundle_service)]
+
+
+# ============================================================================
+# Request models
+# ============================================================================
+
+
+class AnalyzeRequest(BaseModel):
+    """Analyze raw bundle source (YAML or JSON) into an import preview."""
+
+    source: str = Field(min_length=1, description="Raw bundle source text (YAML or JSON).")
+
+
+class InstallRequest(BaseModel):
+    """Install a (previously analyzed, possibly edited) canonical bundle."""
+
+    bundle: Bundle
+    setup_values: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Values for the bundle's setup fields, keyed by setup field key.",
+    )
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.post("/analyze", response_model=ImportPreview)
+async def analyze_bundle(
+    body: AnalyzeRequest,
+    service: BundleServiceDep,
+) -> ImportPreview:
+    """Parse and analyze a bundle source, returning a non-destructive preview."""
+    try:
+        return await service.analyze_text(body.source)
+    except BundleParseError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/install", response_model=InstallResult)
+async def install_bundle(
+    body: InstallRequest,
+    service: BundleServiceDep,
+) -> InstallResult:
+    """Install a canonical bundle: MCP instances, skills, agents and automations."""
+    try:
+        return await service.install(body.bundle, body.setup_values)
+    except BundleInstallError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": str(exc),
+                "issues": [i.model_dump(mode="json") for i in exc.issues],
+            },
+        ) from exc

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/router.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/router.py
@@ -16,6 +16,7 @@ from . import (
     agents_well_known,
     api_keys,
     audit,
+    bundles,
     dashboard,
     files,
     governance,
@@ -98,6 +99,9 @@ protected_v1_router.include_router(workspace_invitations.router)
 
 # Skills management - PROTECTED
 protected_v1_router.include_router(skills.router)
+
+# Bundle import (analyze + install) - PROTECTED
+protected_v1_router.include_router(bundles.router)
 
 # MCP Auth Configs - PROTECTED
 protected_v1_router.include_router(mcp_auth_configs.router)

--- a/agentarea-platform/apps/api/alembic/env.py
+++ b/agentarea-platform/apps/api/alembic/env.py
@@ -22,6 +22,12 @@ except ImportError:
     # Governance library not yet installed - skip for now
     pass
 
+try:
+    from agentarea_bundles.domain.models import InstalledBundle  # noqa: F401
+except ImportError:
+    # Bundles library not yet installed - skip for now
+    pass
+
 config = context.config
 
 if config.config_file_name is not None:

--- a/agentarea-platform/apps/api/alembic/versions/2026_06_03_0001_add_installed_bundles.py
+++ b/agentarea-platform/apps/api/alembic/versions/2026_06_03_0001_add_installed_bundles.py
@@ -1,0 +1,69 @@
+"""add installed_bundles
+
+Provenance + idempotency record for installed agent packages. Stores the
+fully-normalized canonical package (jsonb) keyed by name within a workspace.
+
+Revision ID: 20260603_installed_bundles
+Revises: 011_mcp_instance_spec_not_null
+Create Date: 2026-06-03
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260603_installed_bundles"
+down_revision: str | None = "011_mcp_instance_spec_not_null"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "installed_bundles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("workspace_id", sa.String(255), nullable=False),
+        sa.Column("created_by", sa.String(255), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("schema_version", sa.String(32), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False, server_default="installed"),
+        sa.Column("canonical", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("install_result", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.create_index(
+        "ix_installed_bundles_workspace_id",
+        "installed_bundles",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_installed_bundles_created_by",
+        "installed_bundles",
+        ["created_by"],
+    )
+    op.create_index(
+        "ix_installed_bundles_workspace_name",
+        "installed_bundles",
+        ["workspace_id", "name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_installed_bundles_workspace_name",
+        table_name="installed_bundles",
+    )
+    op.drop_index(
+        "ix_installed_bundles_created_by",
+        table_name="installed_bundles",
+    )
+    op.drop_index(
+        "ix_installed_bundles_workspace_id",
+        table_name="installed_bundles",
+    )
+    op.drop_table("installed_bundles")

--- a/agentarea-platform/apps/api/pyproject.toml
+++ b/agentarea-platform/apps/api/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "agentarea-openapi",
     "agentarea-projects",
     "agentarea-wallet",
+    "agentarea-bundles",
     "alembic>=1.15.2",
     "uvicorn>=0.34.0",
     "fastapi>=0.104.0",
@@ -47,6 +48,7 @@ agentarea-triggers = { workspace = true }
 agentarea-openapi = { workspace = true }
 agentarea-projects = { workspace = true }
 agentarea-wallet = { workspace = true }
+agentarea-bundles = { workspace = true }
 
 [project.scripts]
 agentarea-api = "agentarea_api.cli:cli"

--- a/agentarea-platform/libs/bundles/agentarea_bundles/__init__.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/__init__.py
@@ -1,0 +1,43 @@
+"""Agent package import for AgentArea.
+
+A canonical, declarative package format that bundles agents, skills, MCP
+servers and cron automations. Packages are *analyzed* into an
+``ImportPreview`` (what will be created, what the user must provide, what is
+unsupported) and then *installed* by composing the existing domain services.
+"""
+
+from agentarea_bundles.schemas.bundle import (
+    SCHEMA_VERSION,
+    Bundle,
+    BundleAgent,
+    BundleAutomation,
+    BundleMcp,
+    BundleSkill,
+    SetupField,
+    SetupFieldType,
+)
+from agentarea_bundles.schemas.preview import (
+    EntityKind,
+    EntityStatus,
+    ImportPreview,
+    IssueSeverity,
+    PreviewEntity,
+    PreviewIssue,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Bundle",
+    "BundleAgent",
+    "BundleAutomation",
+    "BundleMcp",
+    "BundleSkill",
+    "EntityKind",
+    "EntityStatus",
+    "ImportPreview",
+    "IssueSeverity",
+    "PreviewEntity",
+    "PreviewIssue",
+    "SetupField",
+    "SetupFieldType",
+]

--- a/agentarea-platform/libs/bundles/agentarea_bundles/application/__init__.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application services for agent-package import."""

--- a/agentarea-platform/libs/bundles/agentarea_bundles/application/analyzer.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/application/analyzer.py
@@ -1,0 +1,337 @@
+"""Analyze a package source into an :class:`ImportPreview`.
+
+Parsing (text -> :class:`Bundle`) is deterministic and pure. Analysis
+adds structural validation (key references, unsupported MCPs, setup
+placeholders) and per-entity existence status. Existence checks are delegated
+to an :class:`ExistenceChecker` so the analyzer stays decoupled from the
+repository layer and is trivially testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import yaml
+from pydantic import ValidationError
+
+from agentarea_bundles.schemas.bundle import Bundle, BundleMcp, setup_refs
+from agentarea_bundles.schemas.preview import (
+    EntityKind,
+    EntityStatus,
+    ImportPreview,
+    IssueSeverity,
+    PreviewEntity,
+    PreviewIssue,
+)
+
+# Commands we can run inside the mcp-bridge container. Anything else (an
+# absolute path, a ${CLAUDE_PLUGIN_ROOT}-relative binary shipped with a plugin)
+# cannot be provisioned in our container runtime and is marked unsupported.
+_SUPPORTED_COMMANDS = {"npx", "uvx", "uv", "python", "python3", "node", "bunx", "deno"}
+
+
+class BundleParseError(ValueError):
+    """Raised when source text is not a valid agent package."""
+
+
+class ExistenceChecker(Protocol):
+    """Workspace existence checks used to compute per-entity status."""
+
+    async def agent_exists(self, name: str) -> bool: ...
+    async def mcp_instance_exists(self, name: str) -> bool: ...
+    async def skill_exists(self, name: str) -> bool: ...
+    async def trigger_exists(self, name: str) -> bool: ...
+
+
+class _NoExistence:
+    """Default checker: nothing pre-exists (everything will be created)."""
+
+    async def agent_exists(self, name: str) -> bool:
+        return False
+
+    async def mcp_instance_exists(self, name: str) -> bool:
+        return False
+
+    async def skill_exists(self, name: str) -> bool:
+        return False
+
+    async def trigger_exists(self, name: str) -> bool:
+        return False
+
+
+def parse_bundle(text: str) -> Bundle:
+    """Parse YAML or JSON source text into a canonical :class:`Bundle`.
+
+    YAML is a superset of JSON, so a single loader handles both authoring forms.
+    """
+    if not text or not text.strip():
+        raise BundleParseError("empty package source")
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise BundleParseError(f"invalid YAML/JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise BundleParseError("package must be a mapping at the top level")
+    try:
+        return Bundle.model_validate(data)
+    except ValidationError as exc:
+        raise BundleParseError(str(exc)) from exc
+
+
+def mcp_is_unsupported(mcp: BundleMcp) -> str | None:
+    """Return a reason string if this MCP cannot run in our runtime, else None."""
+    spec = mcp.json_spec or {}
+    spec_type = spec.get("type")
+    if spec_type != "command":
+        return None  # docker/url always supported
+    command = (spec.get("command") or "").strip()
+    if not command:
+        return "command MCP has no 'command'"
+    if "${CLAUDE_PLUGIN_ROOT}" in command or "$CLAUDE_PLUGIN_ROOT" in command:
+        return "command references a plugin-local binary (${CLAUDE_PLUGIN_ROOT}); not available in the container runtime"
+    if command.startswith(("/", "./", "../")):
+        return f"command '{command}' is a local path; only published runtimes ({', '.join(sorted(_SUPPORTED_COMMANDS))}) are supported"
+    if command not in _SUPPORTED_COMMANDS:
+        return f"command '{command}' is not a supported runtime ({', '.join(sorted(_SUPPORTED_COMMANDS))})"
+    return None
+
+
+class BundleAnalyzer:
+    """Builds an :class:`ImportPreview` from an :class:`Bundle`."""
+
+    def __init__(self, existence: ExistenceChecker | None = None) -> None:
+        self._existence = existence or _NoExistence()
+
+    async def analyze(self, package: Bundle) -> ImportPreview:
+        issues: list[PreviewIssue] = []
+        entities: list[PreviewEntity] = []
+
+        setup_keys = {f.key for f in package.setup}
+        mcp_keys = {m.key for m in package.mcps}
+        skill_keys = {s.key for s in package.skills}
+        agent_keys = {a.key for a in package.agents}
+
+        self._check_duplicate_keys(package, issues)
+        unsupported_mcp_keys = self._analyze_mcps(package, setup_keys, entities, issues)
+        await self._analyze_skills(package, entities)
+        self._analyze_agents(
+            package, mcp_keys, skill_keys, setup_keys, unsupported_mcp_keys, issues
+        )
+        await self._populate_agent_entities(package, entities)
+        await self._analyze_automations(package, agent_keys, entities, issues)
+
+        installable = not any(i.severity is IssueSeverity.BLOCK for i in issues)
+        return ImportPreview(
+            bundle=package,
+            setup=package.setup,
+            entities=entities,
+            issues=issues,
+            installable=installable,
+        )
+
+    # -- sections -----------------------------------------------------------
+
+    def _check_duplicate_keys(self, package: Bundle, issues: list[PreviewIssue]) -> None:
+        for label, items in (
+            ("setup", package.setup),
+            ("mcp", package.mcps),
+            ("skill", package.skills),
+            ("agent", package.agents),
+            ("automation", package.automations),
+        ):
+            seen: set[str] = set()
+            for item in items:
+                if item.key in seen:
+                    issues.append(
+                        PreviewIssue(
+                            severity=IssueSeverity.BLOCK,
+                            message=f"duplicate {label} key '{item.key}'",
+                            entity_key=item.key,
+                        )
+                    )
+                seen.add(item.key)
+
+    def _analyze_mcps(
+        self,
+        package: Bundle,
+        setup_keys: set[str],
+        entities: list[PreviewEntity],
+        issues: list[PreviewIssue],
+    ) -> set[str]:
+        unsupported: set[str] = set()
+        for mcp in package.mcps:
+            reason = mcp_is_unsupported(mcp)
+            # bindings must reference declared setup fields
+            for env_name, ref in mcp.bindings.items():
+                refs = setup_refs(ref)
+                if not refs:
+                    issues.append(
+                        PreviewIssue(
+                            severity=IssueSeverity.BLOCK,
+                            message=f"mcp '{mcp.key}' binding '{env_name}' must reference ${{setup.<key>}}",
+                            entity_key=mcp.key,
+                        )
+                    )
+                for key in refs:
+                    if key not in setup_keys:
+                        issues.append(
+                            PreviewIssue(
+                                severity=IssueSeverity.BLOCK,
+                                message=f"mcp '{mcp.key}' binding references unknown setup field '{key}'",
+                                entity_key=mcp.key,
+                            )
+                        )
+            if reason:
+                unsupported.add(mcp.key)
+                entities.append(
+                    PreviewEntity(
+                        kind=EntityKind.MCP,
+                        key=mcp.key,
+                        name=mcp.name,
+                        status=EntityStatus.UNSUPPORTED,
+                        detail=reason,
+                    )
+                )
+                issues.append(
+                    PreviewIssue(
+                        severity=IssueSeverity.WARN,
+                        message=f"mcp '{mcp.key}' will be skipped: {reason}",
+                        entity_key=mcp.key,
+                    )
+                )
+            else:
+                entities.append(
+                    PreviewEntity(
+                        kind=EntityKind.MCP,
+                        key=mcp.key,
+                        name=mcp.name,
+                        status=EntityStatus.WILL_CREATE,  # refined for existence below
+                    )
+                )
+        return unsupported
+
+    async def _analyze_skills(self, package: Bundle, entities: list[PreviewEntity]) -> None:
+        for skill in package.skills:
+            exists = await self._existence.skill_exists(skill.name)
+            entities.append(
+                PreviewEntity(
+                    kind=EntityKind.SKILL,
+                    key=skill.key,
+                    name=skill.name,
+                    status=EntityStatus.ALREADY_EXISTS if exists else EntityStatus.WILL_CREATE,
+                )
+            )
+
+    def _analyze_agents(
+        self,
+        package: Bundle,
+        mcp_keys: set[str],
+        skill_keys: set[str],
+        setup_keys: set[str],
+        unsupported_mcp_keys: set[str],
+        issues: list[PreviewIssue],
+    ) -> None:
+        for agent in package.agents:
+            for ref in agent.mcps:
+                if ref not in mcp_keys:
+                    issues.append(
+                        PreviewIssue(
+                            severity=IssueSeverity.BLOCK,
+                            message=f"agent '{agent.key}' references unknown mcp '{ref}'",
+                            entity_key=agent.key,
+                        )
+                    )
+                elif ref in unsupported_mcp_keys:
+                    issues.append(
+                        PreviewIssue(
+                            severity=IssueSeverity.WARN,
+                            message=f"agent '{agent.key}' depends on unsupported mcp '{ref}'; it will be created without that tool",
+                            entity_key=agent.key,
+                        )
+                    )
+            for ref in agent.skills:
+                if ref not in skill_keys:
+                    issues.append(
+                        PreviewIssue(
+                            severity=IssueSeverity.BLOCK,
+                            message=f"agent '{agent.key}' references unknown skill '{ref}'",
+                            entity_key=agent.key,
+                        )
+                    )
+            if not agent.model:
+                issues.append(
+                    PreviewIssue(
+                        severity=IssueSeverity.BLOCK,
+                        message=f"agent '{agent.key}' has no model",
+                        entity_key=agent.key,
+                    )
+                )
+            else:
+                for key in setup_refs(agent.model):
+                    if key not in setup_keys:
+                        issues.append(
+                            PreviewIssue(
+                                severity=IssueSeverity.BLOCK,
+                                message=f"agent '{agent.key}' model references unknown setup field '{key}'",
+                                entity_key=agent.key,
+                            )
+                        )
+
+    async def _populate_agent_entities(
+        self, package: Bundle, entities: list[PreviewEntity]
+    ) -> None:
+        for agent in package.agents:
+            exists = await self._existence.agent_exists(agent.name)
+            entities.append(
+                PreviewEntity(
+                    kind=EntityKind.AGENT,
+                    key=agent.key,
+                    name=agent.name,
+                    status=EntityStatus.ALREADY_EXISTS if exists else EntityStatus.WILL_CREATE,
+                )
+            )
+
+    async def _analyze_automations(
+        self,
+        package: Bundle,
+        agent_keys: set[str],
+        entities: list[PreviewEntity],
+        issues: list[PreviewIssue],
+    ) -> None:
+        for auto in package.automations:
+            if auto.agent not in agent_keys:
+                issues.append(
+                    PreviewIssue(
+                        severity=IssueSeverity.BLOCK,
+                        message=f"automation '{auto.key}' references unknown agent '{auto.agent}'",
+                        entity_key=auto.key,
+                    )
+                )
+            exists = await self._existence.trigger_exists(auto.key)
+            entities.append(
+                PreviewEntity(
+                    kind=EntityKind.AUTOMATION,
+                    key=auto.key,
+                    name=auto.key,
+                    status=EntityStatus.ALREADY_EXISTS if exists else EntityStatus.WILL_CREATE,
+                    detail=f"cron '{auto.cron}' ({auto.timezone}), enabled={auto.enabled}",
+                )
+            )
+
+
+def required_setup_errors(package: Bundle, setup_values: dict[str, Any]) -> list[PreviewIssue]:
+    """Block issues for required setup fields missing a value (checked at install)."""
+    issues: list[PreviewIssue] = []
+    for field in package.setup:
+        if not field.required:
+            continue
+        value = setup_values.get(field.key, field.default)
+        if value is None or (isinstance(value, str) and value.strip() == ""):
+            issues.append(
+                PreviewIssue(
+                    severity=IssueSeverity.BLOCK,
+                    message=f"required setup field '{field.key}' is missing",
+                    entity_key=field.key,
+                )
+            )
+    return issues

--- a/agentarea-platform/libs/bundles/agentarea_bundles/application/installer.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/application/installer.py
@@ -1,0 +1,387 @@
+"""Install orchestrator.
+
+Decomposes an :class:`Bundle` into calls against the existing domain
+services, in dependency order:
+
+    setup values -> MCP instances -> skills -> agents -> cron automations
+
+The installer never re-implements domain logic (secret storage, scheduling,
+tool wiring) — it composes the services that already own it. It is idempotent
+by entity name: re-running after a partial failure reuses what already exists
+rather than creating duplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from agentarea_bundles.application.analyzer import mcp_is_unsupported, required_setup_errors
+from agentarea_bundles.schemas.bundle import (
+    Bundle,
+    BundleMcp,
+    SetupFieldType,
+    resolve_placeholders,
+    setup_refs,
+)
+from agentarea_bundles.schemas.preview import EntityKind
+from agentarea_bundles.schemas.result import (
+    InstallAction,
+    InstalledEntity,
+    InstallResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BundleInstallError(Exception):
+    """Raised when a package cannot be installed (e.g. missing required setup)."""
+
+    def __init__(self, message: str, issues: list[Any] | None = None) -> None:
+        super().__init__(message)
+        self.issues = issues or []
+
+
+def _transport_fields(json_spec: dict[str, Any]) -> dict[str, Any]:
+    """Extract the runtime transport portion of a package MCP json_spec."""
+    spec_type = json_spec.get("type")
+    out: dict[str, Any] = {"type": spec_type}
+    if spec_type == "command":
+        out["command"] = json_spec.get("command")
+        if json_spec.get("args"):
+            out["args"] = list(json_spec["args"])
+    elif spec_type == "docker":
+        out["image"] = json_spec.get("image")
+    elif spec_type == "url":
+        out["endpoint_url"] = json_spec.get("endpoint_url") or json_spec.get("url")
+    return out
+
+
+class BundleInstaller:
+    """Orchestrates creation of package entities via existing services."""
+
+    def __init__(
+        self,
+        *,
+        mcp_server_service: Any,
+        mcp_instance_service: Any,
+        skill_service: Any,
+        skill_repository: Any,
+        agent_service: Any,
+        agent_repository: Any,
+        trigger_service: Any,
+        trigger_repository: Any,
+        user_context: Any,
+    ) -> None:
+        self._mcp_server_service = mcp_server_service
+        self._mcp_instance_service = mcp_instance_service
+        self._skill_service = skill_service
+        self._skill_repository = skill_repository
+        self._agent_service = agent_service
+        self._agent_repository = agent_repository
+        self._trigger_service = trigger_service
+        self._trigger_repository = trigger_repository
+        self._user_context = user_context
+
+    async def install(self, package: Bundle, setup_values: dict[str, Any]) -> InstallResult:
+        # Block on missing required setup before touching anything.
+        block = required_setup_errors(package, setup_values)
+        if block:
+            raise BundleInstallError(
+                "package is not installable: missing required setup", issues=block
+            )
+
+        result = InstallResult(bundle_name=package.name)
+
+        mcp_tool_names = await self._install_mcps(package, setup_values, result)
+        skill_ids = await self._install_skills(package, result)
+        agent_ids = await self._install_agents(
+            package, setup_values, mcp_tool_names, skill_ids, result
+        )
+        await self._install_automations(package, agent_ids, result)
+        return result
+
+    # -- MCP ----------------------------------------------------------------
+
+    async def _install_mcps(
+        self, package: Bundle, setup_values: dict[str, Any], result: InstallResult
+    ) -> dict[str, str]:
+        """Returns {package mcp key -> instance name to use in agent tools}."""
+        from agentarea_mcp.schemas.dto import MCPServerCreate, MCPServerInstanceCreate
+
+        tool_names: dict[str, str] = {}
+        for mcp in package.mcps:
+            reason = mcp_is_unsupported(mcp)
+            if reason:
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.MCP,
+                        key=mcp.key,
+                        name=mcp.name,
+                        action=InstallAction.SKIPPED,
+                        detail=reason,
+                    )
+                )
+                continue
+
+            existing = await self._mcp_instance_service.get_by_name(mcp.name)
+            if existing:
+                tool_names[mcp.key] = mcp.name
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.MCP,
+                        key=mcp.key,
+                        name=mcp.name,
+                        action=InstallAction.REUSED,
+                        id=str(existing.id),
+                    )
+                )
+                continue
+
+            transport = _transport_fields(mcp.json_spec)
+            spec_kwargs: dict[str, Any] = {
+                "name": mcp.name,
+                "description": f"Imported from package '{package.name}'",
+                "env_schema": self._build_env_schema(mcp, package),
+                "json_spec": transport,
+            }
+            if transport["type"] == "command":
+                command = transport.get("command")
+                spec_kwargs["cmd"] = [command, *transport.get("args", [])] if command else None
+            elif transport["type"] == "docker":
+                spec_kwargs["docker_image_url"] = transport.get("image")
+            elif transport["type"] == "url":
+                spec_kwargs["remote_url"] = transport.get("endpoint_url")
+
+            spec = await self._mcp_server_service.create_mcp_server(MCPServerCreate(**spec_kwargs))
+
+            target = "headers" if transport["type"] == "url" else "environment"
+            resolved = {
+                env_name: resolve_placeholders(ref, setup_values)
+                for env_name, ref in mcp.bindings.items()
+            }
+            instance_json: dict[str, Any] = {"type": transport["type"]}
+            if resolved:
+                instance_json[target] = resolved
+
+            instance = await self._mcp_instance_service.create_instance(
+                MCPServerInstanceCreate(
+                    name=mcp.name,
+                    server_spec_id=str(spec.id),
+                    json_spec=instance_json,
+                )
+            )
+            if instance is None:
+                raise BundleInstallError(f"failed to create MCP instance '{mcp.name}'")
+
+            tool_names[mcp.key] = mcp.name
+            result.entities.append(
+                InstalledEntity(
+                    kind=EntityKind.MCP,
+                    key=mcp.key,
+                    name=mcp.name,
+                    action=InstallAction.CREATED,
+                    id=str(instance.id),
+                )
+            )
+        return tool_names
+
+    def _build_env_schema(self, mcp: BundleMcp, package: Bundle) -> list[dict[str, Any]]:
+        """Build the spec env_schema, flagging secrets by the setup field type.
+
+        We do not rely on the MCP service's name-based secret heuristic — the
+        package already declares which inputs are secrets via SetupField.type.
+        """
+        env_schema: list[dict[str, Any]] = []
+        for env_name, ref in mcp.bindings.items():
+            refs = setup_refs(ref)
+            field = package.setup_field(refs[0]) if refs else None
+            is_secret = bool(field and field.type is SetupFieldType.SECRET)
+            env_schema.append(
+                {
+                    "name": env_name,
+                    "description": f"{env_name} for {mcp.name}",
+                    "isSecret": is_secret,
+                }
+            )
+        return env_schema
+
+    # -- skills -------------------------------------------------------------
+
+    async def _install_skills(self, package: Bundle, result: InstallResult) -> dict[str, UUID]:
+        """Returns {package skill key -> skill id}."""
+        from agentarea_agents.schemas.skills_dto import SkillCreateFromContent
+
+        skill_ids: dict[str, UUID] = {}
+        for skill in package.skills:
+            existing = await self._skill_repository.get_by_name(skill.name)
+            if existing:
+                skill_ids[skill.key] = existing.id
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.SKILL,
+                        key=skill.key,
+                        name=skill.name,
+                        action=InstallAction.REUSED,
+                        id=str(existing.id),
+                    )
+                )
+                continue
+
+            if skill.source_type != "content":
+                # github import is analyzed/declared but deferred for v0.1.0 install.
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.SKILL,
+                        key=skill.key,
+                        name=skill.name,
+                        action=InstallAction.SKIPPED,
+                        detail=f"source_type '{skill.source_type}' install not yet supported",
+                    )
+                )
+                continue
+
+            created = await self._skill_service.create_from_content(
+                SkillCreateFromContent(
+                    content=skill.content or "",
+                    name=skill.name,
+                    description=None,
+                )
+            )
+            skill_ids[skill.key] = created.id
+            result.entities.append(
+                InstalledEntity(
+                    kind=EntityKind.SKILL,
+                    key=skill.key,
+                    name=skill.name,
+                    action=InstallAction.CREATED,
+                    id=str(created.id),
+                )
+            )
+        return skill_ids
+
+    # -- agents -------------------------------------------------------------
+
+    async def _install_agents(
+        self,
+        package: Bundle,
+        setup_values: dict[str, Any],
+        mcp_tool_names: dict[str, str],
+        skill_ids: dict[str, UUID],
+        result: InstallResult,
+    ) -> dict[str, UUID]:
+        """Returns {package agent key -> agent id}."""
+        from agentarea_agents.schemas.dto import AgentCreate
+        from agentarea_agents.schemas.import_export import ToolConfigYAML
+
+        agent_ids: dict[str, UUID] = {}
+        for agent in package.agents:
+            existing = await self._agent_repository.get_agent_by_name(agent.name)
+            if existing:
+                agent_ids[agent.key] = existing.id
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.AGENT,
+                        key=agent.key,
+                        name=agent.name,
+                        action=InstallAction.REUSED,
+                        id=str(existing.id),
+                    )
+                )
+                continue
+
+            tools = [
+                ToolConfigYAML(type="mcp", name=mcp_tool_names[ref])
+                for ref in agent.mcps
+                if ref in mcp_tool_names  # unsupported MCPs were skipped
+            ]
+            attached_skill_ids = [skill_ids[ref] for ref in agent.skills if ref in skill_ids]
+            model_id = resolve_placeholders(agent.model or "", setup_values)
+
+            created = await self._agent_service.create_agent(
+                AgentCreate(
+                    name=agent.name,
+                    description="",
+                    instruction=agent.instruction,
+                    model_id=model_id,
+                    tools=tools or None,
+                    skill_ids=attached_skill_ids or None,
+                )
+            )
+            agent_ids[agent.key] = created.id
+            result.entities.append(
+                InstalledEntity(
+                    kind=EntityKind.AGENT,
+                    key=agent.key,
+                    name=agent.name,
+                    action=InstallAction.CREATED,
+                    id=str(created.id),
+                )
+            )
+        return agent_ids
+
+    # -- automations --------------------------------------------------------
+
+    async def _install_automations(
+        self, package: Bundle, agent_ids: dict[str, UUID], result: InstallResult
+    ) -> None:
+        from agentarea_triggers.schemas.dto import TriggerCreate
+
+        existing_names = {t.name for t in await self._trigger_repository.list_all()}
+        for auto in package.automations:
+            trigger_name = f"{package.name}:{auto.key}"
+            agent_id = agent_ids.get(auto.agent)
+            if agent_id is None:
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.AUTOMATION,
+                        key=auto.key,
+                        name=trigger_name,
+                        action=InstallAction.SKIPPED,
+                        detail=f"agent '{auto.agent}' was not created",
+                    )
+                )
+                continue
+            if trigger_name in existing_names:
+                result.entities.append(
+                    InstalledEntity(
+                        kind=EntityKind.AUTOMATION,
+                        key=auto.key,
+                        name=trigger_name,
+                        action=InstallAction.REUSED,
+                    )
+                )
+                continue
+
+            dto = TriggerCreate(
+                name=trigger_name,
+                description=auto.prompt,  # becomes the agent task query on each run
+                agent_id=agent_id,
+                trigger_type="cron",
+                cron_expression=auto.cron,
+                timezone=auto.timezone,
+                enabled=auto.enabled,
+            )
+            domain = dto.to_domain(
+                created_by=self._user_context.user_id,
+                workspace_id=self._user_context.workspace_id,
+            )
+            trigger = await self._trigger_service.create_trigger(domain)
+            # TriggerCreate.to_domain does not carry the enabled flag and
+            # create_trigger schedules cron unconditionally. Explicitly disable
+            # so imported automations honour enabled=false: this deactivates the
+            # trigger and pauses its schedule, so the agent never runs before the
+            # user activates it.
+            if not auto.enabled:
+                await self._trigger_service.disable_trigger(trigger.id)
+            result.entities.append(
+                InstalledEntity(
+                    kind=EntityKind.AUTOMATION,
+                    key=auto.key,
+                    name=trigger_name,
+                    action=InstallAction.CREATED,
+                    id=str(trigger.id),
+                    detail=f"enabled={auto.enabled}",
+                )
+            )

--- a/agentarea-platform/libs/bundles/agentarea_bundles/application/service.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/application/service.py
@@ -1,0 +1,127 @@
+"""BundleService: analyze + install entry point.
+
+Wires the pure analyzer/installer to the workspace's repositories and domain
+services, implements the existence checker for preview status, and records an
+``InstalledBundle`` row for provenance/idempotency.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agentarea_bundles.application.analyzer import (
+    BundleAnalyzer,
+    parse_bundle,
+)
+from agentarea_bundles.application.installer import BundleInstaller
+from agentarea_bundles.domain.models import InstalledBundle
+from agentarea_bundles.infrastructure.repository import InstalledBundleRepository
+from agentarea_bundles.schemas.bundle import Bundle
+from agentarea_bundles.schemas.preview import ImportPreview
+from agentarea_bundles.schemas.result import InstallResult
+
+logger = logging.getLogger(__name__)
+
+
+class BundleService:
+    """Analyze package source and install canonical packages into a workspace."""
+
+    def __init__(
+        self,
+        *,
+        repository_factory: Any,
+        agent_service: Any,
+        mcp_server_service: Any,
+        mcp_instance_service: Any,
+        skill_service: Any,
+        trigger_service: Any,
+    ) -> None:
+        self._repository_factory = repository_factory
+        self._user_context = repository_factory.user_context
+        self._agent_service = agent_service
+        self._mcp_server_service = mcp_server_service
+        self._mcp_instance_service = mcp_instance_service
+        self._skill_service = skill_service
+        self._trigger_service = trigger_service
+
+        # Repositories for existence checks / idempotency.
+        from agentarea_agents.infrastructure.repository import AgentRepository
+        from agentarea_agents.infrastructure.skill_repository import SkillRepository
+        from agentarea_triggers.infrastructure.repository import TriggerRepository
+
+        self._agent_repository = repository_factory.create_repository(AgentRepository)
+        self._skill_repository = repository_factory.create_repository(SkillRepository)
+        self._trigger_repository = repository_factory.create_repository(TriggerRepository)
+        self._bundle_repository = repository_factory.create_repository(InstalledBundleRepository)
+
+    # -- analyze ------------------------------------------------------------
+
+    async def analyze_text(self, text: str) -> ImportPreview:
+        """Parse source text into a package and produce an import preview."""
+        package = parse_bundle(text)
+        return await self.analyze_bundle(package)
+
+    async def analyze_bundle(self, package: Bundle) -> ImportPreview:
+        analyzer = BundleAnalyzer(existence=self)
+        return await analyzer.analyze(package)
+
+    # -- install ------------------------------------------------------------
+
+    async def install(self, package: Bundle, setup_values: dict[str, Any]) -> InstallResult:
+        installer = BundleInstaller(
+            mcp_server_service=self._mcp_server_service,
+            mcp_instance_service=self._mcp_instance_service,
+            skill_service=self._skill_service,
+            skill_repository=self._skill_repository,
+            agent_service=self._agent_service,
+            agent_repository=self._agent_repository,
+            trigger_service=self._trigger_service,
+            trigger_repository=self._trigger_repository,
+            user_context=self._user_context,
+        )
+        result = await installer.install(package, setup_values)
+        result.installed_bundle_id = await self._record(package, result)
+        return result
+
+    async def _record(self, package: Bundle, result: InstallResult) -> str:
+        """Upsert the InstalledBundle provenance row (idempotent by name)."""
+        existing = await self._bundle_repository.get_by_name(package.name)
+        install_result = result.model_dump(mode="json")
+        if existing:
+            updated = await self._bundle_repository.update(
+                existing.id,
+                display_name=package.display_name,
+                description=package.description,
+                schema_version=package.schema_version,
+                status="installed",
+                canonical=package.model_dump(mode="json"),
+                install_result=install_result,
+            )
+            return str((updated or existing).id)
+        created: InstalledBundle = await self._bundle_repository.create(
+            name=package.name,
+            display_name=package.display_name,
+            description=package.description,
+            schema_version=package.schema_version,
+            status="installed",
+            canonical=package.model_dump(mode="json"),
+            install_result=install_result,
+        )
+        return str(created.id)
+
+    # -- ExistenceChecker ---------------------------------------------------
+
+    async def agent_exists(self, name: str) -> bool:
+        return await self._agent_repository.get_agent_by_name(name) is not None
+
+    async def mcp_instance_exists(self, name: str) -> bool:
+        return await self._mcp_instance_service.get_by_name(name) is not None
+
+    async def skill_exists(self, name: str) -> bool:
+        return await self._skill_repository.get_by_name(name) is not None
+
+    async def trigger_exists(self, name: str) -> bool:
+        # Triggers are named "<package>:<key>"; match on suffix within workspace.
+        triggers = await self._trigger_repository.list_all()
+        return any(t.name.endswith(f":{name}") for t in triggers)

--- a/agentarea-platform/libs/bundles/agentarea_bundles/domain/__init__.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models for agent-package import."""

--- a/agentarea-platform/libs/bundles/agentarea_bundles/domain/models.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/domain/models.py
@@ -1,0 +1,34 @@
+"""InstalledBundle ORM model.
+
+Provenance + idempotency record: stores the fully-normalized canonical package
+(as jsonb) that was installed in a workspace, keyed by package name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentarea_common.base.models import BaseModel, WorkspaceScopedMixin
+from sqlalchemy import String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class InstalledBundle(BaseModel, WorkspaceScopedMixin):
+    """A package that was analyzed/installed into a workspace."""
+
+    __tablename__ = "installed_bundles"
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    schema_version: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="installed")
+    # The full normalized Bundle as published; source for re-preview/diff.
+    canonical: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    # Map of created/reused entity refs from the last install (kind/key/id/action).
+    install_result: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+
+    def __repr__(self) -> str:
+        """Return a compact string representation."""
+        return f"<InstalledBundle {self.name} ({self.id})>"

--- a/agentarea-platform/libs/bundles/agentarea_bundles/infrastructure/__init__.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure for agent-package import."""

--- a/agentarea-platform/libs/bundles/agentarea_bundles/infrastructure/repository.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/infrastructure/repository.py
@@ -1,0 +1,24 @@
+"""Workspace-scoped repository for InstalledBundle."""
+
+from __future__ import annotations
+
+from agentarea_common.auth.context import UserContext
+from agentarea_common.base import WorkspaceScopedRepository
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentarea_bundles.domain.models import InstalledBundle
+
+
+class InstalledBundleRepository(WorkspaceScopedRepository[InstalledBundle]):
+    def __init__(self, session: AsyncSession, user_context: UserContext):
+        super().__init__(session, InstalledBundle, user_context)
+
+    async def get_by_name(self, name: str) -> InstalledBundle | None:
+        """Find an imported package by name within the current workspace."""
+        query = select(self.model_class).where(
+            self.model_class.name == name,
+            self._get_workspace_filter(),
+        )
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()

--- a/agentarea-platform/libs/bundles/agentarea_bundles/schemas/__init__.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Canonical agent-package schemas and import-preview contracts."""

--- a/agentarea-platform/libs/bundles/agentarea_bundles/schemas/bundle.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/schemas/bundle.py
@@ -1,0 +1,224 @@
+"""Canonical agent-package format (v0.1.0).
+
+This is the *internal* normalized representation. External sources (a hand
+authored YAML, a Claude plugin, a github URL) are parsed into this single
+object by an adapter; analysis and installation only ever operate on it.
+
+Design notes:
+- References between entities are by ``key`` (never DB ids), so a package is
+  portable. The installer resolves keys to real ids at install time.
+- The only place user-supplied values enter is :class:`SetupField`. Everything
+  else references them via ``${setup.<key>}`` placeholders.
+- ``json_spec`` on an MCP is the native runtime shape consumed by the MCP
+  service (``type``: ``command`` | ``docker`` | ``url``) — no second schema.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+SCHEMA_VERSION = "0.1.0"
+
+# ${setup.<key>} placeholder, e.g. "Bearer ${setup.github_token}"
+_PLACEHOLDER_RE = re.compile(r"\$\{setup\.([a-zA-Z0-9_]+)\}")
+
+_KEY_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
+
+
+def setup_refs(value: Any) -> list[str]:
+    """Return the setup-field keys referenced by ``${setup.x}`` in a string."""
+    if not isinstance(value, str):
+        return []
+    return _PLACEHOLDER_RE.findall(value)
+
+
+def resolve_placeholders(value: str, setup_values: dict[str, Any]) -> str:
+    """Substitute ``${setup.<key>}`` occurrences with values from ``setup_values``.
+
+    Missing keys are left as-is; completeness is enforced by the installer so
+    the failure is reported as a structured issue rather than a silent blank.
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key in setup_values and setup_values[key] is not None:
+            return str(setup_values[key])
+        return match.group(0)
+
+    return _PLACEHOLDER_RE.sub(_sub, value)
+
+
+class SetupFieldType(StrEnum):
+    """Input widget / storage hint for a setup field."""
+
+    SECRET = "secret"  # noqa: S105 - enum value, not a credential; stored via secret manager
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    SELECT = "select"
+
+
+class SetupField(BaseModel):
+    """A single value the user must provide before the package can run.
+
+    This is the generalized analogue of a Claude plugin ``userConfig`` entry
+    and mirrors the existing MCP ``env_schema`` (KeyValueInput) shape.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1, description="Stable identifier referenced via ${setup.key}.")
+    label: str = Field(min_length=1, description="Human-readable label rendered in the form.")
+    type: SetupFieldType = Field(default=SetupFieldType.STRING)
+    required: bool = Field(default=False)
+    help: str | None = Field(default=None, description="Help text shown beneath the field.")
+    default: Any | None = Field(default=None)
+    options: list[str] | None = Field(default=None, description="Choices for type='select'.")
+    min: float | None = Field(default=None, description="Lower bound for type='number'.")
+    max: float | None = Field(default=None, description="Upper bound for type='number'.")
+
+    @field_validator("key")
+    @classmethod
+    def _valid_key(cls, v: str) -> str:
+        if not _KEY_RE.match(v):
+            raise ValueError(f"setup key '{v}' must match [a-zA-Z][a-zA-Z0-9_]*")
+        return v
+
+    @model_validator(mode="after")
+    def _check_select(self) -> SetupField:
+        if self.type is SetupFieldType.SELECT and not self.options:
+            raise ValueError(f"setup field '{self.key}' is a select but has no options")
+        return self
+
+
+class BundleMcp(BaseModel):
+    """An MCP server to provision for the package."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1, description="In-package reference key (agents point at this).")
+    name: str = Field(min_length=1, description="Instance display name created in the workspace.")
+    json_spec: dict[str, Any] = Field(
+        description="Native MCP runtime spec. Must include 'type' (command|docker|url)."
+    )
+    bindings: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Maps an env var / header name the server needs to a ${setup.x} "
+            "reference, e.g. {'GITHUB_TOKEN': '${setup.github_token}'}."
+        ),
+    )
+
+    @field_validator("key")
+    @classmethod
+    def _valid_key(cls, v: str) -> str:
+        if not _KEY_RE.match(v):
+            raise ValueError(f"mcp key '{v}' must match [a-zA-Z][a-zA-Z0-9_]*")
+        return v
+
+
+class BundleSkill(BaseModel):
+    """A skill to create for the package."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    # v0.1.0 supports inline content and github; zip/s3 import comes later.
+    source_type: Literal["content", "github"] = "content"
+    content: str | None = Field(
+        default=None, description="SKILL.md markdown for source_type=content."
+    )
+    source_url: str | None = Field(default=None, description="Repo URL for source_type=github.")
+
+    @field_validator("key")
+    @classmethod
+    def _valid_key(cls, v: str) -> str:
+        if not _KEY_RE.match(v):
+            raise ValueError(f"skill key '{v}' must match [a-zA-Z][a-zA-Z0-9_]*")
+        return v
+
+    @model_validator(mode="after")
+    def _check_source(self) -> BundleSkill:
+        if self.source_type == "content" and not self.content:
+            raise ValueError(f"skill '{self.key}' is source_type=content but has no content")
+        if self.source_type == "github" and not self.source_url:
+            raise ValueError(f"skill '{self.key}' is source_type=github but has no source_url")
+        return self
+
+
+class BundleAgent(BaseModel):
+    """An agent to create for the package."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    instruction: str = Field(default="", max_length=20000)
+    # Literal provider model id (e.g. "gpt-4o") or a ${setup.x} reference.
+    model: str | None = Field(default=None)
+    mcps: list[str] = Field(default_factory=list, description="BundleMcp keys to attach as tools.")
+    skills: list[str] = Field(default_factory=list, description="BundleSkill keys to attach.")
+
+    @field_validator("key")
+    @classmethod
+    def _valid_key(cls, v: str) -> str:
+        if not _KEY_RE.match(v):
+            raise ValueError(f"agent key '{v}' must match [a-zA-Z][a-zA-Z0-9_]*")
+        return v
+
+
+class BundleAutomation(BaseModel):
+    """A scheduled run of one of the package's agents (maps to a CronTrigger).
+
+    Automations are imported disabled by default; the user enables them after
+    verifying connections, mirroring the Zapier/Make "connect then activate"
+    flow.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1)
+    type: Literal["cron"] = "cron"
+    cron: str = Field(min_length=1, description="5- or 6-field cron expression.")
+    timezone: str = Field(default="UTC")
+    agent: str = Field(min_length=1, description="BundleAgent key to invoke.")
+    prompt: str = Field(min_length=1, description="Task query passed to the agent on each run.")
+    enabled: bool = Field(default=False)
+
+    @field_validator("key")
+    @classmethod
+    def _valid_key(cls, v: str) -> str:
+        if not _KEY_RE.match(v):
+            raise ValueError(f"automation key '{v}' must match [a-zA-Z][a-zA-Z0-9_]*")
+        return v
+
+
+class Bundle(BaseModel):
+    """The canonical, fully-inlined package object."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str = Field(default=SCHEMA_VERSION)
+    name: str = Field(min_length=1, description="Stable package identifier (idempotency key).")
+    display_name: str | None = Field(default=None)
+    description: str = Field(default="")
+    setup: list[SetupField] = Field(default_factory=list)
+    mcps: list[BundleMcp] = Field(default_factory=list)
+    skills: list[BundleSkill] = Field(default_factory=list)
+    agents: list[BundleAgent] = Field(default_factory=list)
+    automations: list[BundleAutomation] = Field(default_factory=list)
+
+    @field_validator("schema_version")
+    @classmethod
+    def _supported_version(cls, v: str) -> str:
+        if v != SCHEMA_VERSION:
+            raise ValueError(f"unsupported schema_version '{v}'; expected '{SCHEMA_VERSION}'")
+        return v
+
+    def setup_field(self, key: str) -> SetupField | None:
+        return next((f for f in self.setup if f.key == key), None)

--- a/agentarea-platform/libs/bundles/agentarea_bundles/schemas/preview.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/schemas/preview.py
@@ -1,0 +1,67 @@
+"""Import-preview contract: the result of analyzing a package before install."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentarea_bundles.schemas.bundle import Bundle, SetupField
+
+
+class EntityKind(StrEnum):
+    MCP = "mcp"
+    SKILL = "skill"
+    AGENT = "agent"
+    AUTOMATION = "automation"
+
+
+class EntityStatus(StrEnum):
+    WILL_CREATE = "will_create"
+    ALREADY_EXISTS = "already_exists"
+    UNSUPPORTED = "unsupported"
+
+
+class IssueSeverity(StrEnum):
+    BLOCK = "block"  # install cannot proceed
+    WARN = "warn"  # install proceeds, entity may be skipped or degraded
+
+
+class PreviewEntity(BaseModel):
+    """One thing the package will (or won't) create."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: EntityKind
+    key: str
+    name: str
+    status: EntityStatus
+    detail: str | None = Field(default=None)
+
+
+class PreviewIssue(BaseModel):
+    """A problem found while analyzing the package."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    severity: IssueSeverity
+    message: str
+    entity_key: str | None = Field(default=None)
+
+
+class ImportPreview(BaseModel):
+    """What the wizard renders before the user commits to installing."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bundle: Bundle
+    setup: list[SetupField] = Field(default_factory=list)
+    entities: list[PreviewEntity] = Field(default_factory=list)
+    issues: list[PreviewIssue] = Field(default_factory=list)
+    installable: bool = Field(
+        description="True when there are no blocking issues (setup may still be required)."
+    )
+
+    @property
+    def block_issues(self) -> list[PreviewIssue]:
+        return [i for i in self.issues if i.severity is IssueSeverity.BLOCK]

--- a/agentarea-platform/libs/bundles/agentarea_bundles/schemas/result.py
+++ b/agentarea-platform/libs/bundles/agentarea_bundles/schemas/result.py
@@ -1,0 +1,34 @@
+"""Install-result contract returned after a package is installed."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentarea_bundles.schemas.preview import EntityKind
+
+
+class InstallAction(StrEnum):
+    CREATED = "created"
+    REUSED = "reused"  # already existed in the workspace, linked instead of duplicated
+    SKIPPED = "skipped"  # unsupported / not installable
+
+
+class InstalledEntity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: EntityKind
+    key: str
+    name: str
+    action: InstallAction
+    id: str | None = Field(default=None, description="Created/reused entity id, when applicable.")
+    detail: str | None = Field(default=None)
+
+
+class InstallResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_name: str
+    installed_bundle_id: str | None = Field(default=None)
+    entities: list[InstalledEntity] = Field(default_factory=list)

--- a/agentarea-platform/libs/bundles/pyproject.toml
+++ b/agentarea-platform/libs/bundles/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agentarea-bundles"
+version = "0.0.10"
+description = "Agent package import (analyze + install) for AgentArea"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.12"
+dependencies = [
+    "agentarea-common",
+    "agentarea-agents",
+    "agentarea-mcp",
+    "agentarea-triggers",
+    "pydantic>=2.4.2",
+    "PyYAML>=6.0",
+]
+
+[tool.uv.sources]
+agentarea-common = { workspace = true }
+agentarea-agents = { workspace = true }
+agentarea-mcp = { workspace = true }
+agentarea-triggers = { workspace = true }
+
+[tool.hatch.build.targets.wheel]
+packages = ["agentarea_bundles"]

--- a/agentarea-platform/libs/bundles/tests/test_analyzer.py
+++ b/agentarea-platform/libs/bundles/tests/test_analyzer.py
@@ -1,0 +1,118 @@
+"""Analyzer / import-preview tests."""
+
+import pytest
+from agentarea_bundles.application.analyzer import (
+    BundleAnalyzer,
+    BundleParseError,
+    parse_bundle,
+)
+from agentarea_bundles.schemas.preview import EntityStatus, IssueSeverity
+
+GOOD = """
+schema_version: "0.1.0"
+name: seo
+setup:
+  - {key: token, label: Token, type: secret, required: true}
+mcps:
+  - key: gh
+    name: GitHub
+    json_spec: {type: command, command: npx, args: ["-y", "@x/y"]}
+    bindings: {GH_TOKEN: "${setup.token}"}
+skills:
+  - {key: sk, name: Audit, source_type: content, content: "# a"}
+agents:
+  - {key: lead, name: Lead, model: gpt-4o, instruction: x, mcps: [gh], skills: [sk]}
+automations:
+  - {key: daily, type: cron, cron: "0 9 * * *", agent: lead, prompt: go}
+"""
+
+
+async def test_parse_invalid_yaml():
+    with pytest.raises(BundleParseError):
+        parse_bundle(":\n  - [")
+
+
+async def test_parse_empty():
+    with pytest.raises(BundleParseError):
+        parse_bundle("   ")
+
+
+async def test_good_package_installable():
+    preview = await BundleAnalyzer().analyze(parse_bundle(GOOD))
+    assert preview.installable is True
+    assert not preview.block_issues
+    kinds = {(e.kind, e.key): e.status for e in preview.entities}
+    assert all(s == EntityStatus.WILL_CREATE for s in kinds.values())
+
+
+async def test_unknown_mcp_ref_blocks():
+    pkg = parse_bundle(
+        """
+schema_version: "0.1.0"
+name: p
+agents: [{key: a, name: A, model: gpt-4o, mcps: [missing]}]
+"""
+    )
+    preview = await BundleAnalyzer().analyze(pkg)
+    assert preview.installable is False
+    assert any("unknown mcp 'missing'" in i.message for i in preview.block_issues)
+
+
+async def test_binding_unknown_setup_field_blocks():
+    pkg = parse_bundle(
+        """
+schema_version: "0.1.0"
+name: p
+mcps:
+  - key: gh
+    name: GitHub
+    json_spec: {type: command, command: npx}
+    bindings: {GH_TOKEN: "${setup.nope}"}
+agents: [{key: a, name: A, model: gpt-4o}]
+"""
+    )
+    preview = await BundleAnalyzer().analyze(pkg)
+    assert preview.installable is False
+    assert any("unknown setup field 'nope'" in i.message for i in preview.block_issues)
+
+
+async def test_unsupported_mcp_warns_not_blocks():
+    pkg = parse_bundle(
+        """
+schema_version: "0.1.0"
+name: p
+mcps:
+  - {key: bad, name: Bad, json_spec: {type: command, command: "./local/bin"}}
+agents: [{key: a, name: A, model: gpt-4o, mcps: [bad]}]
+"""
+    )
+    preview = await BundleAnalyzer().analyze(pkg)
+    assert preview.installable is True  # warning, not block
+    statuses = {e.key: e.status for e in preview.entities}
+    assert statuses["bad"] == EntityStatus.UNSUPPORTED
+    assert any(i.severity == IssueSeverity.WARN for i in preview.issues)
+
+
+async def test_agent_without_model_blocks():
+    pkg = parse_bundle(
+        'schema_version: "0.1.0"\nname: p\nagents: [{key: a, name: A}]\n'
+    )
+    preview = await BundleAnalyzer().analyze(pkg)
+    assert preview.installable is False
+    assert any("has no model" in i.message for i in preview.block_issues)
+
+
+class _AllExist:
+    async def agent_exists(self, name): return True
+    async def mcp_instance_exists(self, name): return True
+    async def skill_exists(self, name): return True
+    async def trigger_exists(self, name): return True
+
+
+async def test_existence_marks_already_exists():
+    preview = await BundleAnalyzer(existence=_AllExist()).analyze(parse_bundle(GOOD))
+    statuses = {(e.kind, e.key): e.status for e in preview.entities}
+    # mcp existence is by name; supported mcp should be ALREADY_EXISTS
+    assert statuses[("skill", "sk")] == EntityStatus.ALREADY_EXISTS
+    assert statuses[("agent", "lead")] == EntityStatus.ALREADY_EXISTS
+    assert statuses[("automation", "daily")] == EntityStatus.ALREADY_EXISTS

--- a/agentarea-platform/libs/bundles/tests/test_format.py
+++ b/agentarea-platform/libs/bundles/tests/test_format.py
@@ -1,0 +1,54 @@
+"""Canonical format validation tests."""
+
+import pytest
+from agentarea_bundles.schemas.bundle import (
+    Bundle,
+    SetupField,
+    SetupFieldType,
+    resolve_placeholders,
+    setup_refs,
+)
+from pydantic import ValidationError
+
+
+def test_minimal_package_valid():
+    pkg = Bundle(name="p")
+    assert pkg.schema_version == "0.1.0"
+    assert pkg.mcps == []
+
+
+def test_unsupported_schema_version_rejected():
+    with pytest.raises(ValidationError):
+        Bundle(name="p", schema_version="9.9.9")
+
+
+def test_extra_keys_forbidden():
+    with pytest.raises(ValidationError):
+        Bundle.model_validate({"name": "p", "unknown": 1})
+
+
+def test_select_field_requires_options():
+    with pytest.raises(ValidationError):
+        SetupField(key="r", label="Region", type=SetupFieldType.SELECT)
+
+
+def test_invalid_key_rejected():
+    with pytest.raises(ValidationError):
+        SetupField(key="9bad", label="x")
+
+
+def test_skill_content_required_for_content_source():
+    with pytest.raises(ValidationError):
+        Bundle.model_validate(
+            {"name": "p", "skills": [{"key": "s", "name": "S", "source_type": "content"}]}
+        )
+
+
+def test_setup_refs_extraction():
+    assert setup_refs("Bearer ${setup.github_token}") == ["github_token"]
+    assert setup_refs("no refs") == []
+    assert setup_refs(123) == []
+
+
+def test_resolve_placeholders_substitutes_and_keeps_missing():
+    assert resolve_placeholders("${setup.a}/${setup.b}", {"a": "1"}) == "1/${setup.b}"

--- a/agentarea-platform/libs/bundles/tests/test_installer.py
+++ b/agentarea-platform/libs/bundles/tests/test_installer.py
@@ -1,0 +1,171 @@
+"""Installer orchestration tests (mocked domain services)."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from agentarea_bundles.application.analyzer import parse_bundle
+from agentarea_bundles.application.installer import BundleInstaller, BundleInstallError
+from agentarea_bundles.schemas.result import InstallAction
+
+FULL = """
+schema_version: "0.1.0"
+name: seo
+setup:
+  - {key: token, label: Token, type: secret, required: true}
+mcps:
+  - key: gh
+    name: GitHub
+    json_spec: {type: command, command: npx, args: ["-y", "@x/y"]}
+    bindings: {GH_TOKEN: "${setup.token}"}
+skills:
+  - {key: sk, name: Audit, source_type: content, content: "# a"}
+agents:
+  - {key: lead, name: Lead, model: gpt-4o, instruction: x, mcps: [gh], skills: [sk]}
+automations:
+  - {key: daily, type: cron, cron: "0 9 * * *", agent: lead, prompt: go, enabled: false}
+"""
+
+
+class FakeMcpServerSvc:
+    def __init__(self): self.calls = []
+    async def create_mcp_server(self, payload):
+        self.calls.append(payload)
+        return SimpleNamespace(id=uuid4())
+
+
+class FakeMcpInstSvc:
+    def __init__(self, existing=None): self.existing = existing; self.calls = []
+    async def get_by_name(self, name): return self.existing
+    async def create_instance(self, payload):
+        self.calls.append(payload)
+        return SimpleNamespace(id=uuid4())
+
+
+class FakeSkillSvc:
+    def __init__(self): self.calls = []
+    async def create_from_content(self, payload):
+        self.calls.append(payload)
+        return SimpleNamespace(id=uuid4())
+
+
+class FakeSkillRepo:
+    def __init__(self, existing=None): self.existing = existing
+    async def get_by_name(self, name): return self.existing
+
+
+class FakeAgentSvc:
+    def __init__(self): self.calls = []
+    async def create_agent(self, payload):
+        self.calls.append(payload)
+        return SimpleNamespace(id=uuid4())
+
+
+class FakeAgentRepo:
+    def __init__(self, existing=None): self.existing = existing
+    async def get_agent_by_name(self, name): return self.existing
+
+
+class FakeTriggerSvc:
+    def __init__(self): self.created = []; self.disabled = []
+    async def create_trigger(self, domain):
+        t = SimpleNamespace(id=uuid4(), name=domain.name)
+        self.created.append(domain)
+        return t
+    async def disable_trigger(self, trigger_id):
+        self.disabled.append(trigger_id)
+        return True
+
+
+class FakeTriggerRepo:
+    def __init__(self, existing=None): self.existing = existing or []
+    async def list_all(self): return self.existing
+
+
+def _installer(**overrides):
+    deps = dict(
+        mcp_server_service=FakeMcpServerSvc(),
+        mcp_instance_service=FakeMcpInstSvc(),
+        skill_service=FakeSkillSvc(),
+        skill_repository=FakeSkillRepo(),
+        agent_service=FakeAgentSvc(),
+        agent_repository=FakeAgentRepo(),
+        trigger_service=FakeTriggerSvc(),
+        trigger_repository=FakeTriggerRepo(),
+        user_context=SimpleNamespace(user_id="u", workspace_id="w"),
+    )
+    deps.update(overrides)
+    return BundleInstaller(**deps), deps
+
+
+async def test_missing_required_setup_blocks_install():
+    inst, _ = _installer()
+    with pytest.raises(BundleInstallError):
+        await inst.install(parse_bundle(FULL), setup_values={})  # token missing
+
+
+async def test_full_install_creates_everything():
+    inst, deps = _installer()
+    res = await inst.install(parse_bundle(FULL), {"token": "secret"})
+    actions = {(e.kind, e.key): e.action for e in res.entities}
+    assert all(a == InstallAction.CREATED for a in actions.values())
+    # secret resolved into instance environment
+    assert deps["mcp_instance_service"].calls[0].json_spec["environment"] == {"GH_TOKEN": "secret"}
+    # agent wired to mcp by instance name + skill id
+    agent = deps["agent_service"].calls[0]
+    assert [(t.type, t.name) for t in agent.tools] == [("mcp", "GitHub")]
+    assert len(agent.skill_ids) == 1
+
+
+async def test_disabled_automation_is_disabled_after_create():
+    inst, deps = _installer()
+    await inst.install(parse_bundle(FULL), {"token": "secret"})
+    ts = deps["trigger_service"]
+    assert len(ts.created) == 1
+    assert len(ts.disabled) == 1  # disable_trigger called for enabled=false
+
+
+async def test_enabled_automation_not_disabled():
+    pkg = parse_bundle(FULL.replace("enabled: false", "enabled: true"))
+    inst, deps = _installer()
+    await inst.install(pkg, {"token": "secret"})
+    assert deps["trigger_service"].disabled == []
+
+
+async def test_idempotent_reuse_of_existing_entities():
+    existing_skill = SimpleNamespace(id=uuid4())
+    existing_agent = SimpleNamespace(id=uuid4())
+    existing_inst = SimpleNamespace(id=uuid4())
+    inst, deps = _installer(
+        skill_repository=FakeSkillRepo(existing=existing_skill),
+        agent_repository=FakeAgentRepo(existing=existing_agent),
+        mcp_instance_service=FakeMcpInstSvc(existing=existing_inst),
+        trigger_repository=FakeTriggerRepo(existing=[SimpleNamespace(name="seo:daily")]),
+    )
+    res = await inst.install(parse_bundle(FULL), {"token": "secret"})
+    actions = {(e.kind, e.key): e.action for e in res.entities}
+    assert actions[("mcp", "gh")] == InstallAction.REUSED
+    assert actions[("skill", "sk")] == InstallAction.REUSED
+    assert actions[("agent", "lead")] == InstallAction.REUSED
+    assert actions[("automation", "daily")] == InstallAction.REUSED
+    # nothing newly created
+    assert deps["agent_service"].calls == []
+    assert deps["skill_service"].calls == []
+
+
+async def test_unsupported_mcp_skipped_and_agent_created_without_it():
+    pkg = parse_bundle(
+        """
+schema_version: "0.1.0"
+name: p
+mcps:
+  - {key: bad, name: Bad, json_spec: {type: command, command: "./bin/x"}}
+agents: [{key: a, name: A, model: gpt-4o, mcps: [bad]}]
+"""
+    )
+    inst, deps = _installer()
+    res = await inst.install(pkg, {})
+    actions = {(e.kind, e.key): e.action for e in res.entities}
+    assert actions[("mcp", "bad")] == InstallAction.SKIPPED
+    # agent created with no tools (unsupported mcp dropped)
+    assert deps["agent_service"].calls[0].tools is None

--- a/agentarea-platform/pyproject.toml
+++ b/agentarea-platform/pyproject.toml
@@ -42,6 +42,7 @@ members = [
     "libs/openapi",
     "libs/projects",
     "libs/registry",
+    "libs/bundles"
 ]
 
 [tool.uv]
@@ -74,6 +75,7 @@ agentarea-governance = { workspace = true }
 agentarea-openapi = { workspace = true }
 agentarea-projects = { workspace = true }
 agentarea-registry = { workspace = true }
+agentarea-bundles = { workspace = true }
 agentarea-api = { workspace = true }
 agentarea-worker = { workspace = true }
 agentarea-cli = { workspace = true }

--- a/agentarea-platform/uv.lock
+++ b/agentarea-platform/uv.lock
@@ -11,6 +11,7 @@ members = [
     "agentarea-agents",
     "agentarea-agents-sdk",
     "agentarea-api",
+    "agentarea-bundles",
     "agentarea-common",
     "agentarea-context",
     "agentarea-execution",
@@ -122,6 +123,7 @@ version = "0.0.10"
 source = { editable = "apps/api" }
 dependencies = [
     { name = "agentarea-agents" },
+    { name = "agentarea-bundles" },
     { name = "agentarea-common" },
     { name = "agentarea-execution" },
     { name = "agentarea-governance" },
@@ -148,6 +150,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "agentarea-agents", editable = "libs/agents" },
+    { name = "agentarea-bundles", editable = "libs/bundles" },
     { name = "agentarea-common", editable = "libs/common" },
     { name = "agentarea-execution", editable = "libs/execution" },
     { name = "agentarea-governance", editable = "libs/governance" },
@@ -169,6 +172,29 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "uvicorn", specifier = ">=0.34.0" },
+]
+
+[[package]]
+name = "agentarea-bundles"
+version = "0.0.10"
+source = { editable = "libs/bundles" }
+dependencies = [
+    { name = "agentarea-agents" },
+    { name = "agentarea-common" },
+    { name = "agentarea-mcp" },
+    { name = "agentarea-triggers" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agentarea-agents", editable = "libs/agents" },
+    { name = "agentarea-common", editable = "libs/common" },
+    { name = "agentarea-mcp", editable = "libs/mcp" },
+    { name = "agentarea-triggers", editable = "libs/triggers" },
+    { name = "pydantic", specifier = ">=2.4.2" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -886,6 +886,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/bundles/analyze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Analyze Bundle
+         * @description Parse and analyze a bundle source, returning a non-destructive preview.
+         */
+        post: operations["analyze_bundle_v1_bundles_analyze_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/bundles/install": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Install Bundle
+         * @description Install a canonical bundle: MCP instances, skills, agents and automations.
+         */
+        post: operations["install_bundle_v1_bundles_install_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/files": {
         parameters: {
             query?: never;
@@ -3948,6 +3988,17 @@ export interface components {
             tools?: components["schemas"]["ToolConfigYAML"][] | null;
         };
         /**
+         * AnalyzeRequest
+         * @description Analyze raw bundle source (YAML or JSON) into an import preview.
+         */
+        AnalyzeRequest: {
+            /**
+             * Source
+             * @description Raw bundle source text (YAML or JSON).
+             */
+            source: string;
+        };
+        /**
          * ApprovalPolicy
          * @description Human approval and escalation requirements.
          */
@@ -4091,6 +4142,198 @@ export interface components {
             run_budget_usd?: string | null;
             /** Service Budget Usd */
             service_budget_usd?: string | null;
+        };
+        /**
+         * Bundle
+         * @description The canonical, fully-inlined package object.
+         */
+        "Bundle-Input": {
+            /** Agents */
+            agents?: components["schemas"]["BundleAgent"][];
+            /** Automations */
+            automations?: components["schemas"]["BundleAutomation"][];
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Display Name */
+            display_name?: string | null;
+            /** Mcps */
+            mcps?: components["schemas"]["BundleMcp"][];
+            /**
+             * Name
+             * @description Stable package identifier (idempotency key).
+             */
+            name: string;
+            /**
+             * Schema Version
+             * @default 0.1.0
+             */
+            schema_version: string;
+            /** Setup */
+            setup?: components["schemas"]["SetupField"][];
+            /** Skills */
+            skills?: components["schemas"]["BundleSkill"][];
+        };
+        /**
+         * Bundle
+         * @description The canonical, fully-inlined package object.
+         */
+        "Bundle-Output": {
+            /** Agents */
+            agents?: components["schemas"]["BundleAgent"][];
+            /** Automations */
+            automations?: components["schemas"]["BundleAutomation"][];
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Display Name */
+            display_name?: string | null;
+            /** Mcps */
+            mcps?: components["schemas"]["BundleMcp"][];
+            /**
+             * Name
+             * @description Stable package identifier (idempotency key).
+             */
+            name: string;
+            /**
+             * Schema Version
+             * @default 0.1.0
+             */
+            schema_version: string;
+            /** Setup */
+            setup?: components["schemas"]["SetupField"][];
+            /** Skills */
+            skills?: components["schemas"]["BundleSkill"][];
+        };
+        /**
+         * BundleAgent
+         * @description An agent to create for the package.
+         */
+        BundleAgent: {
+            /**
+             * Instruction
+             * @default
+             */
+            instruction: string;
+            /** Key */
+            key: string;
+            /**
+             * Mcps
+             * @description BundleMcp keys to attach as tools.
+             */
+            mcps?: string[];
+            /** Model */
+            model?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Skills
+             * @description BundleSkill keys to attach.
+             */
+            skills?: string[];
+        };
+        /**
+         * BundleAutomation
+         * @description A scheduled run of one of the package's agents (maps to a CronTrigger).
+         *
+         *     Automations are imported disabled by default; the user enables them after
+         *     verifying connections, mirroring the Zapier/Make "connect then activate"
+         *     flow.
+         */
+        BundleAutomation: {
+            /**
+             * Agent
+             * @description BundleAgent key to invoke.
+             */
+            agent: string;
+            /**
+             * Cron
+             * @description 5- or 6-field cron expression.
+             */
+            cron: string;
+            /**
+             * Enabled
+             * @default false
+             */
+            enabled: boolean;
+            /** Key */
+            key: string;
+            /**
+             * Prompt
+             * @description Task query passed to the agent on each run.
+             */
+            prompt: string;
+            /**
+             * Timezone
+             * @default UTC
+             */
+            timezone: string;
+            /**
+             * Type
+             * @default cron
+             * @constant
+             */
+            type: "cron";
+        };
+        /**
+         * BundleMcp
+         * @description An MCP server to provision for the package.
+         */
+        BundleMcp: {
+            /**
+             * Bindings
+             * @description Maps an env var / header name the server needs to a ${setup.x} reference, e.g. {'GITHUB_TOKEN': '${setup.github_token}'}.
+             */
+            bindings?: {
+                [key: string]: string;
+            };
+            /**
+             * Json Spec
+             * @description Native MCP runtime spec. Must include 'type' (command|docker|url).
+             */
+            json_spec: {
+                [key: string]: unknown;
+            };
+            /**
+             * Key
+             * @description In-package reference key (agents point at this).
+             */
+            key: string;
+            /**
+             * Name
+             * @description Instance display name created in the workspace.
+             */
+            name: string;
+        };
+        /**
+         * BundleSkill
+         * @description A skill to create for the package.
+         */
+        BundleSkill: {
+            /**
+             * Content
+             * @description SKILL.md markdown for source_type=content.
+             */
+            content?: string | null;
+            /** Key */
+            key: string;
+            /** Name */
+            name: string;
+            /**
+             * Source Type
+             * @default content
+             * @enum {string}
+             */
+            source_type: "content" | "github";
+            /**
+             * Source Url
+             * @description Repo URL for source_type=github.
+             */
+            source_url?: string | null;
         };
         /**
          * ContentSafetyPolicy
@@ -4308,6 +4551,16 @@ export interface components {
         EffectivePolicyResponse: {
             effective_policy: components["schemas"]["EffectivePolicy"];
         };
+        /**
+         * EntityKind
+         * @enum {string}
+         */
+        EntityKind: "mcp" | "skill" | "agent" | "automation";
+        /**
+         * EntityStatus
+         * @enum {string}
+         */
+        EntityStatus: "will_create" | "already_exists" | "unsupported";
         /** EscalationResolution */
         EscalationResolution: {
             /** Approved */
@@ -4530,6 +4783,24 @@ export interface components {
             task_id: string;
         };
         /**
+         * ImportPreview
+         * @description What the wizard renders before the user commits to installing.
+         */
+        ImportPreview: {
+            bundle: components["schemas"]["Bundle-Output"];
+            /** Entities */
+            entities?: components["schemas"]["PreviewEntity"][];
+            /**
+             * Installable
+             * @description True when there are no blocking issues (setup may still be required).
+             */
+            installable: boolean;
+            /** Issues */
+            issues?: components["schemas"]["PreviewIssue"][];
+            /** Setup */
+            setup?: components["schemas"]["SetupField"][];
+        };
+        /**
          * ImportRequest
          * @description Request body for importing workspace configuration.
          */
@@ -4596,6 +4867,50 @@ export interface components {
             total: number;
         };
         /**
+         * InstallAction
+         * @enum {string}
+         */
+        InstallAction: "created" | "reused" | "skipped";
+        /**
+         * InstallRequest
+         * @description Install a (previously analyzed, possibly edited) canonical bundle.
+         */
+        InstallRequest: {
+            bundle: components["schemas"]["Bundle-Input"];
+            /**
+             * Setup Values
+             * @description Values for the bundle's setup fields, keyed by setup field key.
+             */
+            setup_values?: {
+                [key: string]: unknown;
+            };
+        };
+        /** InstallResult */
+        InstallResult: {
+            /** Bundle Name */
+            bundle_name: string;
+            /** Entities */
+            entities?: components["schemas"]["InstalledEntity"][];
+            /** Installed Bundle Id */
+            installed_bundle_id?: string | null;
+        };
+        /** InstalledEntity */
+        InstalledEntity: {
+            action: components["schemas"]["InstallAction"];
+            /** Detail */
+            detail?: string | null;
+            /**
+             * Id
+             * @description Created/reused entity id, when applicable.
+             */
+            id?: string | null;
+            /** Key */
+            key: string;
+            kind: components["schemas"]["EntityKind"];
+            /** Name */
+            name: string;
+        };
+        /**
          * InvitationCreatedResponse
          * @description Same as InvitationResponse plus the plaintext token, returned ONCE.
          */
@@ -4660,6 +4975,11 @@ export interface components {
             /** Workspace Id */
             workspace_id: string;
         };
+        /**
+         * IssueSeverity
+         * @enum {string}
+         */
+        IssueSeverity: "block" | "warn";
         /** MCPAuthConfigCreateRequest */
         MCPAuthConfigCreateRequest: {
             /**
@@ -5529,6 +5849,31 @@ export interface components {
              */
             parent_agent_id?: string | null;
         };
+        /**
+         * PreviewEntity
+         * @description One thing the package will (or won't) create.
+         */
+        PreviewEntity: {
+            /** Detail */
+            detail?: string | null;
+            /** Key */
+            key: string;
+            kind: components["schemas"]["EntityKind"];
+            /** Name */
+            name: string;
+            status: components["schemas"]["EntityStatus"];
+        };
+        /**
+         * PreviewIssue
+         * @description A problem found while analyzing the package.
+         */
+        PreviewIssue: {
+            /** Entity Key */
+            entity_key?: string | null;
+            /** Message */
+            message: string;
+            severity: components["schemas"]["IssueSeverity"];
+        };
         /** ProjectAgentRef */
         ProjectAgentRef: {
             /**
@@ -5968,6 +6313,60 @@ export interface components {
             /** Sync Mode */
             sync_mode?: string | null;
         };
+        /**
+         * SetupField
+         * @description A single value the user must provide before the package can run.
+         *
+         *     This is the generalized analogue of a Claude plugin ``userConfig`` entry
+         *     and mirrors the existing MCP ``env_schema`` (KeyValueInput) shape.
+         */
+        SetupField: {
+            /** Default */
+            default?: unknown | null;
+            /**
+             * Help
+             * @description Help text shown beneath the field.
+             */
+            help?: string | null;
+            /**
+             * Key
+             * @description Stable identifier referenced via ${setup.key}.
+             */
+            key: string;
+            /**
+             * Label
+             * @description Human-readable label rendered in the form.
+             */
+            label: string;
+            /**
+             * Max
+             * @description Upper bound for type='number'.
+             */
+            max?: number | null;
+            /**
+             * Min
+             * @description Lower bound for type='number'.
+             */
+            min?: number | null;
+            /**
+             * Options
+             * @description Choices for type='select'.
+             */
+            options?: string[] | null;
+            /**
+             * Required
+             * @default false
+             */
+            required: boolean;
+            /** @default string */
+            type: components["schemas"]["SetupFieldType"];
+        };
+        /**
+         * SetupFieldType
+         * @description Input widget / storage hint for a setup field.
+         * @enum {string}
+         */
+        SetupFieldType: "secret" | "string" | "number" | "boolean" | "select";
         /**
          * SkillContentResponse
          * @description Skill content response model.
@@ -8754,6 +9153,72 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AuditLogListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analyze_bundle_v1_bundles_analyze_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnalyzeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportPreview"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    install_bundle_v1_bundles_install_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InstallRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InstallResult"];
                 };
             };
             /** @description Validation Error */

--- a/agentarea-webapp/src/app/(main)/bundles/components/ImportWizard.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/ImportWizard.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { AlertTriangle, CheckCircle2, PackagePlus, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import FormLabel from "@/components/FormLabel/FormLabel";
+import SetupForm from "@/components/SetupForm";
+import { cn } from "@/lib/utils";
+import type {
+  ImportPreview,
+  InstallResult,
+  EntityKind,
+  EntityStatus,
+  InstallAction,
+  PreviewEntity,
+  PreviewIssue,
+  InstalledEntity,
+} from "@/app/(main)/bundles/types";
+
+type WizardStep = "source" | "review" | "result";
+
+const KIND_LABELS: Record<EntityKind, string> = {
+  mcp: "MCP Servers",
+  skill: "Skills",
+  agent: "Agents",
+  automation: "Automations",
+};
+
+const ENTITY_ORDER: EntityKind[] = ["agent", "skill", "mcp", "automation"];
+
+function EntityStatusChip({ status }: { status: EntityStatus }) {
+  if (status === "will_create") {
+    return (
+      <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+        will create
+      </span>
+    );
+  }
+  if (status === "already_exists") {
+    return (
+      <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+        already exists
+      </span>
+    );
+  }
+  return (
+    <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+      unsupported
+    </span>
+  );
+}
+
+function ActionChip({ action }: { action: InstallAction }) {
+  if (action === "created") {
+    return (
+      <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+        created
+      </span>
+    );
+  }
+  if (action === "reused") {
+    return (
+      <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+        reused
+      </span>
+    );
+  }
+  return (
+    <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+      skipped
+    </span>
+  );
+}
+
+function EntityRow({ entity }: { entity: PreviewEntity }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1.5">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium">{entity.name}</span>
+        {entity.detail && (
+          <span className="truncate text-xs text-muted-foreground">{entity.detail}</span>
+        )}
+      </div>
+      <EntityStatusChip status={entity.status} />
+    </div>
+  );
+}
+
+function InstalledEntityRow({ entity }: { entity: InstalledEntity }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1.5">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium">{entity.name}</span>
+        {entity.detail && (
+          <span className="truncate text-xs text-muted-foreground">{entity.detail}</span>
+        )}
+      </div>
+      <ActionChip action={entity.action} />
+    </div>
+  );
+}
+
+function groupEntitiesByKind(entities: PreviewEntity[]): Map<EntityKind, PreviewEntity[]> {
+  const map = new Map<EntityKind, PreviewEntity[]>();
+  for (const e of entities) {
+    const list = map.get(e.kind) ?? [];
+    list.push(e);
+    map.set(e.kind, list);
+  }
+  return map;
+}
+
+function groupInstalledByKind(entities: InstalledEntity[]): Map<EntityKind, InstalledEntity[]> {
+  const map = new Map<EntityKind, InstalledEntity[]>();
+  for (const e of entities) {
+    const list = map.get(e.kind) ?? [];
+    list.push(e);
+    map.set(e.kind, list);
+  }
+  return map;
+}
+
+function hasRequiredEmpty(
+  schema: ImportPreview["setup"],
+  values: Record<string, string | number | boolean>
+): boolean {
+  return schema.some((field) => {
+    if (!field.required) return false;
+    const val = values[field.key];
+    if (val === undefined || val === null) return true;
+    if (typeof val === "string" && val.trim() === "") return true;
+    return false;
+  });
+}
+
+async function callProxy<T>(
+  path: string,
+  body: unknown
+): Promise<{ data: T | null; error: string | null }> {
+  try {
+    const response = await fetch(`/api/proxy/${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const json = await response.json();
+
+    if (!response.ok) {
+      const detail = json?.detail;
+      if (typeof detail === "string") {
+        return { data: null, error: detail };
+      }
+      if (typeof detail?.message === "string") {
+        return { data: null, error: detail.message };
+      }
+      return { data: null, error: `Request failed (${response.status})` };
+    }
+
+    return { data: json as T, error: null };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Network error";
+    return { data: null, error: message };
+  }
+}
+
+export default function ImportWizard() {
+  const [step, setStep] = useState<WizardStep>("source");
+
+  // Source step
+  const [source, setSource] = useState("");
+  const [analyzeLoading, setAnalyzeLoading] = useState(false);
+  const [analyzeError, setAnalyzeError] = useState<string | null>(null);
+
+  // Review step
+  const [preview, setPreview] = useState<ImportPreview | null>(null);
+  const [setupValues, setSetupValues] = useState<Record<string, string | number | boolean>>({});
+  const [setupErrors, setSetupErrors] = useState<Record<string, string>>({});
+  const [installLoading, setInstallLoading] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  // Result step
+  const [result, setResult] = useState<InstallResult | null>(null);
+
+  function initSetupValues(preview: ImportPreview) {
+    const initial: Record<string, string | number | boolean> = {};
+    for (const field of preview.setup) {
+      if (field.default !== undefined && field.default !== null) {
+        initial[field.key] = field.default;
+      }
+    }
+    setSetupValues(initial);
+  }
+
+  async function handleAnalyze() {
+    if (!source.trim()) return;
+    setAnalyzeLoading(true);
+    setAnalyzeError(null);
+
+    const { data, error } = await callProxy<ImportPreview>(
+      "v1/bundles/analyze",
+      { source: source.trim() }
+    );
+
+    setAnalyzeLoading(false);
+
+    if (error || !data) {
+      setAnalyzeError(error ?? "Failed to analyze package.");
+      return;
+    }
+
+    setPreview(data);
+    initSetupValues(data);
+    setStep("review");
+  }
+
+  function handleSetupChange(key: string, value: string | number | boolean) {
+    setSetupValues((prev) => ({ ...prev, [key]: value }));
+    setSetupErrors((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }
+
+  async function handleInstall() {
+    if (!preview) return;
+    setInstallLoading(true);
+    setInstallError(null);
+    setSetupErrors({});
+
+    const { data, error } = await callProxy<InstallResult>(
+      "v1/bundles/install",
+      { bundle: preview.bundle, setup_values: setupValues }
+    );
+
+    setInstallLoading(false);
+
+    if (error || !data) {
+      setInstallError(error ?? "Installation failed.");
+      return;
+    }
+
+    setResult(data);
+    setStep("result");
+  }
+
+  function handleReset() {
+    setStep("source");
+    setSource("");
+    setAnalyzeError(null);
+    setPreview(null);
+    setSetupValues({});
+    setSetupErrors({});
+    setInstallError(null);
+    setResult(null);
+  }
+
+  const installDisabled =
+    !preview ||
+    !preview.installable ||
+    installLoading ||
+    hasRequiredEmpty(preview?.setup ?? [], setupValues);
+
+  if (step === "source") {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <div className="space-y-2 rounded-lg border border-border/60 bg-white p-6 dark:border-zinc-700/60 dark:bg-zinc-900">
+          <div className="grid gap-2">
+            <FormLabel htmlFor="package-source" icon={PackagePlus} required>
+              Package Source
+            </FormLabel>
+            <Textarea
+              id="package-source"
+              placeholder="Paste your agent package YAML or JSON here..."
+              value={source}
+              onChange={(e) => {
+                setSource(e.target.value);
+                setAnalyzeError(null);
+              }}
+              rows={12}
+              className={cn(
+                "font-mono text-xs",
+                analyzeError ? "border-red-300" : ""
+              )}
+            />
+            {analyzeError && (
+              <p className="form-error">{analyzeError}</p>
+            )}
+            <p className="note">
+              Paste a valid agent package definition in YAML or JSON format.
+            </p>
+          </div>
+          <div className="flex justify-end pt-2">
+            <Button
+              onClick={handleAnalyze}
+              disabled={!source.trim() || analyzeLoading}
+              isLoading={analyzeLoading}
+            >
+              {!analyzeLoading && "Analyze Package"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === "review" && preview) {
+    const grouped = groupEntitiesByKind(preview.entities);
+    const blockIssues = preview.issues.filter((i) => i.severity === "block");
+    const warnIssues = preview.issues.filter((i) => i.severity === "warn");
+
+    return (
+      <div className="mx-auto max-w-2xl space-y-4">
+        {/* Package header */}
+        <div className="rounded-lg border border-border/60 bg-white p-5 dark:border-zinc-700/60 dark:bg-zinc-900">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h2 className="truncate text-base font-semibold">
+                {preview.bundle.display_name ?? preview.bundle.name}
+              </h2>
+              {preview.bundle.description && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {preview.bundle.description}
+                </p>
+              )}
+            </div>
+            <span className="shrink-0 rounded bg-zinc-100 px-2 py-0.5 font-mono text-[10px] text-zinc-500 dark:bg-zinc-800">
+              v{preview.bundle.schema_version}
+            </span>
+          </div>
+        </div>
+
+        {/* Entities */}
+        {preview.entities.length > 0 && (
+          <div className="rounded-lg border border-border/60 bg-white dark:border-zinc-700/60 dark:bg-zinc-900">
+            <div className="border-b border-border/60 px-5 py-3 dark:border-zinc-700/60">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                What will be installed
+              </div>
+            </div>
+            <div className="divide-y divide-border/40 dark:divide-zinc-700/40">
+              {ENTITY_ORDER.map((kind) => {
+                const list = grouped.get(kind);
+                if (!list || list.length === 0) return null;
+                return (
+                  <div key={kind} className="px-5 py-3">
+                    <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {KIND_LABELS[kind]}
+                    </div>
+                    <div className="divide-y divide-border/20 dark:divide-zinc-700/20">
+                      {list.map((entity) => (
+                        <EntityRow key={entity.key} entity={entity} />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Issues */}
+        {preview.issues.length > 0 && (
+          <div className="space-y-2">
+            {blockIssues.map((issue, idx) => (
+              <div
+                key={idx}
+                className="flex items-start gap-2.5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+                <p className="text-sm text-red-700 dark:text-red-400">{issue.message}</p>
+              </div>
+            ))}
+            {warnIssues.map((issue, idx) => (
+              <div
+                key={idx}
+                className="flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/50 dark:bg-amber-950/30"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                <p className="text-sm text-amber-700 dark:text-amber-400">{issue.message}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Setup form */}
+        {preview.setup.length > 0 && (
+          <div className="rounded-lg border border-border/60 bg-white dark:border-zinc-700/60 dark:bg-zinc-900">
+            <div className="border-b border-border/60 px-5 py-3 dark:border-zinc-700/60">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Configuration
+              </div>
+            </div>
+            <div className="px-5 py-4">
+              <SetupForm
+                schema={preview.setup}
+                values={setupValues}
+                onChange={handleSetupChange}
+                errors={setupErrors}
+                disabled={installLoading}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Install error */}
+        {installError && (
+          <div className="flex items-start gap-2.5 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+            <p className="text-sm text-red-700 dark:text-red-400">{installError}</p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <Button
+            variant="outline"
+            onClick={handleReset}
+            disabled={installLoading}
+          >
+            Back
+          </Button>
+          <Button
+            onClick={handleInstall}
+            disabled={installDisabled}
+            isLoading={installLoading}
+          >
+            {!installLoading && "Install Package"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === "result" && result) {
+    const grouped = groupInstalledByKind(result.entities);
+
+    return (
+      <div className="mx-auto max-w-2xl space-y-4">
+        {/* Success header */}
+        <div className="flex items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-5 py-4 dark:border-emerald-900/50 dark:bg-emerald-950/30">
+          <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-500" />
+          <div>
+            <p className="text-sm font-medium text-emerald-800 dark:text-emerald-300">
+              Package installed successfully
+            </p>
+            <p className="text-xs text-emerald-700 dark:text-emerald-400">
+              {result.bundle_name}
+            </p>
+          </div>
+        </div>
+
+        {/* Installed entities */}
+        {result.entities.length > 0 && (
+          <div className="rounded-lg border border-border/60 bg-white dark:border-zinc-700/60 dark:bg-zinc-900">
+            <div className="border-b border-border/60 px-5 py-3 dark:border-zinc-700/60">
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Installed entities
+              </div>
+            </div>
+            <div className="divide-y divide-border/40 dark:divide-zinc-700/40">
+              {ENTITY_ORDER.map((kind) => {
+                const list = grouped.get(kind);
+                if (!list || list.length === 0) return null;
+                return (
+                  <div key={kind} className="px-5 py-3">
+                    <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {KIND_LABELS[kind]}
+                    </div>
+                    <div className="divide-y divide-border/20 dark:divide-zinc-700/20">
+                      {list.map((entity) => (
+                        <InstalledEntityRow key={entity.key} entity={entity} />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-3 pt-1">
+          <Button onClick={handleReset} variant="outline">
+            <RotateCcw className="h-4 w-4" />
+            Import another
+          </Button>
+          <Button asChild>
+            <Link href="/agents">Go to Agents</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/agentarea-webapp/src/app/(main)/bundles/import/page.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/import/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import ContentBlock from "@/components/ContentBlock";
+import ImportWizard from "../components/ImportWizard";
+
+export const metadata: Metadata = {
+  title: "Import Agent Package",
+};
+
+export default function ImportBundlePage() {
+  return (
+    <ContentBlock
+      header={{
+        breadcrumb: [
+          { label: "Bundles", href: "/bundles" },
+          { label: "Import" },
+        ],
+        description: "Install a pre-built agent package into your workspace.",
+      }}
+    >
+      <ImportWizard />
+    </ContentBlock>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/bundles/types.ts
+++ b/agentarea-webapp/src/app/(main)/bundles/types.ts
@@ -1,0 +1,95 @@
+// TODO: replace with generated components['schemas'] after running npm run generate:schema
+// (requires the backend API running on :8000 — run `npm run generate:schema` post-deploy)
+
+export type SetupFieldType = "secret" | "string" | "number" | "boolean" | "select";
+
+export interface SetupField {
+  key: string;
+  label: string;
+  type: SetupFieldType;
+  required: boolean;
+  help?: string | null;
+  default?: string | number | boolean | null;
+  options?: string[] | null;
+  min?: number | null;
+  max?: number | null;
+}
+
+export interface PackageMcp {
+  key: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface PackageSkill {
+  key: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface PackageAgent {
+  key: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface PackageAutomation {
+  key: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface Bundle {
+  schema_version: string;
+  name: string;
+  display_name?: string | null;
+  description: string;
+  setup: SetupField[];
+  mcps: PackageMcp[];
+  skills: PackageSkill[];
+  agents: PackageAgent[];
+  automations: PackageAutomation[];
+}
+
+export type EntityKind = "mcp" | "skill" | "agent" | "automation";
+export type EntityStatus = "will_create" | "already_exists" | "unsupported";
+export type IssueSeverity = "block" | "warn";
+
+export interface PreviewEntity {
+  kind: EntityKind;
+  key: string;
+  name: string;
+  status: EntityStatus;
+  detail?: string | null;
+}
+
+export interface PreviewIssue {
+  severity: IssueSeverity;
+  message: string;
+  entity_key?: string | null;
+}
+
+export interface ImportPreview {
+  bundle: Bundle;
+  setup: SetupField[];
+  entities: PreviewEntity[];
+  issues: PreviewIssue[];
+  installable: boolean;
+}
+
+export type InstallAction = "created" | "reused" | "skipped";
+
+export interface InstalledEntity {
+  kind: EntityKind;
+  key: string;
+  name: string;
+  action: InstallAction;
+  id?: string | null;
+  detail?: string | null;
+}
+
+export interface InstallResult {
+  bundle_name: string;
+  installed_bundle_id?: string | null;
+  entities: InstalledEntity[];
+}

--- a/agentarea-webapp/src/components/SetupForm/SetupForm.tsx
+++ b/agentarea-webapp/src/components/SetupForm/SetupForm.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import FormLabel from "@/components/FormLabel/FormLabel";
+import { cn } from "@/lib/utils";
+import type { SetupField } from "@/app/(main)/bundles/types";
+
+export interface SetupFormProps {
+  schema: SetupField[];
+  values: Record<string, string | number | boolean>;
+  onChange: (key: string, value: string | number | boolean) => void;
+  errors?: Record<string, string>;
+  disabled?: boolean;
+}
+
+export default function SetupForm({
+  schema,
+  values,
+  onChange,
+  errors,
+  disabled = false,
+}: SetupFormProps) {
+  if (!schema || schema.length === 0) {
+    return (
+      <p className="note">No configuration required.</p>
+    );
+  }
+
+  const getErrorText = (key: string): string | undefined => {
+    return errors?.[key];
+  };
+
+  return (
+    <div className="grid gap-4">
+      {schema.map((field) => {
+        const errorText = getErrorText(field.key);
+        const value = values[field.key];
+
+        return (
+          <div key={field.key} className="grid gap-2">
+            <FormLabel htmlFor={`setup_${field.key}`} required={field.required}>
+              {field.label}
+            </FormLabel>
+
+            {field.type === "boolean" ? (
+              <Switch
+                id={`setup_${field.key}`}
+                checked={Boolean(value ?? field.default ?? false)}
+                onCheckedChange={(checked) => onChange(field.key, checked)}
+                disabled={disabled}
+              />
+            ) : field.type === "select" ? (
+              <Select
+                value={String(value ?? field.default ?? "")}
+                onValueChange={(val) => onChange(field.key, val)}
+                disabled={disabled}
+              >
+                <SelectTrigger
+                  id={`setup_${field.key}`}
+                  className={cn(errorText ? "border-red-300" : "")}
+                >
+                  <SelectValue placeholder={`Select ${field.label}`} />
+                </SelectTrigger>
+                <SelectContent>
+                  {(field.options ?? []).map((opt) => (
+                    <SelectItem key={opt} value={opt}>
+                      {opt}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : field.type === "number" ? (
+              <Input
+                id={`setup_${field.key}`}
+                type="number"
+                value={String(value ?? field.default ?? "")}
+                min={field.min ?? undefined}
+                max={field.max ?? undefined}
+                onChange={(e) => {
+                  const parsed = e.target.value === "" ? "" : Number(e.target.value);
+                  onChange(field.key, parsed as number);
+                }}
+                disabled={disabled}
+                className={cn(errorText ? "border-red-300" : "")}
+              />
+            ) : field.type === "secret" ? (
+              <Input
+                id={`setup_${field.key}`}
+                type="password"
+                autoComplete="off"
+                value={String(value ?? "")}
+                onChange={(e) => onChange(field.key, e.target.value)}
+                disabled={disabled}
+                className={cn(errorText ? "border-red-300" : "")}
+              />
+            ) : (
+              <Input
+                id={`setup_${field.key}`}
+                type="text"
+                value={String(value ?? field.default ?? "")}
+                onChange={(e) => onChange(field.key, e.target.value)}
+                disabled={disabled}
+                className={cn(errorText ? "border-red-300" : "")}
+              />
+            )}
+
+            {field.help && <p className="note">{field.help}</p>}
+
+            {errorText && (
+              <p className="form-error">{errorText}</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/components/SetupForm/index.ts
+++ b/agentarea-webapp/src/components/SetupForm/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SetupForm";
+export type { SetupFormProps } from "./SetupForm";


### PR DESCRIPTION
## What

Introduces **bundles** — a canonical, declarative format that packages **MCP servers + skills + agents + cron automations** behind a setup form, plus `analyze`/`install` endpoints that provision them into a workspace. One reusable unit you import and configure, rather than wiring each piece by hand.

## Why this shape

- **Not "agent-packages"/"templates"** — it bundles more than agents (connections, knowledge, workers, schedules), so it's a *bundle*.
- A **Claude plugin is an importer into this format, not the format** — Claude has no scheduled-agent concept, so our format must exist regardless; `automations` is our extension.

## Backend (`libs/bundles`)

- Canonical `Bundle` format: `setup / mcps / skills / agents / automations`, refs by `key`, `${setup.x}` placeholders, pydantic/JSON-schema validation.
- **Analyzer → `ImportPreview`**: per-entity status (`will_create` / `already_exists` / `unsupported`), `block`/`warn` issues, `installable` flag, idempotency by name.
- **Installer** composes existing services (MCP spec+instance, skills, agents, triggers) in dependency order. Secrets are flagged by `SetupField.type` and routed through the secret manager.
- `InstalledBundle` provenance model + migration (`installed_bundles`).
- `POST /v1/bundles/analyze` and `POST /v1/bundles/install`.

## Frontend

- Schema-driven **`SetupForm`** component (widget per field type: secret/string/number/boolean/select).
- **Import wizard** at `/bundles`: source → analyze → review (entities + issues) + setup → install → result.

## Notable correctness details

- **Automations import disabled.** `TriggerCreate.to_domain` drops `enabled` and `create_trigger` schedules cron unconditionally, so the installer calls `disable_trigger` after create — an imported cron never runs the agent before the user activates it.
- **Unsupported MCPs skipped.** `${CLAUDE_PLUGIN_ROOT}`-relative local binaries can't run in our container runtime → detected and skipped with a warning; stdio servers (`npx`/`uvx`) run via the mcp-bridge.

## Tests / checks

- 22 backend unit tests (format / analyzer / installer) passing; `ruff` clean.
- Frontend `tsc --noEmit` clean. (ESLint couldn't run locally — env OOM.)

## Not in this PR / follow-ups

- Migration not yet applied to a live DB (`cd apps/api && alembic upgrade head`).
- Claude-plugin directory/zip adapter into the canonical format.
- GitHub-skill install (declared/parsed but currently marked `skipped`).