### PR TITLE
fix(ci): resolve C414 lint and OpenAPI schema drift

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -1155,8 +1155,8 @@ async def submit_task_input(
             "status": "accepted",
             "task_id": str(task_id),
             "input_request_id": submission.input_request_id,
-            "answer_keys": sorted(list(submission.answers.keys())),
-            "secret_keys": sorted(list(secret_refs.keys())),
+            "answer_keys": sorted(submission.answers.keys()),
+            "secret_keys": sorted(secret_refs.keys()),
         }
 
     except HTTPException:

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -1980,9 +1980,7 @@ class AgentExecutionWorkflow:
                 }:
                     field_type = "text"
                 options = [
-                    str(option)
-                    for option in (raw.get("options") or [])
-                    if str(option).strip()
+                    str(option) for option in (raw.get("options") or []) if str(option).strip()
                 ]
                 question = {
                     "id": field_id,

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -337,8 +337,8 @@ class AgentExecutionWorkflow:
                 "UserInputSubmitted",
                 {
                     "input_request_id": input_request_id,
-                    "answer_keys": sorted(list((payload.get("answers") or {}).keys())),
-                    "secret_keys": sorted(list((payload.get("secret_refs") or {}).keys())),
+                    "answer_keys": sorted((payload.get("answers") or {}).keys()),
+                    "secret_keys": sorted((payload.get("secret_refs") or {}).keys()),
                 },
             )
         workflow.logger.info(f"User input submitted: {input_request_id}")
@@ -1920,8 +1920,8 @@ class AgentExecutionWorkflow:
             {
                 "input_request_id": input_request_id,
                 "tool_call_id": tool_call.id,
-                "answer_keys": sorted(list((submission.get("answers") or {}).keys())),
-                "secret_keys": sorted(list((submission.get("secret_refs") or {}).keys())),
+                "answer_keys": sorted((submission.get("answers") or {}).keys()),
+                "secret_keys": sorted((submission.get("secret_refs") or {}).keys()),
                 "iteration": self.state.current_iteration,
             },
         )

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -622,6 +622,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/agents/{agent_id}/tasks/{task_id}/input": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Submit Task Input
+         * @description Submit structured user input to a workflow waiting on request_user_input.
+         *
+         *     Secret values are written to the workspace secret manager at the API boundary.
+         *     Only secret refs are sent to Temporal/LLM context.
+         */
+        post: operations["submit_task_input_v1_agents__agent_id__tasks__task_id__input_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/agents/{agent_id}/tasks/{task_id}/pause": {
         parameters: {
             query?: never;
@@ -5267,6 +5290,16 @@ export interface components {
             total: number;
         };
         /**
+         * InputSecretValue
+         * @description Secret value submitted through the protected input endpoint.
+         */
+        InputSecretValue: {
+            /** Secret Name */
+            secret_name?: string | null;
+            /** Value */
+            value: string;
+        };
+        /**
          * InstallAction
          * @enum {string}
          */
@@ -7250,6 +7283,22 @@ export interface components {
             /** Total */
             total: number;
         };
+        /**
+         * TaskInputSubmission
+         * @description Structured user input submission for a pending workflow input request.
+         */
+        TaskInputSubmission: {
+            /** Answers */
+            answers?: {
+                [key: string]: unknown;
+            };
+            /** Input Request Id */
+            input_request_id: string;
+            /** Secrets */
+            secrets?: {
+                [key: string]: string | components["schemas"]["InputSecretValue"];
+            };
+        };
         /** TaskResponse */
         TaskResponse: {
             /**
@@ -9204,6 +9253,42 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    submit_task_input_v1_agents__agent_id__tasks__task_id__input_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TaskInputSubmission"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/agentarea-webapp/src/app/(main)/agents/[id]/components/AgentOverview.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/components/AgentOverview.tsx
@@ -19,8 +19,9 @@ import {
   getAgentIconComponent,
   resolveAgentIdentity,
 } from "@/lib/agent-identity";
-import { getAgent, listAgentTasks, type Agent } from "@/lib/api";
+import { getAgent, listAgentTasks } from "@/lib/api";
 import { getAgentOverview, getWorkspaceSettings } from "@/lib/api-dashboard";
+import type { Agent } from "@/types/agent";
 import { cn } from "@/lib/utils";
 
 const fmtUsd = (v: number) =>


### PR DESCRIPTION
## Problem

`main` is red on two CI checks, both inherited from the structured human input workflow (#208):

- **CI/CD Pipeline → platform-lint**: 6 × `C414 Unnecessary list() call within sorted()` in `agents_tasks.py` and `agent_execution_workflow.py`.
- **Schema Drift Check**: committed `agentarea-webapp/src/api/schema.d.ts` is stale — missing the new `submit_task_input` endpoint (`/v1/agents/{agent_id}/tasks/{task_id}/input`) and the `TaskInputSubmission` schema.

## Fix

- Drop the redundant inner `list()` calls — `sorted(d.keys())` is semantically identical to `sorted(list(d.keys()))`.
- Regenerate `schema.d.ts` from the live FastAPI spec using the same `npx openapi-typescript` path CI uses, so the committed file matches backend output. No endpoints removed — only reordering plus the new `/input` route and `TaskInputSubmission` schema.

## Verification

- `uv run ruff check .` — all checks pass.
- `export-openapi.py` + `npx openapi-typescript` output is byte-identical to the committed `schema.d.ts` (Schema Drift `diff -q` passes).