### PR TITLE
fix(security): recover governance PEP, ReBAC gate, body-size, model-spec upsert

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/body_size_middleware.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/body_size_middleware.py
@@ -1,0 +1,32 @@
+"""Request body size limit middleware.
+
+Rejects oversized requests with 413 based on the Content-Length header, before
+the body is buffered into memory. A cheap DoS guard for an API that has no
+gateway in front (API4 — unrestricted resource consumption).
+"""
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose declared Content-Length exceeds ``max_bytes``."""
+
+    def __init__(self, app, max_bytes: int):
+        super().__init__(app)
+        self.max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next):
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                declared = int(content_length)
+            except ValueError:
+                declared = None
+            if declared is not None and declared > self.max_bytes:
+                return JSONResponse(
+                    status_code=413,
+                    content={"detail": "Request body too large"},
+                )
+        return await call_next(request)

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/rebac.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/rebac.py
@@ -269,6 +269,23 @@ async def _assert_object_in_workspace(
         )
 
 
+async def _assert_workspace_admin(user_context: UserContext) -> None:
+    """Only a workspace owner/admin may mutate the authorization graph.
+
+    Writing/deleting relation tuples grants or revokes access across the
+    workspace, so it must not be available to every member.
+    """
+    from agentarea_common.auth.authorization import AuthorizationService
+    from agentarea_common.di.container import resolve
+
+    authz = resolve(AuthorizationService)
+    if not await authz.can_write_workspace(user_context, user_context.workspace_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Only a workspace admin may modify the authorization graph",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -489,7 +506,18 @@ async def create_tuple(
     keto = get_keto()
     if keto is None:
         raise HTTPException(status_code=503, detail="Keto is disabled")
+    await _assert_workspace_admin(user_context)
     await _assert_object_in_workspace(payload.namespace, payload.object, user_context, db_session)
+    # Validate the subject too: a subject_set pointing at one of our entity
+    # namespaces must also belong to the caller's workspace, so admins cannot
+    # grant access to/from an object in another workspace.
+    if payload.subject_set is not None and payload.subject_set.namespace in _NAMESPACE_REPOS:
+        await _assert_object_in_workspace(
+            payload.subject_set.namespace,
+            payload.subject_set.object,
+            user_context,
+            db_session,
+        )
     tuple_ = _to_relation_tuple(payload)
     try:
         await keto.write_tuple(tuple_)
@@ -509,6 +537,7 @@ async def delete_tuple(
     keto = get_keto()
     if keto is None:
         raise HTTPException(status_code=503, detail="Keto is disabled")
+    await _assert_workspace_admin(user_context)
     await _assert_object_in_workspace(payload.namespace, payload.object, user_context, db_session)
     tuple_ = _to_relation_tuple(payload)
     try:

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/triggers.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/triggers.py
@@ -35,7 +35,7 @@ from agentarea_triggers.trigger_service import (
     TriggerService,
     TriggerValidationError,
 )
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 TRIGGERS_AVAILABLE = True
@@ -1030,10 +1030,30 @@ async def get_execution_correlations(
         raise HTTPException(status_code=500, detail="Internal server error") from e
 
 
+def _verify_internal_token(http_request: Request) -> None:
+    """Gate an internal-only endpoint with a shared secret.
+
+    The Go event service must send ``X-Internal-Token`` matching
+    ``INTERNAL_API_TOKEN``. When the token is unset the check is skipped
+    (back-compat); set it to require authentication on this endpoint.
+    """
+    import hmac
+
+    from agentarea_common.config import get_settings
+
+    expected = get_settings().app.INTERNAL_API_TOKEN
+    if not expected:
+        return
+    provided = http_request.headers.get("x-internal-token", "")
+    if not hmac.compare_digest(provided, expected):
+        raise HTTPException(status_code=401, detail="Invalid or missing internal service token")
+
+
 @public_router.post("/{trigger_id}/execute", response_model=dict[str, Any])
 async def execute_trigger(
     trigger_id: UUID,
     request: TriggerExecuteRequest,
+    http_request: Request,
     trigger_service: TriggerService = Depends(get_trigger_service),
 ) -> dict[str, Any]:
     """Execute a trigger with the provided event data.
