### PR TITLE
fix(ci): grant packages: write to ci.yml caller in release-prepare

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -18,6 +18,12 @@ permissions:
 jobs:
   # Step 1: Validate current state BEFORE making any changes
   validate-current-state:
+    # ci.yml's docker jobs declare packages: write; GitHub validates a called
+    # workflow's job permissions even when skip-docker short-circuits them, so
+    # the caller must grant packages: write (overrides the top-level default).
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/ci.yml
     with:
       skip-docker: true


### PR DESCRIPTION
Regression from #223. The top-level `permissions: contents: read` I added to harden release-prepare restricted the `validate-current-state` job, which calls the reusable `ci.yml`. GitHub validates a called workflow's nested job permissions at parse time — even though `skip-docker: true` short-circuits the docker jobs, their declared `packages: write` is still checked against the caller's grant, producing:

```
The nested job 'docker-api' is requesting 'packages: write', but is only allowed 'packages: none'.
```

Fix: give `validate-current-state` an explicit job-level `permissions: { contents: read, packages: write }` (overrides the top-level default). Only this job calls ci.yml, so no other caller is affected; CodeQL's missing-permissions check stays satisfied since the job now has an explicit block.