### PR TITLE
Stabilize Temporal test server startup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
   platform-test:
     runs-on: ubuntu-latest
     needs: [changes, platform-lint]
+    env:
+      TEMPORAL_TEST_SERVER_DOWNLOAD_DIR: /tmp/temporal-test-server
+      TEMPORAL_TEST_SERVER_DOWNLOAD_ATTEMPTS: "5"
     # Always run when: called as reusable workflow, on main, on release PRs, or if platform changes detected
     if: |
       always() && !cancelled() && needs.platform-lint.result == 'success' && (

--- a/agentarea-platform/conftest.py
+++ b/agentarea-platform/conftest.py
@@ -3,6 +3,9 @@
 import asyncio
 import base64
 import json
+import os
+import shutil
+import tempfile
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -165,12 +168,48 @@ def admin_jwt_token(test_jwt_secret):
     )
 
 
-# Pytest configuration
-import os  # noqa: E402
+def _patch_temporal_test_server_startup() -> None:
+    """Make Temporal test-server downloads resilient in CI."""
+    try:
+        from temporalio.testing import WorkflowEnvironment
+    except ImportError:
+        return
+
+    if getattr(WorkflowEnvironment, "_agentarea_test_server_patch", False):
+        return
+
+    original_start_time_skipping = WorkflowEnvironment.start_time_skipping
+
+    async def start_time_skipping_with_retry(cls, **kwargs):
+        download_dir = os.environ.get("TEMPORAL_TEST_SERVER_DOWNLOAD_DIR")
+        if not download_dir:
+            download_dir = os.path.join(tempfile.gettempdir(), "agentarea-temporal-test-server")
+        os.makedirs(download_dir, exist_ok=True)
+        kwargs.setdefault("download_dest_dir", download_dir)
+
+        attempts = int(os.environ.get("TEMPORAL_TEST_SERVER_DOWNLOAD_ATTEMPTS", "4"))
+        last_error: Exception | None = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return await original_start_time_skipping(**kwargs)
+            except Exception as exc:
+                last_error = exc
+                if attempt == attempts:
+                    break
+                shutil.rmtree(download_dir, ignore_errors=True)
+                await asyncio.sleep(min(2**attempt, 10))
+        if last_error is None:
+            raise RuntimeError("Temporal test server did not start")
+        raise last_error
+
+    WorkflowEnvironment.start_time_skipping = classmethod(start_time_skipping_with_retry)
+    WorkflowEnvironment._agentarea_test_server_patch = True
 
 
 def pytest_configure(config):
     """Configure pytest with custom markers and environment variables."""
+    _patch_temporal_test_server_startup()
+
     # Set required environment variables for WorkflowSettings
     os.environ.setdefault("WORKFLOW__TEMPORAL_SERVER_URL", "localhost:7233")
     os.environ.setdefault("WORKFLOW__TEMPORAL_NAMESPACE", "default")


### PR DESCRIPTION
## Summary
- add a pytest-level retry/cache wrapper for Temporal `WorkflowEnvironment.start_time_skipping()`
- configure platform-test with a shared Temporal test-server download directory and more attempts

## Why
After fixing the event-service lint gate, the next main push failed because Temporal workflow tests could not download the SDK test-server binary from `temporal.download`. The tests themselves passed locally and in CI until the external download failed, so this makes bootstrap resilient instead of skipping coverage.

## Tested
- `uv run --group lint ruff check conftest.py`
- `TEMPORAL_TEST_SERVER_DOWNLOAD_DIR=/tmp/agentarea-temporal-test-server-check TEMPORAL_TEST_SERVER_DOWNLOAD_ATTEMPTS=3 uv run python -m pytest libs/execution/tests/integration/test_task_complete_smoke.py libs/execution/tests/integration/test_workflow_signals.py libs/execution/tests/integration/test_flow_tool_use.py -m "not integration"`
- `TEMPORAL_TEST_SERVER_DOWNLOAD_DIR=/tmp/agentarea-temporal-test-server-check TEMPORAL_TEST_SERVER_DOWNLOAD_ATTEMPTS=3 make test`
- `git diff --check`
