### PR TITLE
Fix event service lint gate

### DIFF
--- a/agentarea-event-service/cmd/server/main.go
+++ b/agentarea-event-service/cmd/server/main.go
@@ -33,6 +33,7 @@ func main() {
 	cfg := config.Load()
 
 	slog.Info("event-service starting",
+		"version", version,
 		"worker_id", cfg.WorkerID,
 		"inbound_stream", cfg.InboundStream,
 		"enable_telegram_polling", cfg.EnableTelegramPolling,

--- a/agentarea-event-service/internal/channels/telegram/poller.go
+++ b/agentarea-event-service/internal/channels/telegram/poller.go
@@ -11,7 +11,6 @@ import (
 // Poller implements channels.ChannelPoller for Telegram Bot API.
 type Poller struct {
 	client *Client
-	chatID int64 // filled from first message if not set
 }
 
 // NewPoller creates a Telegram poller from trigger config.


### PR DESCRIPTION
## Summary
- remove unused Telegram poller field flagged by events-lint-test
- include the existing event-service version constant in startup logs so it is no longer dead code

## Why
The post-merge main push failed in CI/CD Pipeline because events-lint-test runs golangci-lint for agentarea-event-service on main and found two unused symbols.

## Tested
- `go test ./...` in `agentarea-event-service`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run` in `agentarea-event-service`
- `git diff --check`
