### PR TITLE
fix(release): pin release-publish source SHA to 7 chars

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -51,7 +51,10 @@ jobs:
 
           bash scripts/verify-version-sync.sh
 
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          # Pin to 7 chars: ci.yml/docker metadata tag images with a fixed
+          # 7-char {{sha}}, while `git rev-parse --short` auto-extends to 8+ as
+          # the repo grows, which would look for a non-existent source tag.
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
 


### PR DESCRIPTION
## Problem

The v0.0.11 release-publish run hung all 7 `retag` jobs on **Wait for source image**, then would time out after 15 min. Root cause:

- ci.yml tags images with docker metadata `{{sha}}` = fixed **7-char** short SHA → `agentarea/agentarea-*:0.0.11-cbb36b7`.
- release-publish computed `SHORT_SHA=$(git rev-parse --short HEAD)`, which **auto-extends to 8+** chars as the repo grows → looked for `0.0.11-cbb36b74`, which doesn't exist.

This matched fine at v0.0.10 (April) when 7 chars was still unambiguous; it broke now (68 commits later).

## Fix
`git rev-parse --short=7 HEAD` to match the image tags (same pin `scripts/release.sh` already uses).

## Note
This unblocks v0.0.11 — after merge, re-point the `v0.0.11` tag to the fixed commit so release-publish runs with the corrected workflow.