### PR TITLE
fix(mcp): bind registry_item_id as uuid so catalog reconcile works from zero

### DIFF
--- a/agentarea-platform/libs/mcp/agentarea_mcp/domain/models.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/domain/models.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 from agentarea_common.base.models import AuditMixin, BaseModel, WorkspaceScopedMixin
 from sqlalchemy import JSON, Boolean, String, UniqueConstraint
@@ -30,9 +31,11 @@ class MCPServer(BaseModel, WorkspaceScopedMixin, AuditMixin):
     cmd: Mapped[list[str] | None] = mapped_column(JSON, nullable=True, default=None)
     # Remote URL for URL-type MCP servers (e.g. https://api.githubcopilot.com/mcp/)
     remote_url: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
-    # Provenance: links back to the registry catalog item this spec was installed from
-    registry_item_id: Mapped[str | None] = mapped_column(
-        PG_UUID(as_uuid=False), nullable=True, default=None
+    # Provenance: links back to the registry catalog item this spec was installed from.
+    # Column is a real Postgres uuid; bind as UUID (as_uuid=False makes asyncpg send a
+    # VARCHAR, which Postgres rejects against the uuid column on insert).
+    registry_item_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True, default=None
     )
     # Raw ServerJSON spec from MCP registry — source of truth for icons, headers, variables, etc.
     json_spec: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True, default=None)
@@ -52,7 +55,7 @@ class MCPServer(BaseModel, WorkspaceScopedMixin, AuditMixin):
         env_schema: list[dict[str, Any]] | None = None,
         cmd: list[str] | None = None,
         remote_url: str | None = None,
-        registry_item_id: str | None = None,
+        registry_item_id: UUID | str | None = None,
         json_spec: dict[str, Any] | None = None,
         registry_url: str | None = None,
         # Note: user_id and workspace_id are now handled by BaseModel
@@ -71,6 +74,8 @@ class MCPServer(BaseModel, WorkspaceScopedMixin, AuditMixin):
         self.env_schema = env_schema or []
         self.cmd = cmd
         self.remote_url = remote_url
-        self.registry_item_id = registry_item_id
+        self.registry_item_id = (
+            UUID(registry_item_id) if isinstance(registry_item_id, str) else registry_item_id
+        )
         self.json_spec = json_spec
         self.registry_url = registry_url

--- a/agentarea-platform/libs/mcp/tests/test_catalog_mcp.py
+++ b/agentarea-platform/libs/mcp/tests/test_catalog_mcp.py
@@ -58,7 +58,8 @@ def test_project_marks_read_only_with_provenance():
     item = _item(spec={"connection_type": "url", "url": "https://api/mcp", "env_schema": []})
     server = _project_catalog_mcp_server(item)
     assert str(server.id) == item.id
-    assert server.registry_item_id == item.id
+    # registry_item_id is stored as a real uuid; the fixture id is its string form
+    assert str(server.registry_item_id) == item.id
     assert server.is_catalog is True
     assert server.remote_url == "https://api/mcp"
     assert server.registry_url == "https://registry.example.com"

--- a/agentarea-platform/libs/mcp/tests/test_mcp_models.py
+++ b/agentarea-platform/libs/mcp/tests/test_mcp_models.py
@@ -1,0 +1,16 @@
+from uuid import UUID
+
+from agentarea_mcp.domain.models import MCPServer
+
+
+def test_registry_item_id_binds_as_uuid():
+    """registry_item_id maps to a real Postgres uuid column.
+
+    With as_uuid=False the asyncpg dialect binds the value as VARCHAR, which
+    Postgres rejects against the uuid column on insert (the catalog reconcile
+    failed with DatatypeMismatchError). Guard the binding type so it can't
+    regress to a string bind.
+    """
+    col = MCPServer.__table__.c.registry_item_id
+    assert col.type.python_type is UUID
+    assert getattr(col.type, "as_uuid", False) is True


### PR DESCRIPTION
## Problem

A from-zero quickstart deploy (`install.sh` → `agentarea up` → `agentarea reconcile`) fails when populating the built-in MCP catalog:

```
sqlalchemy.exc.ProgrammingError: asyncpg.exceptions.DatatypeMismatchError:
column "registry_item_id" is of type uuid but expression is of type character varying
INSERT INTO mcp_servers (... registry_item_id ...) VALUES (... $11::VARCHAR ...)
```

`mcp_servers.registry_item_id` is created as a real Postgres `uuid` column (migration `008_add_registries`), but the SQLAlchemy model declared it as `PG_UUID(as_uuid=False)`. With `as_uuid=False` the asyncpg dialect binds the value as `VARCHAR`, which Postgres rejects against the `uuid` column — so the very first `mcp_servers` insert during reconcile dies.

The existing catalog tests run on SQLite, which doesn't enforce the uuid/varchar distinction, so the bug only surfaces on Postgres.

## Fix

- `registry_item_id` → `PG_UUID(as_uuid=True)` (matches the migration; asyncpg now sends a native uuid).
- Add a guard test asserting the column binds as uuid.

## Verification

Reproduced live against a from-zero stack: before, reconcile failed on `registry_item_id` (`$11::VARCHAR`); after copying the patched model into the running container, that bind became `$12::UUID` and the type mismatch was gone.