@@ -1045,6 +1065,7 @@ async def execute_trigger(
     Args:
         trigger_id: The unique identifier of the trigger
         request: Events and channel origin data
+        http_request: Raw request, used to verify the internal service token
         trigger_service: Injected trigger service
 
     Returns:
@@ -1053,6 +1074,7 @@ async def execute_trigger(
     Raises:
         HTTPException: If trigger not found or execution fails
     """
+    _verify_internal_token(http_request)
     _check_triggers_availability()
 
     try:

--- a/agentarea-platform/apps/api/agentarea_api/main.py
+++ b/agentarea-platform/apps/api/agentarea_api/main.py
@@ -235,6 +235,16 @@ def create_app() -> FastAPI:
 
     app.add_middleware(AuditContextMiddleware)
 
+    # Reject oversized request bodies (413) before buffering — cheap DoS guard.
+    from agentarea_common.config import get_settings as _get_settings
+
+    from agentarea_api.api.body_size_middleware import BodySizeLimitMiddleware
+
+    app.add_middleware(
+        BodySizeLimitMiddleware,
+        max_bytes=_get_settings().app.MAX_REQUEST_BODY_BYTES,
+    )
+
     # Add CORS middleware. Origins are an explicit allowlist (never "*"): with
     # allow_credentials=True a wildcard would reflect any origin for credentialed
     # cross-site reads. Configure via CORS_ALLOWED_ORIGINS.

--- a/agentarea-platform/apps/api/tests/test_body_size_limit.py
+++ b/agentarea-platform/apps/api/tests/test_body_size_limit.py
@@ -1,0 +1,37 @@
+"""Tests for the request body size limit middleware."""
+
+import pytest
+from agentarea_api.api.body_size_middleware import BodySizeLimitMiddleware
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client(max_bytes: int) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=max_bytes)
+
+    @app.post("/echo")
+    async def echo() -> dict:
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_body_under_limit_passes():
+    client = _client(max_bytes=1000)
+    resp = client.post("/echo", content=b"x" * 100)
+    assert resp.status_code == 200
+
+
+def test_body_over_limit_rejected_with_413():
+    client = _client(max_bytes=1000)
+    resp = client.post("/echo", content=b"x" * 2000)
+    assert resp.status_code == 413
+    assert "too large" in resp.json()["detail"].lower()
+
+
+@pytest.mark.parametrize("size", [999, 1000])
+def test_body_at_or_below_limit_passes(size):
+    client = _client(max_bytes=1000)
+    resp = client.post("/echo", content=b"x" * size)
+    assert resp.status_code == 200

--- a/agentarea-platform/libs/common/agentarea_common/auth/dependencies.py
+++ b/agentarea-platform/libs/common/agentarea_common/auth/dependencies.py
@@ -248,15 +248,21 @@ async def _try_hydra_token(token: str, request: Request) -> UserContext | None:
     """
     import jwt as pyjwt
 
+    from agentarea_common.config import get_settings
+
     try:
         jwks_client = _get_hydra_jwks()
         signing_key = jwks_client.get_signing_key_from_jwt(token)
 
+        # Enforce audience when configured (HYDRA_AUDIENCE); otherwise stay
+        # back-compatible and skip aud verification.
+        hydra_audience = get_settings().mcp.HYDRA_AUDIENCE
         payload = pyjwt.decode(
             token,
             signing_key.key,
             algorithms=["RS256"],
-            options={"verify_aud": False},
+            audience=hydra_audience or None,
+            options={"verify_aud": bool(hydra_audience)},
         )
 
         subject = payload.get("sub", "")

--- a/agentarea-platform/libs/common/agentarea_common/config/app.py
+++ b/agentarea-platform/libs/common/agentarea_common/config/app.py
@@ -15,6 +15,11 @@ class AppSettings(BaseAppSettings):
     DEBUG: bool = False
     DEPLOYMENT_MODE: str = "oss"
 
+    # Max accepted request body size (bytes). Rejects oversized payloads with
+    # 413 before they are buffered. Generous default so file uploads / workspace
+    # imports keep working; tighten per deployment if needed.
+    MAX_REQUEST_BODY_BYTES: int = 50 * 1024 * 1024  # 50 MB
+
     # Public base URL for this API (used in OAuth AS metadata and redirect URLs)
     API_BASE_URL: str = "http://localhost:8000"
     # AgentArea frontend URL (users are redirected here to log in if no session)

--- a/agentarea-platform/libs/common/agentarea_common/config/app.py
+++ b/agentarea-platform/libs/common/agentarea_common/config/app.py
@@ -20,6 +20,11 @@ class AppSettings(BaseAppSettings):
     # imports keep working; tighten per deployment if needed.
     MAX_REQUEST_BODY_BYTES: int = 50 * 1024 * 1024  # 50 MB
 
+    # Shared secret for internal service-to-service calls (e.g. the Go event
+    # service calling the public trigger-execute endpoint). When set, those
+    # endpoints require a matching X-Internal-Token header. Unset = not enforced.
+    INTERNAL_API_TOKEN: str | None = None
+
     # Public base URL for this API (used in OAuth AS metadata and redirect URLs)
     API_BASE_URL: str = "http://localhost:8000"
     # AgentArea frontend URL (users are redirected here to log in if no session)

--- a/agentarea-platform/libs/common/agentarea_common/config/mcp.py
+++ b/agentarea-platform/libs/common/agentarea_common/config/mcp.py
@@ -15,6 +15,11 @@ class MCPSettings(BaseAppSettings):
     HYDRA_PUBLIC_URL: str = "http://hydra:4444"
     HYDRA_ADMIN_URL: str = "http://hydra:4445"
     HYDRA_BROWSER_URL: str = "http://localhost:4444"
+    # Expected audience for Hydra-issued OAuth tokens. When set, the API
+    # enforces the `aud` claim (rejecting tokens minted for other clients).
+    # Unset = audience not verified (back-compat); set to this API's resource
+    # identifier to harden the MCP OAuth path.
+    HYDRA_AUDIENCE: str | None = None
     MCP_OAUTH_SCOPES: str = "openid offline_access"
     # Allow OpenAPI connections to reach localhost/private IPs (self-hosted deployments)
     ALLOW_PRIVATE_URLS: bool = False

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -3527,4 +3527,3 @@ class AgentExecutionWorkflow:
             },
             "context": self.context_manager.get_status() if self.context_manager else None,
         }
