### PR TITLE
feat(registry): catalog source manifest + reconcile auto-detect (+docker manifest CI fix)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -323,6 +323,7 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         env:
           PRIMARY_IMAGE: ${{ steps.image.outputs.primary }}
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
@@ -331,5 +332,12 @@ jobs:
       - name: Inspect manifest
         env:
           PRIMARY_IMAGE: ${{ steps.image.outputs.primary }}
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
         run: |
-          docker buildx imagetools inspect "${PRIMARY_IMAGE}:${{ steps.version.outputs.version }}-${{ github.sha }}"
+          MANIFEST_TAG="$(
+            jq -er --arg image "$PRIMARY_IMAGE" '
+              .tags | map(select(startswith($image + ":"))) | first
+            ' <<< "$DOCKER_METADATA_OUTPUT_JSON"
+          )"
+
+          docker buildx imagetools inspect "$MANIFEST_TAG"

--- a/agentarea-platform/apps/api/agentarea_api/cli.py
+++ b/agentarea-platform/apps/api/agentarea_api/cli.py
@@ -198,16 +198,25 @@ def validate():
 @click.option(
     "--source",
     multiple=True,
-    help="Registry source file/URL (can be repeated). Auto-detects type.",
+    help="Registry source file/URL (can be repeated). Type is auto-detected.",
 )
-def reconcile(registries_config: str | None, source: tuple[str, ...]):
+@click.option(
+    "--config-file",
+    default=None,
+    help="Path to a YAML/JSON manifest listing registry sources.",
+)
+def reconcile(registries_config: str | None, source: tuple[str, ...], config_file: str | None):
     """Idempotent reconcile — ensure registries exist and sync them."""
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 
-    asyncio.run(_reconcile(registries_config, source))
+    asyncio.run(_reconcile(registries_config, source, config_file))
 
 
-async def _reconcile(registries_config: str | None, sources: tuple[str, ...]):
+async def _reconcile(
+    registries_config: str | None,
+    sources: tuple[str, ...],
+    config_file: str | None = None,
+):
     """Async reconcile implementation."""
     from agentarea_common.auth.context import UserContext
     from agentarea_mcp.infrastructure.repository import MCPServerRepository
@@ -233,21 +242,30 @@ async def _reconcile(registries_config: str | None, sources: tuple[str, ...]):
             click.echo(f"Failed to parse REGISTRIES_CONFIG: {e}")
             sys.exit(1)
 
-    # Add any --source args as auto-detected registries
+    # Load a manifest file (YAML or JSON list of registry definitions)
+    if config_file:
+        import yaml
+
+        try:
+            with open(config_file) as f:
+                file_configs = yaml.safe_load(f)
+        except (OSError, yaml.YAMLError) as e:
+            click.echo(f"Failed to read --config-file {config_file}: {e}")
+            sys.exit(1)
+        if not isinstance(file_configs, list):
+            click.echo(f"--config-file {config_file} must contain a list of registries")
+            sys.exit(1)
+        configs.extend(file_configs)
+        click.echo(f"Loaded {len(file_configs)} registries from {config_file}")
+
+    # Add any --source args (type is inferred from the fetched payload)
     for src in sources:
         name = (
             os.path.basename(src).rsplit(".", 1)[0]
             if not src.startswith("http")
             else src.split("/")[-1]
         )
-        configs.append(
-            {
-                "name": name,
-                "type": "mcp_servers",
-                "source_type": "url",
-                "source_url": src,
-            }
-        )
+        configs.append({"name": name, "source_url": src})
 
     if not configs:
         click.echo("No registry config provided (set REGISTRIES_CONFIG or use --source)")
@@ -318,9 +336,13 @@ async def _reconcile(registries_config: str | None, sources: tuple[str, ...]):
                     registry_id = existing.id
                     click.echo(f"Found existing registry: {registry_id}")
                 else:
