### PR TITLE
fix(release): retag operator image, not removed bootstrap

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -75,7 +75,7 @@ jobs:
           - api
           - worker
           - frontend
-          - bootstrap
+          - operator
           - mcp-manager
           - mcp-runner
           - events


### PR DESCRIPTION
The release-publish retag matrix still listed `bootstrap`, which #137 replaced with `operator`. As a result, for v0.0.12 the `retag (bootstrap)` job hung on **Wait for source image** (no `agentarea-bootstrap` is built anymore) and would time out, blocking the GitHub Release job — while `agentarea-operator` never received its `:latest`/`:<version>` tags.

All quickstart images (api, worker, frontend, mcp-manager, mcp-runner, events) retagged fine; only this matrix mismatch remained.

Swap `bootstrap` -> `operator` so the matrix matches the components ci.yml actually builds.