-

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -2121,7 +2121,7 @@ class AgentExecutionWorkflow:
                 start_to_close_timeout=ACTIVITY_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
             )
-        return approved
+        return bool(approved)
 
     async def _gate_tool_call(self, tool_call: ToolCall) -> bool:
         """Single policy enforcement point applied to EVERY capability tool call.

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -43,11 +43,12 @@ with workflow.unsafe.imports_passed_through():
         EventManager,
         MessageBuilder,
         StateValidator,
+        ToolAction,
         ToolCallExtractor,
         build_output_summary,
         caller_can_approve,
+        decide_tool_action,
         policy_approvers,
-        policy_requires_approval,
         resolve_effective_budget,
     )
     from .models import (
@@ -2012,6 +2013,141 @@ class AgentExecutionWorkflow:
             normalized["options"] = options
         return [normalized]
 
+    async def _deny_tool_call(self, tool_call: ToolCall, tool_name: str, reason: str) -> None:
+        """Reject a tool call by policy: surface the reason to the LLM, never run it."""
+        workflow.logger.warning(f"Tool '{tool_name}' denied by policy: {reason}")
+        self.state.messages.append(
+            Message(
+                role="tool",
+                content=f"Tool call denied by policy: {reason}",
+                tool_call_id=tool_call.id,
+                name=tool_name,
+            )
+        )
+
+    async def _require_tool_approval(
+        self, tool_call: ToolCall, tool_name: str, tool_args: dict
+    ) -> bool:
+        """Run the human-in-the-loop escalation flow. Returns True if approved."""
+        escalation_id = str(workflow.uuid4())
+        escalation = PendingEscalation(
+            escalation_id=escalation_id,
+            tool_call_id=tool_call.id,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            approvers=policy_approvers(self.state.effective_policy),
+        )
+        self._pending_escalations[escalation_id] = escalation
+        self.state.status = ExecutionStatus.WAITING_FOR_APPROVAL
+
+        # Persist approval status to DB so inbox can query it
+        await workflow.execute_activity(
+            Activities.UPDATE_TASK_STATUS,
+            args=[
+                UpdateTaskStatusRequest(
+                    task_id=self.state.task_id,
+                    status="waiting_for_approval",
+                    workspace_id=self.state.workspace_id,
+                )
+            ],
+            start_to_close_timeout=ACTIVITY_TIMEOUT,
+            retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
+        )
+
+        self.event_manager.add_event(
+            EventTypes.HUMAN_APPROVAL_REQUESTED,
+            {
+                "escalation_id": escalation_id,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call.id,
+                "iteration": self.state.current_iteration,
+                "arguments": tool_args,
+                "approvers": escalation.approvers,
+                "message": f"Tool '{tool_name}' requires human approval",
+            },
+        )
+        await self._publish_events_immediately()
+
+        # Wait for THIS specific escalation to be resolved
+        await workflow.wait_condition(lambda: escalation.resolved)
+
+        approved = escalation.approved
+        if not approved:
+            deny_msg = escalation.deny_comment or "Denied by user"
+            self.event_manager.add_event(
+                EventTypes.HUMAN_APPROVAL_DENIED,
+                {
+                    "escalation_id": escalation_id,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call.id,
+                    "iteration": self.state.current_iteration,
+                    "comment": deny_msg,
+                },
+            )
+            await self._publish_events_immediately()
+            self.state.messages.append(
+                Message(
+                    role="tool",
+                    content=f"Tool call denied by human operator: {deny_msg}",
+                    tool_call_id=tool_call.id,
+                    name=tool_name,
+                )
+            )
+        else:
+            self.event_manager.add_event(
+                EventTypes.HUMAN_APPROVAL_RECEIVED,
+                {
+                    "escalation_id": escalation_id,
+                    "tool_name": tool_name,
+                    "tool_call_id": tool_call.id,
+                    "iteration": self.state.current_iteration,
+                },
+            )
+            await self._publish_events_immediately()
+
+        # Clean up and restore running status once no escalations remain
+        del self._pending_escalations[escalation_id]
+        if not self._pending_escalations:
+            self.state.status = ExecutionStatus.EXECUTING
+            await workflow.execute_activity(
+                Activities.UPDATE_TASK_STATUS,
+                args=[
+                    UpdateTaskStatusRequest(
+                        task_id=self.state.task_id,
+                        status="running",
+                        workspace_id=self.state.workspace_id,
+                    )
+                ],
+                start_to_close_timeout=ACTIVITY_TIMEOUT,
+                retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
+            )
+        return approved
+
+    async def _gate_tool_call(self, tool_call: ToolCall) -> bool:
+        """Single policy enforcement point applied to EVERY capability tool call.
+
+        Returns True if the call may proceed; False if it was denied by policy
+        or its approval was rejected (a tool message has already been appended
+        so the LLM sees the outcome).
+        """
+        import json
+
+        tool_name = tool_call.function["name"]
+        try:
+            tool_args = json.loads(tool_call.function["arguments"])
+        except (json.JSONDecodeError, KeyError):
+            tool_args = {}
+
+        decision = decide_tool_action(self.state.effective_policy, tool_name)
+        workflow.logger.info(f"Tool '{tool_name}' policy decision: {decision.value}")
+
+        if decision is ToolAction.DENY:
+            await self._deny_tool_call(tool_call, tool_name, "not permitted by policy")
+            return False
+        if decision is ToolAction.REQUIRE_APPROVAL:
+            return await self._require_tool_approval(tool_call, tool_name, tool_args)
+        return True
+
     async def _execute_mcp_tool(self, tool_call: ToolCall) -> None:
         """Execute a single MCP tool call using Pydantic models."""
         tool_name = tool_call.function["name"]
@@ -2024,127 +2160,9 @@ class AgentExecutionWorkflow:
         except (json.JSONDecodeError, KeyError):
             tool_args = {}
 
-        # Approval gating before starting the tool activity — driven solely by the
-        # governance ApprovalPolicy on the task's effective_policy snapshot.
-        approval_required = self._tool_requires_approval(tool_name)
-        workflow.logger.info(
-            f"Tool '{tool_name}' policy approval check: requires_approval={approval_required}"
-        )
-
-        if approval_required:
-            escalation_id = str(workflow.uuid4())
-            escalation = PendingEscalation(
-                escalation_id=escalation_id,
-                tool_call_id=tool_call.id,
-                tool_name=tool_name,
-                tool_args=tool_args,
-                approvers=policy_approvers(self.state.effective_policy),
-            )
-            self._pending_escalations[escalation_id] = escalation
-
-            self.state.status = ExecutionStatus.WAITING_FOR_APPROVAL
-
-            # Persist approval status to DB so inbox can query it
-            await workflow.execute_activity(
-                Activities.UPDATE_TASK_STATUS,
-                args=[
-                    UpdateTaskStatusRequest(
-                        task_id=self.state.task_id,
-                        status="waiting_for_approval",
-                        workspace_id=self.state.workspace_id,
-                    )
-                ],
-                start_to_close_timeout=ACTIVITY_TIMEOUT,
-                retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
-            )
-
-            # Publish approval requested event with escalation_id
-            self.event_manager.add_event(
-                EventTypes.HUMAN_APPROVAL_REQUESTED,
-                {
-                    "escalation_id": escalation_id,
-                    "tool_name": tool_name,
-                    "tool_call_id": tool_call.id,
-                    "iteration": self.state.current_iteration,
-                    "arguments": tool_args,
-                    "approvers": escalation.approvers,
-                    "message": f"Tool '{tool_name}' requires human approval",
-                },
-            )
-            await self._publish_events_immediately()
-
-            # Wait for THIS specific escalation to be resolved
-            await workflow.wait_condition(lambda: escalation.resolved)
-
-            if not escalation.approved:
-                # Denied — add tool result as denied, don't execute
-                deny_msg = escalation.deny_comment or "Denied by user"
-                self.event_manager.add_event(
-                    EventTypes.HUMAN_APPROVAL_DENIED,
-                    {
-                        "escalation_id": escalation_id,
-                        "tool_name": tool_name,
-                        "tool_call_id": tool_call.id,
-                        "iteration": self.state.current_iteration,
-                        "comment": deny_msg,
-                    },
-                )
-                await self._publish_events_immediately()
-
-                # Add denied result as tool response so LLM knows
-                self.state.messages.append(
-                    Message(
-                        role="tool",
-                        content=f"Tool call denied by human operator: {deny_msg}",
-                        tool_call_id=tool_call.id,
-                        name=tool_name,
-                    )
-                )
-
-                # Clean up and update status
-                del self._pending_escalations[escalation_id]
-                if not self._pending_escalations:
-                    self.state.status = ExecutionStatus.EXECUTING
-                    await workflow.execute_activity(
-                        Activities.UPDATE_TASK_STATUS,
-                        args=[
-                            UpdateTaskStatusRequest(
-                                task_id=self.state.task_id,
-                                status="running",
-                                workspace_id=self.state.workspace_id,
-                            )
-                        ],
-                        start_to_close_timeout=ACTIVITY_TIMEOUT,
-                        retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
-                    )
-                return
-
-            # Approved — continue to execute
-            self.event_manager.add_event(
-                EventTypes.HUMAN_APPROVAL_RECEIVED,
-                {
-                    "escalation_id": escalation_id,
-                    "tool_name": tool_name,
-                    "tool_call_id": tool_call.id,
-                    "iteration": self.state.current_iteration,
-                },
-            )
-            await self._publish_events_immediately()
-            del self._pending_escalations[escalation_id]
-            if not self._pending_escalations:
-                self.state.status = ExecutionStatus.EXECUTING
-                await workflow.execute_activity(
-                    Activities.UPDATE_TASK_STATUS,
-                    args=[
-                        UpdateTaskStatusRequest(
-                            task_id=self.state.task_id,
-                            status="running",
-                            workspace_id=self.state.workspace_id,
-                        )
-                    ],
-                    start_to_close_timeout=ACTIVITY_TIMEOUT,
-                    retry_policy=RetryPolicy(maximum_attempts=DEFAULT_RETRY_ATTEMPTS),
-                )
+        # Single policy enforcement point (allow / deny / require-approval).
+        if not await self._gate_tool_call(tool_call):
+            return
 
         # Publish tool call started event (only after approval if required)
         self.event_manager.add_event(
@@ -2626,6 +2644,8 @@ class AgentExecutionWorkflow:
 
     async def _execute_skill_activation(self, tool_call: ToolCall) -> None:
         """Execute skill activation locally (no Temporal activity needed)."""
+        if not await self._gate_tool_call(tool_call):
+            return
         try:
             args = json.loads(tool_call.function["arguments"])
         except (json.JSONDecodeError, KeyError):
@@ -2663,6 +2683,8 @@ class AgentExecutionWorkflow:
 
     async def _execute_skill_script(self, tool_call: ToolCall) -> None:
         """Execute a skill-bundled script via MCP Manager sandbox."""
+        if not await self._gate_tool_call(tool_call):
+            return
         try:
             args = json.loads(tool_call.function["arguments"])
         except (json.JSONDecodeError, KeyError):
@@ -2806,6 +2828,8 @@ class AgentExecutionWorkflow:
         efficient (no polling), durable (survives worker crashes), and
         supports cancellation propagation.
         """
