### PR TITLE
fix(oauth): reject path traversal in Hydra oauth2 proxy (py/partial-ssrf #258)

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
@@ -15,12 +15,26 @@ Steps 4-6 are proxied via /.well-known/... and the full oauth2/* proxy below so
 that the single AS URL (API_BASE_URL) works for both discovery and token ops.
 """
 
+import re
+
 import httpx
 from agentarea_common.config import get_settings
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
 oauth_as_router = APIRouter(tags=["oauth-as"])
+
+# Conservative allowlist for the proxied /oauth2/{path} subpath. The host is
+# fixed to HYDRA_PUBLIC_URL, so the caller can only influence the path/query;
+# restrict the path to OAuth2-style identifiers and forbid parent traversal so a
+# request cannot escape /oauth2/ on the Hydra host (partial-SSRF hardening).
+_SAFE_OAUTH2_SUBPATH = re.compile(r"^[A-Za-z0-9._~/-]+$")
+
+
+def _is_safe_oauth2_subpath(path: str) -> bool:
+    if not path or not _SAFE_OAUTH2_SUBPATH.match(path):
+        return False
+    return ".." not in path.split("/")
 
 
 def _hydra_public_url() -> str:
@@ -172,6 +186,12 @@ async def hydra_dcr_proxy(request: Request) -> Response:
 )
 async def hydra_oauth2_proxy(path: str, request: Request) -> Response:
     """Proxy all /oauth2/* requests through to Hydra (excluding /register handled above)."""
+    if not _is_safe_oauth2_subpath(path):
+        return JSONResponse(
+            content={"error": "invalid_request", "error_description": "invalid oauth2 path"},
+            status_code=400,
+        )
+
     hydra_url = _hydra_public_url()
     target = f"{hydra_url}/oauth2/{path}"
     if request.url.query:

--- a/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
@@ -1,0 +1,30 @@
+"""Tests for the Hydra OAuth2 proxy path hardening.
+
+The proxy forwards /oauth2/{path} to a fixed, config-driven Hydra host. The host
+cannot be changed by the caller, but the user-controlled subpath must not be able
+to traverse out of /oauth2/ on that host (partial-SSRF / path-traversal hardening).
+"""
+
+from agentarea_api.api.v1.mcp_oauth_as import _is_safe_oauth2_subpath
+
+
+class TestOAuth2SubpathValidation:
+    def test_allows_legitimate_oauth2_paths(self):
+        for p in ["token", "revoke", "introspect", "sessions/logout", "userinfo", "device.well"]:
+            assert _is_safe_oauth2_subpath(p), p
+
+    def test_rejects_parent_traversal(self):
+        for p in ["../admin/clients", "..", "token/../../admin", "a/../../b", "sub/.."]:
+            assert not _is_safe_oauth2_subpath(p), p
+
+    def test_rejects_backslash_and_control_chars(self):
+        for p in ["foo\\bar", "tok\nen", "tok\ren", "a\x00b"]:
+            assert not _is_safe_oauth2_subpath(p), p
+
+    def test_rejects_url_authority_injection(self):
+        # Characters that could confuse URL parsing into changing the authority.
+        for p in ["@evil.com/path", "evil.com:8080/x", "host/with space"]:
+            assert not _is_safe_oauth2_subpath(p), p
+
+    def test_rejects_empty(self):
+        assert not _is_safe_oauth2_subpath("")


### PR DESCRIPTION
## What

Hardens the Hydra OAuth2 proxy against path traversal (CodeQL `py/partial-ssrf` #258).

`GET|POST|... /oauth2/{path:path}` forwards to a **fixed, config-driven** Hydra host (`HYDRA_PUBLIC_URL`) — the caller cannot change the destination host, so this was never an internal-SSRF. But the user-controlled `{path}` could contain `..` and traverse out of `/oauth2/` on the Hydra host. This adds an in-code guard instead of dismissing the alert:

- `_is_safe_oauth2_subpath`: conservative allowlist (`^[A-Za-z0-9._~/-]+$`) + reject parent-traversal segments (`..`).
- Proxy returns `400 invalid_request` for unsafe subpaths before forwarding.

This is the companion to #236 (which fixed the real, host-controllable SSRF #259 in model discovery).

## Verification
- New `test_mcp_oauth_as.py`: 5 tests (legit paths, traversal, backslash/control chars, authority-injection chars, empty) — pass.
- `ruff check` / `ruff format --check` clean; no new pyright errors (uvx import-resolution noise is identical to baseline).

## Note
The `{path}`/query still flow into the request as the proxy's path+query on the fixed host, which is the intended proxy behavior; the host is not user-controllable. If CodeQL still reports residual partial-ssrf purely from query forwarding, it is not exploitable (fixed host) and can be dismissed.