+                    registry_type = config.get("type")
+                    if not registry_type:
+                        registry_type = service.detect_type_from_source(config["source_url"])
+                        click.echo(f"Detected type: {registry_type}")
                     registry = await service.create_registry(
                         name=registry_name,
-                        registry_type=config.get("type", "mcp_servers"),
+                        registry_type=registry_type,
                         source_type=config.get("source_type", "url"),
                         source_url=config["source_url"],
                         description=config.get("description"),

--- a/agentarea-platform/apps/api/agentarea_api/cli.py
+++ b/agentarea-platform/apps/api/agentarea_api/cli.py
@@ -271,6 +271,13 @@ async def _reconcile(
         click.echo("No registry config provided (set REGISTRIES_CONFIG or use --source)")
         return
 
+    # Validate up front so a malformed entry reports a clear message instead of
+    # failing deep inside the per-registry loop with a bare KeyError.
+    for i, config in enumerate(configs):
+        if not isinstance(config, dict) or "name" not in config or "source_url" not in config:
+            click.echo(f"Registry entry {i} must be a mapping with 'name' and 'source_url'")
+            sys.exit(1)
+
     skill_repo_cls = None
     try:
         from agentarea_agents.infrastructure.skill_repository import SkillRepository
@@ -338,6 +345,10 @@ async def _reconcile(
                 else:
                     registry_type = config.get("type")
                     if not registry_type:
+                        # Detection fetches the source to inspect its shape; the
+                        # subsequent sync_registry fetches it again to parse. The
+                        # extra GET is acceptable for a one-shot reconcile — set an
+                        # explicit `type` in the manifest to skip detection.
                         registry_type = service.detect_type_from_source(config["source_url"])
                         click.echo(f"Detected type: {registry_type}")
                     registry = await service.create_registry(

--- a/agentarea-platform/libs/registry/agentarea_registry/application/service.py
+++ b/agentarea-platform/libs/registry/agentarea_registry/application/service.py
@@ -40,6 +40,17 @@ VALID_REGISTRY_TYPES = (
 )
 VALID_SOURCE_TYPES = ("url", "github", "api")
 
+# Top-level catalog key -> registry type. Each catalog document carries exactly
+# one of these keys, so the registry type can be inferred from the payload shape
+# when it is not stated explicitly.
+TYPE_BY_TOPLEVEL_KEY = {
+    "servers": "mcp_servers",
+    "skills": "skills",
+    "providers": "llm_providers",
+    "models": "llm_models",
+    "agents": "agents",
+}
+
 
 class RegistryService:
     """Manages registry CRUD, sync, and spec update operations."""
@@ -517,6 +528,28 @@ class RegistryService:
             return json.loads(raw)
         except json.JSONDecodeError:
             return yaml.safe_load(raw)
+
+    @staticmethod
+    def _detect_type(data: Any) -> str:
+        """Infer the registry type from a fetched catalog's top-level key."""
+        if not isinstance(data, dict):
+            raise ValueError("cannot detect registry type: source root is not a mapping")
+        matched = [
+            rtype for key, rtype in TYPE_BY_TOPLEVEL_KEY.items() if isinstance(data.get(key), list)
+        ]
+        if len(matched) == 1:
+            return matched[0]
+        if not matched:
+            raise ValueError(
+                "cannot detect registry type: expected one top-level key of "
+                f"{list(TYPE_BY_TOPLEVEL_KEY)}"
+            )
+        raise ValueError(f"ambiguous registry type: multiple catalog keys present {matched}")
+
+    @classmethod
+    def detect_type_from_source(cls, source_url: str) -> str:
+        """Fetch a source and infer its registry type from the payload shape."""
+        return cls._detect_type(cls._fetch_source(source_url))
 
     # ── Source parsing (type-dispatched) ──
 

--- a/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
+++ b/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
@@ -5,7 +5,9 @@ DB-coupled entity creation is verified in operator handler tests and the
 end-to-end minikube smoke test.
 """
 
+import pytest
 from agentarea_registry.application.service import (
+    TYPE_BY_TOPLEVEL_KEY,
     VALID_REGISTRY_TYPES,
     RegistryService,
 )
@@ -22,6 +24,58 @@ class TestValidTypes:
 
     def test_includes_agents(self):
         assert "agents" in VALID_REGISTRY_TYPES
+
+
+class TestDetectType:
+    @pytest.mark.parametrize(("key", "expected"), list(TYPE_BY_TOPLEVEL_KEY.items()))
+    def test_detects_each_type_from_its_key(self, key, expected):
+        assert RegistryService._detect_type({key: []}) == expected
+
+    def test_every_detectable_type_is_a_valid_registry_type(self):
+        # Guards the mapping against drift: every detected type must be one
+        # create_registry accepts, and every valid type must be detectable.
+        assert set(TYPE_BY_TOPLEVEL_KEY.values()) == set(VALID_REGISTRY_TYPES)
+
+    def test_detection_key_matches_parser_key(self):
+        # The detection key for each type must be the same top-level key the
+        # corresponding parser reads, or detection silently mis-routes. Feed a
+        # one-item doc under the detected key and assert the parser sees it.
+        sentinels = {
+            "mcp_servers": {
+                "servers": [
+                    {
+                        "server": {
+                            "name": "x/y",
+                            "remotes": [{"type": "streamable-http", "url": "https://x"}],
+                        }
+                    }
+                ]
+            },
+            "skills": {"skills": [{"name": "x"}]},
+            "llm_providers": {"providers": [{"provider_key": "x", "name": "X"}]},
+            "llm_models": {"models": [{"provider_key": "x", "model_name": "m"}]},
+            "agents": {"agents": [{"name": "x"}]},
+        }
+        for rtype, data in sentinels.items():
+            assert RegistryService._detect_type(data) == rtype
+            assert len(RegistryService._parse_source(rtype, data)) == 1
+
+    def test_rejects_unknown_shape(self):
+        with pytest.raises(ValueError, match="cannot detect registry type"):
+            RegistryService._detect_type({"widgets": []})
+
+    def test_rejects_non_mapping(self):
+        with pytest.raises(ValueError, match="not a mapping"):
+            RegistryService._detect_type([{"name": "x"}])
+
+    def test_rejects_ambiguous_shape(self):
+        with pytest.raises(ValueError, match="ambiguous"):
+            RegistryService._detect_type({"servers": [], "skills": []})
+
+    def test_ignores_non_list_key(self):
+        # A key present but not a list must not trigger a match.
+        with pytest.raises(ValueError, match="cannot detect registry type"):
+            RegistryService._detect_type({"servers": {"not": "a list"}})
 
 
 class TestParseLLMProviders:
@@ -196,9 +250,7 @@ class TestParseSourceDispatch:
         assert result[0]["external_id"] == "p/m"
 
     def test_dispatches_agents(self):
-        result = RegistryService._parse_source(
-            "agents", {"agents": [{"name": "A"}]}
-        )
+        result = RegistryService._parse_source("agents", {"agents": [{"name": "A"}]})
         assert result[0]["name"] == "A"
 
     def test_unknown_type_raises(self):

--- a/data/registry-sources.yaml
+++ b/data/registry-sources.yaml
@@ -1,0 +1,54 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentArea platform catalog sources (canonical record — do not lose these URLs)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Remote registries that seed the built-in catalog (registry_items) for a
+# platform install. They live in our S3 bucket `agentarea-mcp-registry` and are
+# produced by the landing repo (../landing):
+#   - MCP servers : mirror of registry.modelcontextprotocol.io (3.6k+ servers)
+#   - Skills      : transform of majiayu000/claude-skill-registry, sharded by
+#                   ../landing/scripts/build-skills.mjs
+#
+# HOW TO INSTALL (reconcile into the system)
+#   Feed this manifest to the idempotent `reconcile` CLI command:
+#
+#       uv run agentarea-api reconcile --config-file data/registry-sources.yaml
+#
+#   reconcile creates each registry if missing, fetches the source URL, infers
+#   the type from the payload shape, parses it, and upserts catalog items.
+#   Re-run any time to resync.
+#
+# Each entry:
+#   name        registry name (stable identifier)
+#   source_url  HTTP(S) URL or local path to the catalog document
+#   type        optional — auto-detected from the payload when omitted
+#   description optional human note
+# ─────────────────────────────────────────────────────────────────────────────
+
+- name: mcp-servers-catalog
+  # S3 mirror of the official MCP registry ({ servers: [...] }).
+  source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/mcp-servers.json
+  description: Built-in MCP server catalog (mirror of registry.modelcontextprotocol.io)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Skills catalog (S3) — REFERENCE ONLY, not yet reconcilable.
+#
+# The skills registry on S3 uses the landing site's *paginated* layout, which
+# does not match the reconcile skills parser (it expects a single
+# `{ skills: [...] }` document with content/members/s3_path). Captured here so
+# the URLs are not lost; add an active entry once either the parser learns the
+# paginated shape or a flattened `skills.json` is published.
+#
+# Base:  https://agentarea-mcp-registry.s3.amazonaws.com/registry/skills
+#   index.json                  — metadata, categories, topByStars, pagesTotal
+#   lookup.json                 — { skillId: pageNumber }
+#   pages/page-{N}.json         — 100 skills per shard (1..pagesTotal), stars DESC
+#   categories/{category}.json  — all skills for a category
+#
+# Upstream (rebuilt + uploaded by ../landing/scripts/build-skills.mjs):
+#   https://raw.githubusercontent.com/majiayu000/claude-skill-registry-core/main/registry.json
+#
+# - name: skills-catalog
+#   source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/skills/skills.json
+#   description: Built-in skills catalog
+# ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two changes — a backend feature and an unrelated CI hotfix that was pending in the tree (kept as separate commits).

## 1. Registry catalog sources + reconcile auto-detection
- **`data/registry-sources.yaml`** — canonical manifest of the platform's S3 catalog sources (`agentarea-mcp-registry`), so the URLs aren't lost. MCP servers active; skills documented (their paginated S3 layout doesn't match the skills parser yet).
- **`reconcile --config-file <path>`** — feed the manifest to the existing idempotent reconcile:
  ```
  uv run agentarea-api reconcile --config-file data/registry-sources.yaml
  ```
- **Registry-type auto-detection** — `RegistryService.detect_type_from_source` infers the type from the payload's top-level key (`servers`→mcp_servers, `skills`, `providers`→llm_providers, `models`→llm_models, `agents`). `--source` and manifest entries no longer hardcode `mcp_servers`; `type` is optional everywhere and only needed as an override.

Reuses the existing `RegistryService.sync_registry` engine — no resurrection of the removed `ReconcilerService`.

## 2. CI: docker multi-arch manifest inspect fix
The Inspect step hardcoded `${version}-${github.sha}` (full SHA), but `docker/metadata-action` emits the short-SHA tag → inspect targeted a nonexistent tag and failed. Now selects the actual produced tag from `DOCKER_METADATA_OUTPUT_JSON`.

## Verification
- `ruff check` + `ruff format --check` clean on changed files.
- Detection unit-tested (5 types + 3 rejection cases) and live against the real MCP S3 source → `mcp_servers`, 4247 items parsed, 0 malformed.
- Both YAML files validated.