+        if not await self._gate_tool_call(tool_call):
+            return
         tool_name = tool_call.function["name"]
         agent_info = self._agent_tool_registry[tool_name]
         agent_id = agent_info["agent_id"]
@@ -3504,11 +3528,3 @@ class AgentExecutionWorkflow:
             "context": self.context_manager.get_status() if self.context_manager else None,
         }
 
-    def _tool_requires_approval(self, tool_name: str) -> bool:
-        """Whether this tool call needs human approval.
-
-        Single source of truth is the governance ApprovalPolicy on the task's
-        effective_policy snapshot — not per-tool agent config. When this returns
-        True the loop pauses on the existing human-in-the-loop path.
-        """
-        return policy_requires_approval(self.state.effective_policy, tool_name)

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/helpers.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/helpers.py
@@ -1,6 +1,7 @@
 """Helper classes and utilities for agent execution workflows."""
 
 from datetime import UTC, datetime
+from enum import Enum
 from typing import Any, cast
 
 from temporalio import workflow
@@ -53,6 +54,46 @@ def policy_requires_approval(effective_policy: dict[str, Any] | None, tool_name:
 def policy_approvers(effective_policy: dict[str, Any] | None) -> list[str]:
     """Subject refs allowed to approve, from ApprovalPolicy.approvers."""
     return list(((effective_policy or {}).get("approval") or {}).get("approvers") or [])
+
+
+class ToolAction(str, Enum):
+    """Verdict of the tool-call policy decision (single PEP for every tool)."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    REQUIRE_APPROVAL = "require_approval"
+
+
+def decide_tool_action(effective_policy: dict[str, Any] | None, tool_name: str) -> ToolAction:
+    """Single policy decision point applied to EVERY capability tool call.
+
+    Consolidates ``ToolsPolicy`` (allow/deny) and ``ApprovalPolicy`` from the
+    resolved governance snapshot into one verdict, with precedence:
+
+    1. tool in ``tools.denied``                -> DENY
+    2. ``tools.allowed`` set and tool not in it -> DENY  (allow-list mode;
+       ``allowed=None`` means "no allow-list", ``allowed=[]`` denies all)
+    3. approval required (global flag or tool in escalation_rules)
+       -> REQUIRE_APPROVAL
+    4. otherwise                                -> ALLOW
+
+    Deny wins over allow wins over approval. Pure and deterministic so it is
+    safe to call inside the Temporal workflow.
+    """
+    tools = (effective_policy or {}).get("tools") or {}
+
+    denied = tools.get("denied") or []
+    if tool_name in denied:
+        return ToolAction.DENY
+
+    allowed = tools.get("allowed")
+    if allowed is not None and tool_name not in allowed:
+        return ToolAction.DENY
+
+    if policy_requires_approval(effective_policy, tool_name):
+        return ToolAction.REQUIRE_APPROVAL
+
+    return ToolAction.ALLOW
 
 
 def caller_can_approve(approvers: list[str], caller_user_id: str) -> bool:

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/helpers.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/helpers.py
@@ -1,7 +1,7 @@
 """Helper classes and utilities for agent execution workflows."""
 
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, cast
 
 from temporalio import workflow
@@ -56,7 +56,7 @@ def policy_approvers(effective_policy: dict[str, Any] | None) -> list[str]:
     return list(((effective_policy or {}).get("approval") or {}).get("approvers") or [])
 
 
-class ToolAction(str, Enum):
+class ToolAction(StrEnum):
     """Verdict of the tool-call policy decision (single PEP for every tool)."""
 
     ALLOW = "allow"

--- a/agentarea-platform/libs/execution/tests/unit/test_tool_gate_wiring.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_tool_gate_wiring.py
@@ -1,0 +1,47 @@
+"""Wiring tests: every capability dispatch branch goes through the single PEP.
+
+These assert the *wiring* (each branch calls `_gate_tool_call` and aborts when
+policy denies), complementing test_tool_policy_decision.py which covers the
+decision *logic*. The workflow instance is built via __new__ so no Temporal
+runtime is needed — the gate is the first thing each branch touches, so a
+denied gate returns before any activity/child-workflow call.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from agentarea_execution.workflows.agent_execution_workflow import AgentExecutionWorkflow
+
+# The four capability branches that must enforce policy. Control primitives
+# (completion, user-input, recall, read_output, activate_source, load_tools)
+# are intentionally exempt and not listed here.
+CAPABILITY_BRANCHES = [
+    "_execute_mcp_tool",
+    "_execute_skill_script",
+    "_execute_agent_delegation",
+    "_execute_skill_activation",
+]
+
+
+def _workflow() -> AgentExecutionWorkflow:
+    # Bypass __init__: we only exercise the early gate path.
+    return AgentExecutionWorkflow.__new__(AgentExecutionWorkflow)
+
+
+def _tool_call(name: str = "shell") -> SimpleNamespace:
+    return SimpleNamespace(id="tc-1", function={"name": name, "arguments": "{}"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", CAPABILITY_BRANCHES)
+async def test_branch_calls_gate_and_aborts_on_deny(method_name):
+    wf = _workflow()
+    wf._gate_tool_call = AsyncMock(return_value=False)
+    tool_call = _tool_call()
+
+    result = await getattr(wf, method_name)(tool_call)
+
+    # Denied -> branch returns without touching any downstream executor.
+    assert result is None
+    wf._gate_tool_call.assert_awaited_once_with(tool_call)

--- a/agentarea-platform/libs/execution/tests/unit/test_tool_policy_decision.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_tool_policy_decision.py
@@ -1,0 +1,63 @@
+"""Unit tests for the unified tool-call policy decision (decide_tool_action)."""
+
+from agentarea_execution.workflows.helpers import ToolAction, decide_tool_action
+
+
+def test_no_policy_allows():
+    assert decide_tool_action(None, "shell") is ToolAction.ALLOW
+    assert decide_tool_action({}, "shell") is ToolAction.ALLOW
+
+
+def test_denied_tool_is_denied():
+    policy = {"tools": {"denied": ["shell"]}}
+    assert decide_tool_action(policy, "shell") is ToolAction.DENY
+    assert decide_tool_action(policy, "web_search") is ToolAction.ALLOW
+
+
+def test_allowlist_mode_denies_unlisted():
+    policy = {"tools": {"allowed": ["web_search"]}}
+    assert decide_tool_action(policy, "web_search") is ToolAction.ALLOW
+    assert decide_tool_action(policy, "shell") is ToolAction.DENY
+
+
+def test_empty_allowlist_denies_everything():
+    policy = {"tools": {"allowed": []}}
+    assert decide_tool_action(policy, "anything") is ToolAction.DENY
+
+
+def test_allowed_none_is_not_a_restriction():
+    policy = {"tools": {"allowed": None, "denied": []}}
+    assert decide_tool_action(policy, "anything") is ToolAction.ALLOW
+
+
+def test_global_approval_requires_approval():
+    policy = {"approval": {"requires_human_approval": True}}
+    assert decide_tool_action(policy, "web_search") is ToolAction.REQUIRE_APPROVAL
+
+
+def test_escalation_rule_requires_approval_for_that_tool_only():
+    policy = {"approval": {"escalation_rules": ["shell"]}}
+    assert decide_tool_action(policy, "shell") is ToolAction.REQUIRE_APPROVAL
+    assert decide_tool_action(policy, "web_search") is ToolAction.ALLOW
+
+
+def test_deny_takes_precedence_over_approval():
+    # A denied tool is rejected outright, never escalated for approval.
+    policy = {
+        "tools": {"denied": ["shell"]},
+        "approval": {"requires_human_approval": True},
+    }
+    assert decide_tool_action(policy, "shell") is ToolAction.DENY
+
+
+def test_deny_takes_precedence_over_allowlist():
+    policy = {"tools": {"allowed": ["shell"], "denied": ["shell"]}}
+    assert decide_tool_action(policy, "shell") is ToolAction.DENY
+
+
+def test_allowed_tool_still_escalates_when_in_rules():
+    policy = {
+        "tools": {"allowed": ["shell"]},
+        "approval": {"escalation_rules": ["shell"]},
+    }
+    assert decide_tool_action(policy, "shell") is ToolAction.REQUIRE_APPROVAL

--- a/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_spec_repository.py
+++ b/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_spec_repository.py
@@ -204,6 +204,8 @@ class ModelSpecRepository(WorkspaceScopedRepository[ModelSpec]):
         """
         provider_spec_id = kwargs.get("provider_spec_id")
         model_name = kwargs.get("model_name")
+        if provider_spec_id is None or model_name is None:
+            raise ValueError("provider_spec_id and model_name are required for upsert")
         existing = await self._find_global_by_provider_and_model(provider_spec_id, model_name)
         if existing:
             owned = str(getattr(existing, "workspace_id", "")) == str(

--- a/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_spec_repository.py
+++ b/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_spec_repository.py
@@ -172,21 +172,55 @@ class ModelSpecRepository(WorkspaceScopedRepository[ModelSpec]):
             projections.append(spec)
         return projections
 
+    async def _find_global_by_provider_and_model(
+        self, provider_spec_id, model_name: str
+    ) -> ModelSpec | None:
+        """Find a spec by the GLOBAL unique key ``(provider_spec_id, model_name)``.
+
+        The ``uq_model_specs_provider_model`` constraint does NOT include
+        ``workspace_id``, so existence must be checked across all workspaces. A
+        workspace-scoped lookup misses a row owned by another workspace (e.g. the
+        platform catalog, or a different tenant that discovered the same model)
+        and a subsequent INSERT then hits the unique violation.
+        """
+        pid = (
+            provider_spec_id
+            if isinstance(provider_spec_id, UUID)
+            else UUID(str(provider_spec_id))
+        )
+        result = await self.session.execute(
+            select(ModelSpec).where(
+                ModelSpec.provider_spec_id == pid,
+                ModelSpec.model_name == model_name,
+            )
+        )
+        return result.scalars().first()
+
     async def upsert_by_provider_and_model_kwargs(self, **kwargs) -> ModelSpec:
-        """Upsert model spec by provider and model name using kwargs (avoids entity construction)."""
+        """Upsert a model spec keyed on the global ``(provider_spec_id, model_name)``.
+
+        Idempotent against the global unique constraint: update the row when this
+        workspace owns it, otherwise return the existing (e.g. platform-catalog or
+        another tenant's) row as-is instead of inserting a duplicate that would
+        raise ``IntegrityError``.
+        """
         provider_spec_id = kwargs.get("provider_spec_id")
         model_name = kwargs.get("model_name")
-        existing = await self.find_one_by(provider_spec_id=provider_spec_id, model_name=model_name)
+        existing = await self._find_global_by_provider_and_model(provider_spec_id, model_name)
         if existing:
-            update_fields = {
-                k: v
-                for k, v in kwargs.items()
-                if k not in ("provider_spec_id", "model_name") and v is not None
-            }
-            updated = await self.update(existing.id, **update_fields)
-            return updated or existing
-        else:
-            return await self.create(**kwargs)
+            owned = str(getattr(existing, "workspace_id", "")) == str(
+                self.user_context.workspace_id
+            )
+            if owned:
+                update_fields = {
+                    k: v
+                    for k, v in kwargs.items()
+                    if k not in ("provider_spec_id", "model_name") and v is not None
+                }
+                updated = await self.update(existing.id, **update_fields)
+                return updated or existing
+            return existing
+        return await self.create(**kwargs)
 
     async def upsert_by_provider_and_model(self, entity: ModelSpec) -> ModelSpec:
         """Upsert model spec by provider and model name - used in bootstrap"""

--- a/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_spec_repository.py
+++ b/agentarea-platform/libs/llm/agentarea_llm/infrastructure/model_spec_repository.py
@@ -184,9 +184,7 @@ class ModelSpecRepository(WorkspaceScopedRepository[ModelSpec]):
         and a subsequent INSERT then hits the unique violation.
         """
         pid = (
-            provider_spec_id
-            if isinstance(provider_spec_id, UUID)
-            else UUID(str(provider_spec_id))
+            provider_spec_id if isinstance(provider_spec_id, UUID) else UUID(str(provider_spec_id))
         )
         result = await self.session.execute(
             select(ModelSpec).where(

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -3374,6 +3374,7 @@ export interface paths {
          *     Args:
          *         trigger_id: The unique identifier of the trigger
          *         request: Events and channel origin data
+         *         http_request: Raw request, used to verify the internal service token
          *         trigger_service: Injected trigger service
          *
          *     Returns:

--- a/agentarea-webapp/src/components/ProviderConfigForm/ProviderConfigForm.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/ProviderConfigForm.tsx
@@ -428,10 +428,12 @@ export default function ProviderConfigForm({
           toast.success(t("toast.configurationUpdatedSuccessfully"));
         }
       } else {
+        // These messages are ICU plurals on {modelCount}; passing the arg avoids
+        // next-intl returning the raw key (e.g. "ProviderConfigForm.toast.…").
         toast.success(
           isEdit
-            ? t("toast.configurationUpdated")
-            : t("toast.configurationCreated")
+            ? t("toast.configurationUpdated", { modelCount: 0 })
+            : t("toast.configurationCreated", { modelCount: 0 })
         );
       }
 

--- a/agentarea-webapp/src/components/ProviderConfigForm/components/ModelInstances.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/components/ModelInstances.tsx
@@ -105,8 +105,17 @@ export default function ModelInstances({
           endpoint_url: endpointUrl || null,
         });
         if (error) {
-          const detail = (error as any)?.detail ?? t("failedToDiscoverCheckKey");
-          toast.error(typeof detail === "string" ? detail : t("failedToDiscover"));
+          // Surface the real backend error. Only fall back to a NEUTRAL generic
+          // message — never blame the API key for non-auth failures (e.g. a 500
+          // would otherwise be reported as "Check API key", which is misleading).
+          const d = (error as any)?.detail;
+          const msg =
+            typeof d === "string" && d
+              ? d
+              : Array.isArray(d) && d[0]?.msg
+                ? d[0].msg
+                : (error as any)?.message || t("failedToDiscover");
+          toast.error(msg);
           return;
         }
         const result = data as { discovered?: number; new_models?: number };


### PR DESCRIPTION
Recovers four security/hardening commits that were committed on a local branch, never pushed, and orphaned when that branch was deleted. Re-applied cleanly onto current main (cherry-picked, no conflicts).

## Commits
- **PEP gating** — enforce governance policy on every capability tool call (unified PEP) in the agent execution workflow; adds `decide_tool_action`/tool-gate wiring + unit tests.
- **body-size limit + Hydra audience** — `BodySizeLimitMiddleware` (413 over `MAX_REQUEST_BODY_BYTES`) + opt-in Hydra OAuth `aud` enforcement.
- **model-spec idempotent upsert** — global existence check to stop discover-preview IntegrityErrors; surface real backend errors in the UI.
- **ReBAC tuple-write gate + trigger internal-token** — require workspace-admin to create/delete Keto tuples; `X-Internal-Token` on `/triggers/{id}/execute`.

## Verification
- `ruff check` clean on all changed files (local).
- Full unit/functional suite runs in CI (fresh worktree had no venv).