### PR TITLE
Fix members page and rebuild the policy editor

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/workspace_invitations.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/workspace_invitations.py
@@ -1,19 +1,24 @@
 """Workspace invitation and membership API endpoints.
 
-Scope: workspace-only invitations (link-bearing token grants membership).
-Authz beyond "must be a workspace member" — owner-only checks, role
-presets, per-resource grants — is intentionally out of scope here. That
-lives in the future Keto-integration PR.
+Routes expose product-level workspace membership operations. The configured
+relationship graph owns access decisions; persistence tables are only used for
+invitation state.
 """
 
 import logging
 from collections.abc import AsyncGenerator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 from agentarea_common.auth.dependencies import UserContextDep
 from agentarea_common.config import get_database
+from agentarea_common.rebac import (
+    KetoError,
+    KetoUnavailableError,
+    OpenFGAError,
+    OpenFGAUnavailableError,
+)
 from agentarea_common.workspaces import (
     InvitationAlreadyAccepted,
     InvitationExpired,
@@ -22,9 +27,12 @@ from agentarea_common.workspaces import (
     WorkspaceInvitation,
     WorkspaceInvitationRepository,
     WorkspaceInvitationService,
-    WorkspaceMembership,
-    WorkspaceMembershipRepository,
-    WorkspaceMembershipService,
+)
+from agentarea_common.workspaces.memberships import (
+    get_workspace_membership_graph,
+    grant_workspace_membership,
+    list_workspace_member_ids,
+    revoke_workspace_membership,
 )
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -47,18 +55,10 @@ SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 
 def get_invitation_service(session: SessionDep) -> WorkspaceInvitationService:
-    return WorkspaceInvitationService(
-        WorkspaceInvitationRepository(session),
-        WorkspaceMembershipRepository(session),
-    )
-
-
-def get_membership_service(session: SessionDep) -> WorkspaceMembershipService:
-    return WorkspaceMembershipService(WorkspaceMembershipRepository(session))
+    return WorkspaceInvitationService(WorkspaceInvitationRepository(session))
 
 
 InvitationServiceDep = Annotated[WorkspaceInvitationService, Depends(get_invitation_service)]
-MembershipServiceDep = Annotated[WorkspaceMembershipService, Depends(get_membership_service)]
 
 
 # ---------------------------------------------------------------------------
@@ -127,43 +127,75 @@ def _invitation_to_response(invitation: WorkspaceInvitation) -> InvitationRespon
     )
 
 
-def _membership_to_response(
-    membership: WorkspaceMembership,
-    invitation: WorkspaceInvitation | None = None,
-) -> MemberResponse:
-    email = invitation.email if invitation else None
-    return MemberResponse(
-        id=membership.id,
-        workspace_id=membership.workspace_id,
-        user_id=membership.user_id,
-        email=email,
-        display_name=email,
-        joined_at=membership.created_at,
-        invitation_id=UUID(str(membership.invitation_id)) if membership.invitation_id else None,
-    )
-
-
-async def _members_to_response(
-    session: AsyncSession,
-    memberships: list[WorkspaceMembership],
+def _member_ids_to_response(
+    workspace_id: str,
+    member_ids: list[str],
+    *,
+    current_user_id: str,
+    current_user_email: str | None,
+    current_user_name: str | None,
 ) -> list[MemberResponse]:
-    invitation_repo = WorkspaceInvitationRepository(session)
-    invitation_by_id: dict[str, WorkspaceInvitation] = {}
-
-    for membership in memberships:
-        if not membership.invitation_id:
-            continue
-        invitation = await invitation_repo.get_by_id(membership.invitation_id)
-        if invitation is not None:
-            invitation_by_id[str(invitation.id)] = invitation
-
-    return [
-        _membership_to_response(
-            membership,
-            invitation_by_id.get(str(membership.invitation_id)),
+    responses: list[MemberResponse] = []
+    for member_id in member_ids:
+        is_current_user = member_id == current_user_id
+        display_name = current_user_name if is_current_user else None
+        email = current_user_email if is_current_user else None
+        responses.append(
+            MemberResponse(
+                id=_stable_member_response_id(workspace_id, member_id),
+                workspace_id=workspace_id,
+                user_id=member_id,
+                email=email,
+                display_name=display_name or email,
+                joined_at=datetime.now(UTC),
+                invitation_id=None,
+            )
         )
-        for membership in memberships
-    ]
+    return responses
+
+
+def _stable_member_response_id(workspace_id: str, user_id: str) -> UUID:
+    try:
+        return UUID(str(user_id))
+    except ValueError:
+        return uuid5(NAMESPACE_URL, f"agentarea:workspace-member:{workspace_id}:{user_id}")
+
+
+def _raise_membership_graph_unavailable(exc: Exception) -> None:
+    raise HTTPException(status_code=503, detail="Workspace membership graph unavailable") from exc
+
+
+async def _grant_member(workspace_id: str, user_id: str) -> None:
+    graph = get_workspace_membership_graph()
+    if graph is None:
+        raise HTTPException(status_code=503, detail="Workspace membership graph is disabled")
+    try:
+        await grant_workspace_membership(graph, workspace_id=workspace_id, user_id=user_id)
+    except (KetoError, KetoUnavailableError, OpenFGAError, OpenFGAUnavailableError) as exc:
+        logger.exception("Failed to grant workspace membership")
+        _raise_membership_graph_unavailable(exc)
+
+
+async def _revoke_member(workspace_id: str, user_id: str) -> None:
+    graph = get_workspace_membership_graph()
+    if graph is None:
+        raise HTTPException(status_code=503, detail="Workspace membership graph is disabled")
+    try:
+        await revoke_workspace_membership(graph, workspace_id=workspace_id, user_id=user_id)
+    except (KetoError, KetoUnavailableError, OpenFGAError, OpenFGAUnavailableError) as exc:
+        logger.exception("Failed to revoke workspace membership")
+        _raise_membership_graph_unavailable(exc)
+
+
+async def _list_member_ids(workspace_id: str) -> list[str]:
+    graph = get_workspace_membership_graph()
+    if graph is None:
+        raise HTTPException(status_code=503, detail="Workspace membership graph is disabled")
+    try:
+        return await list_workspace_member_ids(graph, workspace_id)
+    except (KetoError, KetoUnavailableError, OpenFGAError, OpenFGAUnavailableError) as exc:
+        logger.exception("Failed to list workspace memberships")
+        _raise_membership_graph_unavailable(exc)
 
 
 def _ensure_workspace_access(user: UserContextDep, workspace_id: str) -> None:
@@ -266,11 +298,10 @@ async def accept_invitation(
 ):
     """Accept an invitation as the authenticated user.
 
-    Idempotent: accepting twice (or accepting when already a member)
-    returns the same membership.
+    Idempotent for the same acceptor.
     """
     try:
-        invitation, membership = await service.accept(token=body.token, user_id=user.user_id)
+        invitation = await service.accept(token=body.token, user_id=user.user_id)
     except InvitationNotFound as exc:
         raise HTTPException(status_code=404, detail="invalid token") from exc
     except InvitationExpired as exc:
@@ -280,9 +311,11 @@ async def accept_invitation(
     except InvitationAlreadyAccepted as exc:
         raise HTTPException(status_code=409, detail="invitation already accepted") from exc
 
+    await _grant_member(invitation.workspace_id, user.user_id)
+
     return AcceptInvitationResponse(
         workspace_id=invitation.workspace_id,
-        user_id=membership.user_id,
+        user_id=user.user_id,
         invitation_id=invitation.id,
     )
 
@@ -295,12 +328,19 @@ async def accept_invitation(
 async def list_members(
     workspace_id: str,
     user: UserContextDep,
-    session: SessionDep,
-    service: MembershipServiceDep,
 ):
     _ensure_workspace_access(user, workspace_id)
-    members = await service.list_members(workspace_id)
-    return await _members_to_response(session, members)
+    if workspace_id == user.user_id:
+        await _grant_member(workspace_id, user.user_id)
+
+    member_ids = await _list_member_ids(workspace_id)
+    return _member_ids_to_response(
+        workspace_id,
+        member_ids,
+        current_user_id=user.user_id,
+        current_user_email=user.email,
+        current_user_name=None,
+    )
 
 
 @router.delete(
@@ -311,13 +351,7 @@ async def remove_member(
     workspace_id: str,
     user_id: str,
     user: UserContextDep,
-    service: MembershipServiceDep,
 ):
-    """Remove a member from the workspace. Self-removal allowed; removing
-    others requires the caller to be a member of the workspace (owner-only
-    check belongs to the permissions PR).
-    """
+    """Remove a member from the workspace."""
     _ensure_workspace_access(user, workspace_id)
-    removed = await service.remove(workspace_id=workspace_id, user_id=user_id)
-    if not removed:
-        raise HTTPException(status_code=404, detail="Membership not found")
+    await _revoke_member(workspace_id, user_id)

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/workspace_invitations.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/workspace_invitations.py
@@ -8,7 +8,7 @@ invitation state.
 import logging
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, NoReturn
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 from agentarea_common.auth.dependencies import UserContextDep
@@ -161,7 +161,7 @@ def _stable_member_response_id(workspace_id: str, user_id: str) -> UUID:
         return uuid5(NAMESPACE_URL, f"agentarea:workspace-member:{workspace_id}:{user_id}")
 
 
-def _raise_membership_graph_unavailable(exc: Exception) -> None:
+def _raise_membership_graph_unavailable(exc: Exception) -> NoReturn:
     raise HTTPException(status_code=503, detail="Workspace membership graph unavailable") from exc
 
 

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/workspaces.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/workspaces.py
@@ -15,9 +15,10 @@ from agentarea_common.base.repository_factory import RepositoryFactory
 from agentarea_common.config import get_database
 from agentarea_common.workspaces import (
     Workspace,
-    WorkspaceMembershipRepository,
     WorkspaceRepository,
     WorkspaceService,
+    get_workspace_membership_graph,
+    list_workspace_ids_for_member,
 )
 from agentarea_governance.application import (
     GovernancePolicyService,
@@ -58,7 +59,6 @@ def get_workspace_service(session: SessionDep, user: UserContextDep) -> Workspac
 
     return WorkspaceService(
         WorkspaceRepository(session),
-        WorkspaceMembershipRepository(session),
         on_created=seed_default_policies,
     )
 
@@ -87,5 +87,13 @@ async def list_workspaces(
     new user always gets at least one entry. Baseline governance policies are
     seeded by the workspace-creation hook (see ``get_workspace_service``).
     """
-    workspaces = await service.list_for_user(user.user_id, email=user.email)
+    graph = get_workspace_membership_graph()
+    member_workspace_ids = (
+        await list_workspace_ids_for_member(graph, user.user_id) if graph is not None else []
+    )
+    workspaces = await service.list_for_user(
+        user.user_id,
+        email=user.email,
+        member_workspace_ids=member_workspace_ids,
+    )
     return [WorkspaceResponse(id=w.id, slug=w.slug, name=w.name, type=w.type) for w in workspaces]

--- a/agentarea-platform/libs/common/agentarea_common/auth/dependencies.py
+++ b/agentarea-platform/libs/common/agentarea_common/auth/dependencies.py
@@ -45,29 +45,34 @@ async def _resolve_accessible_workspaces(user_context: UserContext) -> None:
 
     Combines the policy-level static list from ``AuthorizationService``
     (own workspace + system workspace, plus enterprise overrides) with
-    the dynamic list of workspaces the user has joined via accepted
-    invitations. Membership resolution lives at the request boundary,
-    not inside ``AuthorizationService``, so the auth domain service has
-    no infrastructure dependencies and stays singleton-safe.
+    the dynamic list of workspaces the user has joined. Membership resolution
+    lives at the request boundary, not inside ``AuthorizationService``, so the
+    auth domain service has no infrastructure dependencies and stays
+    singleton-safe.
     """
-    from agentarea_common.config.database import get_database
     from agentarea_common.di.container import resolve
-    from agentarea_common.workspaces.repository import WorkspaceMembershipRepository
+    from agentarea_common.workspaces.memberships import (
+        get_workspace_membership_graph,
+        list_workspace_ids_for_member,
+    )
 
     authz = resolve(AuthorizationService)
     accessible = list(await authz.get_accessible_workspaces(user_context))
 
     try:
-        database = get_database()
-        async with database.async_session_factory() as session:
-            repo = WorkspaceMembershipRepository(session)
-            memberships = await repo.list_for_user(user_context.user_id)
-        for membership in memberships:
-            if membership.workspace_id not in accessible:
-                accessible.append(membership.workspace_id)
+        graph = get_workspace_membership_graph()
+        member_workspace_ids = (
+            await list_workspace_ids_for_member(graph, user_context.user_id)
+            if graph is not None
+            else []
+        )
+        for workspace_id in member_workspace_ids:
+            if workspace_id not in accessible:
+                accessible.append(workspace_id)
     except Exception as exc:
-        # Membership lookup failures must not lock the user out of their
-        # own workspace — degrade to the static policy list.
+        # Membership lookup failures must not lock the user out of their own
+        # workspace. Do not fall back to DB membership; graph grants are the
+        # membership source of truth.
         logger.warning(
             "Could not resolve workspace memberships for user %s: %s",
             user_context.user_id,

--- a/agentarea-platform/libs/common/agentarea_common/workspaces/__init__.py
+++ b/agentarea-platform/libs/common/agentarea_common/workspaces/__init__.py
@@ -1,9 +1,8 @@
 """Workspace membership and invitation domain.
 
-Lives in common because membership is cross-cutting — many libs will
-eventually consult it. Authz/permissions (Keto integration, role
-presets, per-resource grants) are NOT here; they're a separate layer
-that will be added in a future PR.
+Lives in common because membership is cross-cutting — many libs consult it.
+The public operations stay product-level even when the configured graph backend
+changes.
 """
 
 from .models import (
@@ -16,6 +15,15 @@ from .models import (
     WorkspaceInvitation,
     WorkspaceMembership,
 )
+from .memberships import (
+    check_workspace_membership,
+    get_workspace_membership_graph,
+    grant_workspace_membership,
+    list_workspace_ids_for_member,
+    list_workspace_member_ids,
+    revoke_workspace_membership,
+    workspace_membership,
+)
 from .repository import (
     WorkspaceInvitationRepository,
     WorkspaceMembershipRepository,
@@ -27,7 +35,6 @@ from .service import (
     InvitationNotFound,
     InvitationRevoked,
     WorkspaceInvitationService,
-    WorkspaceMembershipService,
     WorkspaceService,
 )
 from .slug import slugify
@@ -48,8 +55,14 @@ __all__ = [
     "WorkspaceInvitationService",
     "WorkspaceMembership",
     "WorkspaceMembershipRepository",
-    "WorkspaceMembershipService",
     "WorkspaceRepository",
     "WorkspaceService",
+    "check_workspace_membership",
+    "get_workspace_membership_graph",
+    "grant_workspace_membership",
+    "list_workspace_ids_for_member",
+    "list_workspace_member_ids",
+    "revoke_workspace_membership",
     "slugify",
+    "workspace_membership",
 ]

--- a/agentarea-platform/libs/common/agentarea_common/workspaces/__init__.py
+++ b/agentarea-platform/libs/common/agentarea_common/workspaces/__init__.py
@@ -5,6 +5,15 @@ The public operations stay product-level even when the configured graph backend
 changes.
 """
 
+from .memberships import (
+    check_workspace_membership,
+    get_workspace_membership_graph,
+    grant_workspace_membership,
+    list_workspace_ids_for_member,
+    list_workspace_member_ids,
+    revoke_workspace_membership,
+    workspace_membership,
+)
 from .models import (
     INVITATION_STATUS_ACCEPTED,
     INVITATION_STATUS_PENDING,
@@ -14,15 +23,6 @@ from .models import (
     Workspace,
     WorkspaceInvitation,
     WorkspaceMembership,
-)
-from .memberships import (
-    check_workspace_membership,
-    get_workspace_membership_graph,
-    grant_workspace_membership,
-    list_workspace_ids_for_member,
-    list_workspace_member_ids,
-    revoke_workspace_membership,
-    workspace_membership,
 )
 from .repository import (
     WorkspaceInvitationRepository,

--- a/agentarea-platform/libs/common/agentarea_common/workspaces/memberships.py
+++ b/agentarea-platform/libs/common/agentarea_common/workspaces/memberships.py
@@ -1,0 +1,130 @@
+"""Workspace membership operations backed by the configured relationship graph."""
+
+from __future__ import annotations
+
+from agentarea_common.config import get_settings
+from agentarea_common.di.container import get_container
+from agentarea_common.rebac import (
+    CheckResult,
+    KetoClient,
+    KetoError,
+    OpenFGAClient,
+    OpenFGAError,
+    RelationQuery,
+    RelationTuple,
+)
+
+MembershipGraph = KetoClient | OpenFGAClient
+
+
+def get_workspace_membership_graph() -> MembershipGraph | None:
+    """Resolve the configured relationship graph for workspace memberships."""
+    settings = get_settings()
+    if settings.access_control.ACCESS_CONTROL_BACKEND == "openfga":
+        try:
+            return get_container().get(OpenFGAClient)
+        except ValueError:
+            return OpenFGAClient(
+                api_url=settings.openfga.ACCESS_CONTROL_OPENFGA_API_URL,
+                store_id=settings.openfga.ACCESS_CONTROL_OPENFGA_STORE_ID,
+                authorization_model_id=settings.openfga.ACCESS_CONTROL_OPENFGA_AUTHORIZATION_MODEL_ID,
+                timeout_seconds=settings.openfga.ACCESS_CONTROL_OPENFGA_TIMEOUT_SECONDS,
+            )
+    if settings.access_control.ACCESS_CONTROL_BACKEND == "keto":
+        try:
+            return get_container().get(KetoClient)
+        except ValueError:
+            return KetoClient(
+                read_url=settings.keto.ACCESS_CONTROL_KETO_READ_URL,
+                write_url=settings.keto.ACCESS_CONTROL_KETO_WRITE_URL,
+                timeout_seconds=settings.keto.ACCESS_CONTROL_KETO_TIMEOUT_SECONDS,
+            )
+    return None
+
+
+def workspace_membership(workspace_id: str, user_id: str) -> RelationTuple:
+    return RelationTuple(
+        namespace="Workspace",
+        object=workspace_id,
+        relation="members",
+        subject_id=_user_subject(user_id),
+    )
+
+
+async def check_workspace_membership(
+    graph: MembershipGraph,
+    *,
+    workspace_id: str,
+    user_id: str,
+) -> bool:
+    result: CheckResult = await graph.check(
+        namespace="Workspace",
+        object=workspace_id,
+        relation="members",
+        subject_id=_user_subject(user_id),
+    )
+    return result.allowed
+
+
+async def list_workspace_member_ids(graph: MembershipGraph, workspace_id: str) -> list[str]:
+    relationships = await graph.query_all_tuples(
+        RelationQuery(namespace="Workspace", object=workspace_id, relation="members")
+    )
+    member_ids = {
+        _user_id_from_subject(relationship.subject_id)
+        for relationship in relationships
+        if relationship.subject_id and relationship.subject_id.startswith("User:")
+    }
+    return sorted(member_ids)
+
+
+async def list_workspace_ids_for_member(graph: MembershipGraph, user_id: str) -> list[str]:
+    relationships = await graph.query_all_tuples(
+        RelationQuery(namespace="Workspace", relation="members", subject_id=_user_subject(user_id))
+    )
+    workspace_ids = {
+        relationship.object
+        for relationship in relationships
+        if relationship.namespace == "Workspace" and relationship.relation == "members"
+    }
+    return sorted(workspace_ids)
+
+
+async def grant_workspace_membership(
+    graph: MembershipGraph,
+    *,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    if await check_workspace_membership(graph, workspace_id=workspace_id, user_id=user_id):
+        return
+    try:
+        await graph.write_tuple(workspace_membership(workspace_id, user_id))
+    except (KetoError, OpenFGAError) as exc:
+        if "already exist" in str(exc):
+            return
+        raise
+
+
+async def revoke_workspace_membership(
+    graph: MembershipGraph,
+    *,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    if not await check_workspace_membership(graph, workspace_id=workspace_id, user_id=user_id):
+        return
+    try:
+        await graph.delete_tuple(workspace_membership(workspace_id, user_id))
+    except (KetoError, OpenFGAError) as exc:
+        if "did not exist" in str(exc) or "does not exist" in str(exc):
+            return
+        raise
+
+
+def _user_subject(user_id: str) -> str:
+    return user_id if user_id.startswith("User:") else f"User:{user_id}"
+
+
+def _user_id_from_subject(subject: str) -> str:
+    return subject.split(":", 1)[1] if subject.startswith("User:") else subject

--- a/agentarea-platform/libs/common/agentarea_common/workspaces/repository.py
+++ b/agentarea-platform/libs/common/agentarea_common/workspaces/repository.py
@@ -1,13 +1,12 @@
-"""Repositories for workspace invitations and memberships.
+"""Repositories for workspace invitations and workspace rows.
 
 These don't extend ``WorkspaceScopedRepository`` because:
 - ``WorkspaceInvitation`` is created by a workspace member but the
   acceptance flow is performed by a different user who isn't yet
   scoped to the target workspace — a generic workspace-scope filter
   doesn't fit.
-- ``WorkspaceMembership`` is *the* mechanism that defines workspace
-  membership; bootstrapping it via a workspace-scoped filter would be
-  circular.
+- ``Workspace`` is the scope root, so scoping a workspace lookup by workspace
+  would be circular.
 
 Both repositories accept ``UserContext`` per project convention but
 use it only for explicit policy checks inside the calling service.
@@ -129,11 +128,13 @@ class WorkspaceRepository:
         result = await self.session.execute(select(Workspace).where(Workspace.slug == slug))
         return result.scalar_one_or_none()
 
-    async def list_for_user(self, user_id: str) -> list[Workspace]:
-        """Workspaces the user can reach: their own + any joined via membership."""
-        member_workspace_ids = select(WorkspaceMembership.workspace_id).where(
-            WorkspaceMembership.user_id == user_id
-        )
+    async def list_for_user(
+        self,
+        user_id: str,
+        *,
+        member_workspace_ids: list[str],
+    ) -> list[Workspace]:
+        """Workspaces the user can reach: owned + explicitly granted memberships."""
         result = await self.session.execute(
             select(Workspace)
             .where(

--- a/agentarea-platform/libs/common/agentarea_common/workspaces/service.py
+++ b/agentarea-platform/libs/common/agentarea_common/workspaces/service.py
@@ -17,11 +17,9 @@ from .models import (
     WORKSPACE_TYPE_SHARED,
     Workspace,
     WorkspaceInvitation,
-    WorkspaceMembership,
 )
 from .repository import (
     WorkspaceInvitationRepository,
-    WorkspaceMembershipRepository,
     WorkspaceRepository,
 )
 from .slug import slugify
@@ -60,10 +58,8 @@ class WorkspaceInvitationService:
     def __init__(
         self,
         invitation_repo: WorkspaceInvitationRepository,
-        membership_repo: WorkspaceMembershipRepository,
     ) -> None:
         self.invitation_repo = invitation_repo
-        self.membership_repo = membership_repo
 
     async def create_invitation(
         self,
@@ -103,14 +99,11 @@ class WorkspaceInvitationService:
         invitation.status = INVITATION_STATUS_REVOKED
         return await self.invitation_repo.update(invitation)
 
-    async def accept(
-        self, *, token: str, user_id: str
-    ) -> tuple[WorkspaceInvitation, WorkspaceMembership]:
+    async def accept(self, *, token: str, user_id: str) -> WorkspaceInvitation:
         """Accept an invitation as ``user_id``.
 
-        Idempotent on (workspace_id, user_id): if the user is already a
-        member of the target workspace, the invitation is still marked
-        accepted (if pending) and the existing membership is returned.
+        Idempotent for the same acceptor. The caller owns granting workspace
+        membership in the configured authorization graph.
         """
         invitation = await self.invitation_repo.get_by_token_hash(_hash_token(token))
         if invitation is None:
@@ -120,65 +113,35 @@ class WorkspaceInvitationService:
             raise InvitationRevoked("invitation revoked")
 
         if invitation.status == INVITATION_STATUS_ACCEPTED:
-            existing = await self.membership_repo.get(invitation.workspace_id, user_id)
-            if existing is not None:
-                return invitation, existing
+            if invitation.accepted_by_user_id == user_id:
+                return invitation
             raise InvitationAlreadyAccepted("invitation already accepted")
 
         if invitation.is_expired(_utcnow()):
             raise InvitationExpired("invitation expired")
-
-        existing = await self.membership_repo.get(invitation.workspace_id, user_id)
-        if existing is not None:
-            membership = existing
-        else:
-            membership = await self.membership_repo.add(
-                WorkspaceMembership(
-                    workspace_id=invitation.workspace_id,
-                    user_id=user_id,
-                    invitation_id=invitation.id,
-                )
-            )
 
         invitation.status = INVITATION_STATUS_ACCEPTED
         invitation.accepted_at = _utcnow()
         invitation.accepted_by_user_id = user_id
         await self.invitation_repo.update(invitation)
 
-        return invitation, membership
-
-
-class WorkspaceMembershipService:
-    def __init__(self, membership_repo: WorkspaceMembershipRepository) -> None:
-        self.membership_repo = membership_repo
-
-    async def list_members(self, workspace_id: str) -> list[WorkspaceMembership]:
-        return await self.membership_repo.list_for_workspace(workspace_id)
-
-    async def is_member(self, workspace_id: str, user_id: str) -> bool:
-        return (await self.membership_repo.get(workspace_id, user_id)) is not None
-
-    async def remove(self, *, workspace_id: str, user_id: str) -> bool:
-        return await self.membership_repo.delete(workspace_id, user_id)
+        return invitation
 
 
 class WorkspaceService:
     """Lifecycle of the reified ``Workspace`` entity.
 
     Owns provisioning of personal workspaces and creation of shared ones.
-    Membership remains the source of truth for *who* can reach a shared
-    workspace; this service just keeps the workspace row and the owner's
-    membership in sync on create.
+    Workspace membership is granted/revoked by the domain membership graph,
+    outside this workspace-row lifecycle service.
     """
 
     def __init__(
         self,
         workspace_repo: WorkspaceRepository,
-        membership_repo: WorkspaceMembershipRepository,
         on_created: Callable[[Workspace], Awaitable[None]] | None = None,
     ) -> None:
         self.workspace_repo = workspace_repo
-        self.membership_repo = membership_repo
         # Fired exactly once when a workspace row is genuinely inserted (not on
         # idempotent re-reads). The composition layer wires cross-domain
         # provisioning here (e.g. baseline governance policies) without this
@@ -217,8 +180,8 @@ class WorkspaceService:
         return await self.workspace_repo.get_by_slug(slug)
 
     async def create_shared(self, *, owner_user_id: str, name: str) -> Workspace:
-        """Create a shared workspace and make the creator its first member."""
-        workspace = await self._insert_with_unique_slug(
+        """Create a shared workspace row."""
+        return await self._insert_with_unique_slug(
             slugify(name, fallback="workspace"),
             lambda slug: Workspace(
                 id=str(uuid4()),
@@ -228,24 +191,24 @@ class WorkspaceService:
                 owner_user_id=owner_user_id,
             ),
         )
-        if await self.membership_repo.get(workspace.id, owner_user_id) is None:
-            await self.membership_repo.add(
-                WorkspaceMembership(
-                    workspace_id=workspace.id,
-                    user_id=owner_user_id,
-                    invitation_id=None,
-                )
-            )
-        return workspace
 
-    async def list_for_user(self, user_id: str, *, email: str | None = None) -> list[Workspace]:
-        """List every workspace the user can reach (personal + memberships).
+    async def list_for_user(
+        self,
+        user_id: str,
+        *,
+        email: str | None = None,
+        member_workspace_ids: list[str] | None = None,
+    ) -> list[Workspace]:
+        """List every workspace the user can reach.
 
         Provisions the personal workspace first so a brand-new user always
         gets at least one entry.
         """
         await self.ensure_personal(user_id, email=email)
-        return await self.workspace_repo.list_for_user(user_id)
+        return await self.workspace_repo.list_for_user(
+            user_id,
+            member_workspace_ids=member_workspace_ids or [],
+        )
 
     async def _next_free_slug(self, base: str) -> str:
         candidate = base

--- a/agentarea-platform/tests/integration/repositories/test_workspace_repository.py
+++ b/agentarea-platform/tests/integration/repositories/test_workspace_repository.py
@@ -3,9 +3,9 @@
 These cover the foundation that the workspace switcher (Step 2) builds on:
 - personal workspaces are real rows, provisioned idempotently, with
   ``id == user_id`` so existing data needs no backfill;
-- shared workspaces get a generated id plus an owner membership;
-- listing returns a user's personal workspace and every workspace they
-  joined via membership.
+- shared workspaces get a generated id;
+- listing returns a user's personal workspace and workspace ids supplied by
+  the membership graph.
 
 The fixtures here intentionally create *only* the workspace tables on an
 in-memory SQLite engine rather than the shared ``db_session`` fixture,
@@ -23,7 +23,6 @@ from agentarea_common.workspaces.models import (
     WorkspaceMembership,
 )
 from agentarea_common.workspaces.repository import (
-    WorkspaceMembershipRepository,
     WorkspaceRepository,
 )
 from agentarea_common.workspaces.service import WorkspaceService
@@ -56,7 +55,6 @@ async def db_session():
 def workspace_service(db_session):
     return WorkspaceService(
         workspace_repo=WorkspaceRepository(db_session),
-        membership_repo=WorkspaceMembershipRepository(db_session),
     )
 
 
@@ -112,7 +110,7 @@ async def test_ensure_personal_is_idempotent(workspace_service):
 
 
 @pytest.mark.asyncio
-async def test_create_shared_creates_workspace_and_owner_membership(workspace_service, db_session):
+async def test_create_shared_creates_workspace_row(workspace_service):
     ws = await workspace_service.create_shared(owner_user_id="user-1", name="Team A")
 
     assert ws.type == WORKSPACE_TYPE_SHARED
@@ -120,20 +118,16 @@ async def test_create_shared_creates_workspace_and_owner_membership(workspace_se
     assert ws.name == "Team A"
     assert ws.owner_user_id == "user-1"
 
-    membership_repo = WorkspaceMembershipRepository(db_session)
-    assert await membership_repo.get(ws.id, "user-1") is not None
-
 
 @pytest.mark.asyncio
-async def test_list_for_user_returns_personal_and_member_workspaces(workspace_service, db_session):
-    # user-1 owns a shared workspace; user-2 is added to it as a member.
+async def test_list_for_user_returns_personal_and_granted_workspaces(workspace_service):
+    # user-1 owns a shared workspace; user-2 receives membership from graph.
     shared = await workspace_service.create_shared(owner_user_id="user-1", name="Team A")
-    membership_repo = WorkspaceMembershipRepository(db_session)
-    await membership_repo.add(
-        WorkspaceMembership(workspace_id=shared.id, user_id="user-2", invitation_id=None)
-    )
 
-    user2_workspaces = await workspace_service.list_for_user("user-2")
+    user2_workspaces = await workspace_service.list_for_user(
+        "user-2",
+        member_workspace_ids=[shared.id],
+    )
     ids = {w.id for w in user2_workspaces}
 
     assert "user-2" in ids  # personal, auto-provisioned by list_for_user

--- a/agentarea-platform/tests/unit/test_workspace_on_created_hook.py
+++ b/agentarea-platform/tests/unit/test_workspace_on_created_hook.py
@@ -27,11 +27,6 @@ class _FakeWorkspaceRepo:
         return workspace
 
 
-class _FakeMembershipRepo:
-    async def get(self, *_args, **_kwargs):
-        return object()  # already a member -> no insert path needed
-
-
 @pytest.mark.asyncio
 async def test_hook_fires_on_genuine_create():
     fired: list[str] = []
@@ -41,7 +36,6 @@ async def test_hook_fires_on_genuine_create():
 
     service = WorkspaceService(
         _FakeWorkspaceRepo(existing=None),
-        _FakeMembershipRepo(),
         on_created=on_created,
     )
 
@@ -61,7 +55,6 @@ async def test_hook_does_not_fire_on_idempotent_reread():
     )
     service = WorkspaceService(
         _FakeWorkspaceRepo(existing=existing),
-        _FakeMembershipRepo(),
         on_created=on_created,
     )
 

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -1277,8 +1277,7 @@ export interface paths {
          * Accept Invitation
          * @description Accept an invitation as the authenticated user.
          *
-         *     Idempotent: accepting twice (or accepting when already a member)
-         *     returns the same membership.
+         *     Idempotent for the same acceptor.
          */
         post: operations["accept_invitation_v1_invitations_accept_post"];
         delete?: never;
@@ -3920,9 +3919,7 @@ export interface paths {
         post?: never;
         /**
          * Remove Member
-         * @description Remove a member from the workspace. Self-removal allowed; removing
-         *     others requires the caller to be a member of the workspace (owner-only
-         *     check belongs to the permissions PR).
+         * @description Remove a member from the workspace.
          */
         delete: operations["remove_member_v1_workspaces__workspace_id__members__user_id__delete"];
         options?: never;

--- a/agentarea-webapp/src/app/(main)/members/page.tsx
+++ b/agentarea-webapp/src/app/(main)/members/page.tsx
@@ -14,6 +14,36 @@ export const metadata: Metadata = {
   title: "Members",
 };
 
+function ensureCurrentUserMember(
+  members: WorkspaceMember[],
+  currentUser: {
+    workspaceId: string | null;
+    userId: string | null;
+    email: string | null;
+    name: string | null;
+    username: string | null;
+  }
+): WorkspaceMember[] {
+  if (!currentUser.workspaceId || !currentUser.userId) return members;
+  if (members.some((member) => member.user_id === currentUser.userId)) {
+    return members;
+  }
+
+  return [
+    {
+      id: currentUser.userId,
+      workspace_id: currentUser.workspaceId,
+      user_id: currentUser.userId,
+      email: currentUser.email,
+      display_name:
+        currentUser.name || currentUser.email || currentUser.username || null,
+      joined_at: new Date().toISOString(),
+      invitation_id: null,
+    },
+    ...members,
+  ];
+}
+
 export default async function MembersPage() {
   const t = await getTranslations("MembersPage");
   const { workspaceId, userId, email, name, username } = await getAuthContext();
@@ -29,6 +59,14 @@ export default async function MembersPage() {
     members = membersRes.data ?? [];
     invitations = invitationsRes.data ?? [];
   }
+
+  members = ensureCurrentUserMember(members, {
+    workspaceId,
+    userId,
+    email,
+    name,
+    username,
+  });
 
   return (
     <ContentBlock

--- a/agentarea-webapp/src/app/(main)/policies/[policyId]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/[policyId]/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { PolicyEditorPageData } from "../components/PolicyEditorPageData";
+
+export const metadata: Metadata = {
+  title: "Edit Policy",
+};
+
+export default async function EditPolicyPage({
+  params,
+}: {
+  params: Promise<{ policyId: string }>;
+}) {
+  const { policyId } = await params;
+  return <PolicyEditorPageData policyId={policyId} />;
+}

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesData.tsx
@@ -1,6 +1,5 @@
 import EmptyState from "@/components/EmptyState";
 import { listAgents, listPolicies } from "@/lib/api";
-import { getAuthContext } from "@/lib/getAuthContext";
 import type { Policy } from "@/types/policies";
 import PoliciesEditableView from "./PoliciesEditableView";
 
@@ -14,10 +13,9 @@ export async function PoliciesData() {
   let agents: AgentLike[] = [];
   let policiesError: string | null = null;
 
-  const [policiesRes, agentsRes, authContext] = await Promise.all([
+  const [policiesRes, agentsRes] = await Promise.all([
     listPolicies().catch((reason) => ({ data: null, error: reason })),
     listAgents().catch((reason) => ({ data: null, error: reason })),
-    getAuthContext(),
   ]);
 
   if (policiesRes.error) {
@@ -49,16 +47,5 @@ export async function PoliciesData() {
     );
   }
 
-  const hasWorkspacePolicy = policies.some(
-    (p) => p.subject_type === "workspace"
-  );
-
-  return (
-    <PoliciesEditableView
-      policies={policies}
-      agents={agents}
-      workspaceId={authContext.workspaceId}
-      hasWorkspacePolicy={hasWorkspacePolicy}
-    />
-  );
+  return <PoliciesEditableView policies={policies} agents={agents} />;
 }

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesData.tsx
@@ -6,6 +6,8 @@ import PoliciesEditableView from "./PoliciesEditableView";
 interface AgentLike {
   id: string;
   name: string;
+  icon?: string | null;
+  color_token?: string | null;
 }
 
 export async function PoliciesData() {
@@ -31,6 +33,8 @@ export async function PoliciesData() {
     agents = ((agentsRes.data as AgentLike[] | null) ?? []).map((a) => ({
       id: a.id,
       name: a.name,
+      icon: a.icon,
+      color_token: a.color_token,
     }));
   }
 

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesEditableView.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesEditableView.tsx
@@ -1,16 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import type { Policy } from "@/types/policies";
-import PolicyEditor, { type PolicyEditorTarget } from "./PolicyEditor";
 import PoliciesList from "./PoliciesList";
-
-// Custom event dispatched by the header "New policy" control. The header button
-// lives in a separate React tree (page-level controls slot), so we bridge it to
-// this client component via a window event — mirroring how the Access view
-// reaches into the DOM for its primary action.
-export const NEW_POLICY_EVENT = "policies:new";
 
 interface AgentOption {
   id: string;
@@ -20,45 +13,23 @@ interface AgentOption {
 interface PoliciesEditableViewProps {
   policies: Policy[];
   agents: AgentOption[];
-  workspaceId: string | null;
-  hasWorkspacePolicy: boolean;
 }
 
 export default function PoliciesEditableView({
   policies,
   agents,
-  workspaceId,
-  hasWorkspacePolicy,
 }: PoliciesEditableViewProps) {
   const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const [target, setTarget] = useState<PolicyEditorTarget | null>(null);
 
   const policyById = useMemo(
     () => new Map(policies.map((p) => [p.id, p])),
     [policies]
   );
 
-  const openCreate = () => {
-    // No workspace policy yet → default new rules to workspace scope.
-    setTarget(
-      hasWorkspacePolicy ? { mode: "create-agent" } : { mode: "create-workspace" }
-    );
-    setOpen(true);
-  };
-
-  useEffect(() => {
-    const handler = () => openCreate();
-    window.addEventListener(NEW_POLICY_EVENT, handler);
-    return () => window.removeEventListener(NEW_POLICY_EVENT, handler);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasWorkspacePolicy]);
-
   const handleEditRule = (ruleId: string) => {
     const policy = policyById.get(ruleId);
     if (!policy) return;
-    setTarget({ mode: "edit", policy });
-    setOpen(true);
+    router.push(`/policies/${policy.id}`);
   };
 
   return (
@@ -80,14 +51,6 @@ export default function PoliciesEditableView({
           onEditRule={handleEditRule}
         />
       )}
-      <PolicyEditor
-        open={open}
-        onOpenChange={setOpen}
-        target={target}
-        agents={agents}
-        workspaceId={workspaceId}
-        onSaved={() => router.refresh()}
-      />
     </>
   );
 }

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesEditableView.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesEditableView.tsx
@@ -8,6 +8,8 @@ import PoliciesList from "./PoliciesList";
 interface AgentOption {
   id: string;
   name: string;
+  icon?: string | null;
+  color_token?: string | null;
 }
 
 interface PoliciesEditableViewProps {

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesHeaderControls.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesHeaderControls.tsx
@@ -1,20 +1,16 @@
 "use client";
 
+import Link from "next/link";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { NEW_POLICY_EVENT } from "./PoliciesEditableView";
 
 export default function PoliciesHeaderControls() {
-  // The editor lives in the body (PoliciesEditableView). The page-level controls
-  // slot is a separate React tree, so we bridge the click via a window event.
-  const handleClick = () => {
-    window.dispatchEvent(new CustomEvent(NEW_POLICY_EVENT));
-  };
-
   return (
-    <Button size="sm" className="shrink-0 gap-2" onClick={handleClick}>
-      <Plus className="h-4 w-4" />
-      New policy
+    <Button size="sm" className="shrink-0 gap-2" asChild>
+      <Link href="/policies/new">
+        <Plus className="h-4 w-4" />
+        New policy
+      </Link>
     </Button>
   );
 }

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesList.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesList.tsx
@@ -18,6 +18,8 @@ import { policyToRule } from "./policy-rules";
 interface AgentOption {
   id: string;
   name: string;
+  icon?: string | null;
+  color_token?: string | null;
 }
 
 const CATEGORY_ICON: Record<string, LucideIcon> = {

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -131,6 +131,12 @@ interface FormState {
   outputSanitizer: boolean;
 }
 
+interface PolicyDraft {
+  id: string;
+  effect: PolicyEffect;
+  form: FormState;
+}
+
 const EMPTY_FORM: FormState = {
   enabled: true,
   capKind: "spend",
@@ -147,6 +153,22 @@ const EMPTY_FORM: FormState = {
   promptInjection: true,
   outputSanitizer: false,
 };
+
+function cloneForm(form: FormState): FormState {
+  return {
+    ...form,
+    tools: [...form.tools],
+    approvers: [...form.approvers],
+  };
+}
+
+function newDraft(id: string, effect: PolicyEffect = "cap"): PolicyDraft {
+  return {
+    id,
+    effect,
+    form: cloneForm(EMPTY_FORM),
+  };
+}
 
 // Loosely validate Keto subject refs (user:<id> | group:<id>#member, etc.).
 const SUBJECT_REF_RE = /^[a-zA-Z]+:[^\s]+/;
@@ -1202,8 +1224,10 @@ export default function PolicyEditor({
   returnHref = "/policies",
 }: PolicyEditorProps) {
   const router = useRouter();
-  const [effect, setEffect] = useState<PolicyEffect>("cap");
-  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [drafts, setDrafts] = useState<PolicyDraft[]>(() => [
+    newDraft("draft-1"),
+  ]);
+  const [activeDraftId, setActiveDraftId] = useState("draft-1");
   const [scopeMode, setScopeMode] = useState<ScopeMode>("workspace");
   const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
   const [agentToAddId, setAgentToAddId] = useState<string>("");
@@ -1211,6 +1235,10 @@ export default function PolicyEditor({
   const [error, setError] = useState<string | null>(null);
 
   const isEdit = target?.mode === "edit";
+  const activeDraft =
+    drafts.find((draft) => draft.id === activeDraftId) ?? drafts[0];
+  const effect = activeDraft?.effect ?? "cap";
+  const form = activeDraft?.form ?? EMPTY_FORM;
 
   const subjectType = useMemo<"workspace" | "agent">(() => {
     if (target.mode === "edit")
@@ -1269,8 +1297,14 @@ export default function PolicyEditor({
   useEffect(() => {
     if (target.mode === "edit") {
       const seeded = policyToForm(target.policy);
-      setEffect(seeded.effect);
-      setForm(seeded.form);
+      setDrafts([
+        {
+          id: "draft-1",
+          effect: seeded.effect,
+          form: cloneForm(seeded.form),
+        },
+      ]);
+      setActiveDraftId("draft-1");
       setScopeMode(
         target.policy.subject_type === "agent" ? "agents" : "workspace"
       );
@@ -1279,8 +1313,8 @@ export default function PolicyEditor({
       );
       setAgentToAddId("");
     } else {
-      setEffect("cap");
-      setForm(EMPTY_FORM);
+      setDrafts([newDraft("draft-1")]);
+      setActiveDraftId("draft-1");
       setScopeMode(target.mode === "create-agent" ? "agents" : "workspace");
       setSelectedAgentIds(
         target.mode === "create-agent" && target.agentId ? [target.agentId] : []
@@ -1291,7 +1325,37 @@ export default function PolicyEditor({
   }, [target]);
 
   const update = <K extends keyof FormState>(key: K, value: FormState[K]) =>
-    setForm((prev) => ({ ...prev, [key]: value }));
+    setDrafts((prev) =>
+      prev.map((draft) =>
+        draft.id === activeDraftId
+          ? { ...draft, form: { ...draft.form, [key]: value } }
+          : draft
+      )
+    );
+
+  const updateActiveEffect = (nextEffect: PolicyEffect) => {
+    setDrafts((prev) =>
+      prev.map((draft) =>
+        draft.id === activeDraftId ? { ...draft, effect: nextEffect } : draft
+      )
+    );
+  };
+
+  const addDraft = () => {
+    const id = `draft-${drafts.length + 1}-${Date.now()}`;
+    setDrafts((prev) => [...prev, newDraft(id, "deny")]);
+    setActiveDraftId(id);
+  };
+
+  const removeDraft = (draftId: string) => {
+    if (drafts.length <= 1) return;
+    const nextActiveId =
+      activeDraftId === draftId
+        ? (drafts.find((draft) => draft.id !== draftId)?.id ?? "draft-1")
+        : activeDraftId;
+    setDrafts((prev) => prev.filter((draft) => draft.id !== draftId));
+    setActiveDraftId(nextActiveId);
+  };
 
   const addSelectedAgent = () => {
     if (!agentToAddId || selectedAgentIdSet.has(agentToAddId)) return;
@@ -1340,9 +1404,18 @@ export default function PolicyEditor({
       return;
     }
 
-    const built = buildRuleBodies(effect, form);
-    if ("error" in built) {
-      setError(built.error);
+    const draftsToSave = isEdit ? [activeDraft] : drafts;
+    const builtDrafts = draftsToSave.map((draft, index) => ({
+      draft,
+      index,
+      result: buildRuleBodies(draft.effect, draft.form),
+    }));
+    const invalidDraft = builtDrafts.find((item) => "error" in item.result);
+    if (invalidDraft && "error" in invalidDraft.result) {
+      setActiveDraftId(invalidDraft.draft.id);
+      setError(
+        `Rule ${invalidDraft.index + 1} (${EFFECT_STYLES[invalidDraft.draft.effect].label}): ${invalidDraft.result.error}`
+      );
       return;
     }
 
@@ -1353,6 +1426,8 @@ export default function PolicyEditor({
         // PATCH the single rule. Edit only writes the first body (a rule edits
         // one rule); extra tools added in edit mode are ignored to keep edit
         // 1:1 with the backing rule.
+        const built = builtDrafts[0].result;
+        if ("error" in built) return;
         const body = built.bodies[0];
         const response = await fetch(
           `/api/proxy/v1/policies/${target.policy.id}`,
@@ -1364,7 +1439,7 @@ export default function PolicyEditor({
               effect: body.effect,
               params: body.params,
               condition: body.condition ?? null,
-              enabled: form.enabled,
+              enabled: activeDraft.form.enabled,
             }),
           }
         );
@@ -1375,23 +1450,27 @@ export default function PolicyEditor({
       } else {
         // POST one rule per scope/body pair (deny/approval may fan out over tools).
         for (const subject of subjects) {
-          for (const body of built.bodies) {
-            const response = await fetch(`/api/proxy/v1/policies`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                subject_type: subject.subject_type,
-                subject_id: subject.subject_id,
-                target: body.target,
-                effect: body.effect,
-                params: body.params,
-                condition: body.condition ?? null,
-                enabled: form.enabled,
-              }),
-            });
-            if (!response.ok) {
-              setError(await readDetail(response, "Save failed"));
-              return;
+          for (const item of builtDrafts) {
+            if ("error" in item.result) continue;
+            for (const body of item.result.bodies) {
+              const response = await fetch(`/api/proxy/v1/policies`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  subject_type: subject.subject_type,
+                  subject_id: subject.subject_id,
+                  target: body.target,
+                  effect: body.effect,
+                  params: body.params,
+                  condition: body.condition ?? null,
+                  enabled: item.draft.form.enabled,
+                }),
+              });
+              if (!response.ok) {
+                setActiveDraftId(item.draft.id);
+                setError(await readDetail(response, "Save failed"));
+                return;
+              }
             }
           }
         }
@@ -1436,23 +1515,32 @@ export default function PolicyEditor({
       ? "New agent policy"
       : "New workspace rule";
   const hasAgentScopeEditor = subjectType === "agent" && !isEdit;
-  const effectCode = hasAgentScopeEditor ? "03" : "02";
-  const detailsCode = hasAgentScopeEditor ? "04" : "03";
-  const stateCode = hasAgentScopeEditor ? "05" : "04";
   const compiledSubjects = resolveSubjects();
-  const compiledBodies = buildRuleBodies(effect, form);
+  const compiledDrafts = drafts.map((draft) => ({
+    draft,
+    result: buildRuleBodies(draft.effect, draft.form),
+  }));
+  const firstInvalidDraft = compiledDrafts.find(
+    (item) => "error" in item.result
+  );
   const compiledError =
     compiledSubjects === null
       ? subjectType === "agent"
         ? "agent scope pending"
         : "workspace scope missing"
-      : "error" in compiledBodies
-        ? compiledBodies.error
+      : firstInvalidDraft && "error" in firstInvalidDraft.result
+        ? `${EFFECT_STYLES[firstInvalidDraft.draft.effect].label}: ${firstInvalidDraft.result.error}`
         : null;
   const compiledRuleCount =
-    compiledSubjects && "bodies" in compiledBodies
-      ? compiledSubjects.length * compiledBodies.bodies.length
+    compiledSubjects && !firstInvalidDraft
+      ? compiledSubjects.length *
+        compiledDrafts.reduce(
+          (sum, item) =>
+            "bodies" in item.result ? sum + item.result.bodies.length : sum,
+          0
+        )
       : null;
+  const enabledDraftCount = drafts.filter((draft) => draft.form.enabled).length;
   const compiledRows = [
     {
       label: "scope",
@@ -1461,7 +1549,12 @@ export default function PolicyEditor({
           ? "workspace"
           : `${selectedAgentIds.length} agent${selectedAgentIds.length === 1 ? "" : "s"}`,
     },
-    { label: "effect", value: EFFECT_STYLES[effect].label.toLowerCase() },
+    { label: "drafts", value: String(drafts.length) },
+    {
+      label: "active",
+      value: `${enabledDraftCount}/${drafts.length} enabled`,
+    },
+    { label: "selected", value: EFFECT_STYLES[effect].label.toLowerCase() },
     { label: "target", value: previewTarget(effect, form) },
     { label: "params", value: previewParams(effect, form) },
     {
@@ -1472,7 +1565,6 @@ export default function PolicyEditor({
       label: "rules",
       value: compiledRuleCount === null ? "pending" : String(compiledRuleCount),
     },
-    { label: "state", value: form.enabled ? "enabled" : "disabled" },
   ];
 
   return (
@@ -1504,144 +1596,218 @@ export default function PolicyEditor({
                 . Tool access grants are managed in the Access view.
               </p>
             </div>
-            <div className="border border-border/70 bg-background px-3 py-2 text-right">
+            <div className="min-w-[220px] border border-border/70 bg-background px-3 py-2">
               <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-                Scope
+                Target
               </p>
-              <p className="mt-1 text-sm font-medium text-foreground">
-                {subjectType === "workspace" ? "All agents" : "Selected"}
-              </p>
+              {isEdit ? (
+                <p className="mt-1 text-sm font-medium text-foreground">
+                  {subjectType === "workspace"
+                    ? "Workspace"
+                    : selectedAgents[0]?.name || target.policy.subject_id}
+                </p>
+              ) : (
+                <div className="mt-2 inline-flex flex-wrap items-center gap-px border border-border/70 bg-muted/30 p-px">
+                  {[
+                    { value: "workspace" as const, label: "All agents" },
+                    { value: "agents" as const, label: "Selected agents" },
+                  ].map((option) => {
+                    const active = scopeMode === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => setScopeMode(option.value)}
+                        className={cn(
+                          "px-2.5 py-1 text-xs transition",
+                          active
+                            ? "bg-background text-foreground shadow-[inset_0_-2px_0_hsl(var(--primary))]"
+                            : "text-muted-foreground hover:text-foreground"
+                        )}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
+          {hasAgentScopeEditor && (
+            <div className="mt-4 grid gap-3 border-t border-border/70 pt-4 lg:grid-cols-[minmax(240px,360px)_minmax(0,1fr)]">
+              <div className="flex items-end gap-2">
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <Label htmlFor="policy-agent">Agent</Label>
+                  <Select value={agentToAddId} onValueChange={setAgentToAddId}>
+                    <SelectTrigger id="policy-agent">
+                      <SelectValue placeholder="Select an agent" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {addableAgents.map((agent) => (
+                        <SelectItem
+                          key={agent.id}
+                          value={agent.id}
+                          textValue={agent.name}
+                        >
+                          <AgentIdentity agent={agent} size="xs" />
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  disabled={!agentToAddId}
+                  onClick={addSelectedAgent}
+                  aria-label="Add agent"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="min-w-0 space-y-2">
+                {selectedAgents.length > 0 ? (
+                  selectedAgents.map((agent) => (
+                    <div
+                      key={agent.id}
+                      className="flex items-center gap-2 border border-border/70 bg-background px-3 py-2"
+                    >
+                      <AgentIdentity
+                        agent={agent}
+                        size="xs"
+                        className="flex-1"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeSelectedAgent(agent.id)}
+                        aria-label={`Remove ${agent.name}`}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))
+                ) : (
+                  <p className="border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
+                    Add agents to scope this policy.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="relative px-5">
-          {!isEdit && (
-            <BlueprintSection code="01" title="Scope">
-              <div className="inline-flex flex-wrap items-center gap-px border border-border/70 bg-muted/30 p-px">
-                {[
-                  { value: "workspace" as const, label: "All agents" },
-                  { value: "agents" as const, label: "Selected agents" },
-                ].map((option) => {
-                  const active = scopeMode === option.value;
+          <BlueprintSection code="01" title="Policy Rules">
+            <div className="space-y-3">
+              <div className="grid gap-2 md:grid-cols-2">
+                {drafts.map((draft, index) => {
+                  const active = draft.id === activeDraftId;
+                  const style = EFFECT_STYLES[draft.effect];
+                  const Icon = style.icon;
                   return (
-                    <button
-                      key={option.value}
-                      type="button"
-                      onClick={() => setScopeMode(option.value)}
+                    <div
+                      key={draft.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setActiveDraftId(draft.id)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          setActiveDraftId(draft.id);
+                        }
+                      }}
                       className={cn(
-                        "px-3 py-1.5 text-sm transition",
-                        active
-                          ? "bg-background text-foreground shadow-[inset_0_-2px_0_hsl(var(--primary))]"
-                          : "text-muted-foreground hover:text-foreground"
+                        "cursor-pointer border border-border/70 bg-muted/20 px-3 py-2 transition-colors hover:bg-muted/30",
+                        active && "shadow-[inset_2px_0_0_hsl(var(--primary))]"
                       )}
                     >
-                      {option.label}
-                    </button>
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                            Rule {index + 1}
+                          </p>
+                          <div className="mt-1 flex items-center gap-2">
+                            <Icon
+                              className="h-4 w-4 text-muted-foreground"
+                              strokeWidth={1.8}
+                              aria-hidden
+                            />
+                            <span className="text-sm font-medium text-foreground">
+                              {style.label}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {draft.form.enabled ? "enabled" : "disabled"}
+                            </span>
+                          </div>
+                          <p className="mt-1 truncate text-xs text-muted-foreground">
+                            {previewParams(draft.effect, draft.form)}
+                          </p>
+                        </div>
+                        {!isEdit && drafts.length > 1 && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              removeDraft(draft.id);
+                            }}
+                            aria-label={`Remove rule ${index + 1}`}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
                   );
                 })}
               </div>
-            </BlueprintSection>
-          )}
 
-          {isEdit && (
-            <BlueprintSection code="01" title="Scope">
-              <p className="mt-1 text-sm text-foreground">
-                {subjectType === "workspace"
-                  ? "All agents"
-                  : selectedAgents[0]?.name || target.policy.subject_id}
-              </p>
-            </BlueprintSection>
-          )}
+              {!isEdit && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addDraft}
+                >
+                  <Plus className="mr-1.5 h-4 w-4" />
+                  Add rule
+                </Button>
+              )}
 
-          {hasAgentScopeEditor && (
-            <BlueprintSection code="02" title="Agents">
-              <div className="space-y-3">
-                <div className="flex items-end gap-2">
-                  <div className="min-w-0 flex-1 space-y-1.5">
-                    <Label htmlFor="policy-agent">Agent</Label>
-                    <Select
-                      value={agentToAddId}
-                      onValueChange={setAgentToAddId}
-                    >
-                      <SelectTrigger id="policy-agent">
-                        <SelectValue placeholder="Select an agent" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {addableAgents.map((agent) => (
-                          <SelectItem
-                            key={agent.id}
-                            value={agent.id}
-                            textValue={agent.name}
-                          >
-                            <AgentIdentity agent={agent} size="xs" />
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    disabled={!agentToAddId}
-                    onClick={addSelectedAgent}
-                    aria-label="Add agent"
-                  >
-                    <Plus className="h-4 w-4" />
-                  </Button>
-                </div>
-
-                <div className="space-y-2">
-                  {selectedAgents.length > 0 ? (
-                    selectedAgents.map((agent) => (
-                      <div
-                        key={agent.id}
-                        className="flex items-center gap-2 border border-border/70 bg-muted/20 px-3 py-2"
-                      >
-                        <AgentIdentity
-                          agent={agent}
-                          size="xs"
-                          className="flex-1"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => removeSelectedAgent(agent.id)}
-                          aria-label={`Remove ${agent.name}`}
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
-                      Add agents to scope this policy.
+              <div className="flex flex-wrap items-center justify-between gap-3 border border-border/70 bg-background px-3 py-3">
+                <div className="min-w-0 space-y-2">
+                  <Label>Rule type</Label>
+                  <EffectSegmented
+                    value={effect}
+                    onChange={updateActiveEffect}
+                    disabled={isEdit}
+                  />
+                  {isEdit && (
+                    <p className="text-xs text-muted-foreground">
+                      The rule type is fixed once a rule is created.
                     </p>
                   )}
                 </div>
+                <div className="flex items-center gap-3">
+                  <Label htmlFor="policy-enabled">Enabled</Label>
+                  <Switch
+                    id="policy-enabled"
+                    checked={form.enabled}
+                    onCheckedChange={(v) => update("enabled", v)}
+                  />
+                </div>
               </div>
-            </BlueprintSection>
-          )}
-
-          {/* Effect */}
-          <BlueprintSection code={effectCode} title="Effect">
-            <EffectSegmented
-              value={effect}
-              onChange={setEffect}
-              disabled={isEdit}
-            />
-            {isEdit && (
-              <p className="text-xs text-muted-foreground">
-                The effect is fixed once a rule is created.
-              </p>
-            )}
+            </div>
           </BlueprintSection>
 
           {/* Effect-specific fields */}
           {effect === "cap" && (
-            <BlueprintSection code={detailsCode} title="Limits">
+            <BlueprintSection code="02" title="Rule Config">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
                 <div className="space-y-1.5">
                   <Label htmlFor="cap-kind">Budget type</Label>
@@ -1711,7 +1877,7 @@ export default function PolicyEditor({
           )}
 
           {effect === "deny" && (
-            <BlueprintSection code={detailsCode} title="Deny List">
+            <BlueprintSection code="02" title="Rule Config">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
                 <Label>Denied tools</Label>
                 <ToolSelector
@@ -1743,7 +1909,7 @@ export default function PolicyEditor({
           )}
 
           {effect === "approval" && (
-            <BlueprintSection code={detailsCode} title="Approval">
+            <BlueprintSection code="02" title="Rule Config">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
                 <div className="flex items-center justify-between">
                   <div>
@@ -1794,7 +1960,7 @@ export default function PolicyEditor({
           )}
 
           {effect === "safety" && (
-            <BlueprintSection code={detailsCode} title="Safety">
+            <BlueprintSection code="02" title="Rule Config">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
                 <div className="flex items-center justify-between">
                   <Label htmlFor="prompt-injection" className="font-normal">
@@ -1819,23 +1985,6 @@ export default function PolicyEditor({
               </div>
             </BlueprintSection>
           )}
-
-          {/* Enabled */}
-          <BlueprintSection code={stateCode} title="State">
-            <div className="flex items-center justify-between border border-border/70 bg-muted/20 p-4">
-              <div>
-                <Label htmlFor="policy-enabled">Rule enabled</Label>
-                <p className="text-xs text-muted-foreground">
-                  Disabled rules are kept but not enforced.
-                </p>
-              </div>
-              <Switch
-                id="policy-enabled"
-                checked={form.enabled}
-                onCheckedChange={(v) => update("enabled", v)}
-              />
-            </div>
-          </BlueprintSection>
         </div>
 
         {error && (
@@ -1878,7 +2027,11 @@ export default function PolicyEditor({
               disabled={saving}
               onClick={save}
             >
-              {isEdit ? "Save rule" : "Create rule"}
+              {isEdit
+                ? "Save rule"
+                : drafts.length > 1
+                  ? "Create rules"
+                  : "Create rule"}
             </Button>
           </div>
         </div>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -439,6 +439,49 @@ function BlueprintSection({
   );
 }
 
+function previewTarget(effect: PolicyEffect, form: FormState): string {
+  if (effect === "cap") return form.capKind;
+  if (effect === "deny") {
+    return form.tools.length === 0 ? "tool:<pending>" : "tool";
+  }
+  if (effect === "approval") {
+    return form.approvalAllActions ? "*" : "tool";
+  }
+  return "content";
+}
+
+function previewParams(effect: PolicyEffect, form: FormState): string {
+  if (effect === "cap") {
+    if (form.capKind === "tokens") {
+      const parts: string[] = [];
+      if (form.maxTokens) parts.push(`max=${form.maxTokens}`);
+      if (form.maxTokensPerCall) parts.push(`call=${form.maxTokensPerCall}`);
+      return parts.length > 0 ? parts.join(" ") : "tokens=pending";
+    }
+    return `amount=${form.amountUsd || "pending"}${
+      form.capKind === "spend" ? ` period=${form.period}` : ""
+    }`;
+  }
+  if (effect === "deny") {
+    return form.tools.length > 0
+      ? `tools=${form.tools.length}`
+      : "tools=pending";
+  }
+  if (effect === "approval") {
+    const scope = form.approvalAllActions
+      ? "actions=*"
+      : `tools=${form.tools.length || "pending"}`;
+    const approvers =
+      form.approvers.length > 0 ? ` approvers=${form.approvers.length}` : "";
+    return `${scope}${approvers}`;
+  }
+  const checks = [
+    form.promptInjection && "prompt_injection",
+    form.outputSanitizer && "output_sanitizer",
+  ].filter(Boolean);
+  return checks.length > 0 ? checks.join(" ") : "checks=pending";
+}
+
 // --- editor ---------------------------------------------------------------
 
 export default function PolicyEditor({
@@ -659,6 +702,37 @@ export default function PolicyEditor({
   const effectCode = hasAgentScopeEditor ? "03" : "02";
   const detailsCode = hasAgentScopeEditor ? "04" : "03";
   const stateCode = hasAgentScopeEditor ? "05" : "04";
+  const compiledSubjects = resolveSubjects();
+  const compiledBodies = buildRuleBodies(effect, form);
+  const compiledError =
+    compiledSubjects === null
+      ? subjectType === "agent"
+        ? "agent scope pending"
+        : "workspace scope missing"
+      : "error" in compiledBodies
+        ? compiledBodies.error
+        : null;
+  const compiledRuleCount =
+    compiledSubjects && "bodies" in compiledBodies
+      ? compiledSubjects.length * compiledBodies.bodies.length
+      : null;
+  const compiledRows = [
+    {
+      label: "scope",
+      value:
+        subjectType === "workspace"
+          ? "workspace"
+          : `${selectedAgentIds.length} agent${selectedAgentIds.length === 1 ? "" : "s"}`,
+    },
+    { label: "effect", value: effect },
+    { label: "target", value: previewTarget(effect, form) },
+    { label: "params", value: previewParams(effect, form) },
+    {
+      label: "rules",
+      value: compiledRuleCount === null ? "pending" : String(compiledRuleCount),
+    },
+    { label: "state", value: form.enabled ? "enabled" : "disabled" },
+  ];
 
   return (
     <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
@@ -1107,6 +1181,39 @@ export default function PolicyEditor({
           {affectedAgents.length > 8 && (
             <p className="text-xs text-muted-foreground">
               +{affectedAgents.length - 8} more
+            </p>
+          )}
+        </div>
+
+        <div className="border-t border-border/70 p-4">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Compiled output
+            </p>
+            {compiledError && (
+              <span className="border border-dashed border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase text-muted-foreground">
+                pending
+              </span>
+            )}
+          </div>
+          <dl className="border border-border/70 bg-muted/20 font-mono text-[11px]">
+            {compiledRows.map((row) => (
+              <div
+                key={row.label}
+                className="grid grid-cols-[72px_minmax(0,1fr)] border-b border-border/60 last:border-b-0"
+              >
+                <dt className="border-r border-border/60 px-2 py-1.5 uppercase tracking-[0.12em] text-muted-foreground">
+                  {row.label}
+                </dt>
+                <dd className="truncate px-2 py-1.5 text-foreground/85">
+                  {row.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+          {compiledError && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              {compiledError}
             </p>
           )}
         </div>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Link as LinkIcon, UsersRound, X } from "lucide-react";
+import { AgentIdentity } from "@/components/AgentIdentity";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,6 +30,8 @@ export type PolicyEditorTarget =
 interface AgentOption {
   id: string;
   name: string;
+  icon?: string | null;
+  color_token?: string | null;
 }
 
 interface PolicyEditorProps {
@@ -601,8 +604,12 @@ export default function PolicyEditor({
                 </SelectTrigger>
                 <SelectContent>
                   {agents.map((agent) => (
-                    <SelectItem key={agent.id} value={agent.id}>
-                      {agent.name}
+                    <SelectItem
+                      key={agent.id}
+                      value={agent.id}
+                      textValue={agent.name}
+                    >
+                      <AgentIdentity agent={agent} size="xs" />
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -863,14 +870,17 @@ export default function PolicyEditor({
             affectedAgents.slice(0, 8).map((agent) => (
               <div
                 key={agent.id}
-                className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
+                className="rounded-md border border-border px-3 py-2"
               >
-                <span className="truncate text-sm text-foreground">
-                  {agent.name}
-                </span>
-                <span className="shrink-0 text-[11px] text-muted-foreground">
-                  Agent
-                </span>
+                <AgentIdentity
+                  agent={agent}
+                  size="xs"
+                  right={
+                    <span className="text-[11px] text-muted-foreground">
+                      Agent
+                    </span>
+                  }
+                />
               </div>
             ))
           ) : (

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Link as LinkIcon, Plus, UsersRound, X } from "lucide-react";
 import { AgentIdentity } from "@/components/AgentIdentity";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -32,6 +33,8 @@ interface AgentOption {
   name: string;
   icon?: string | null;
   color_token?: string | null;
+  tools?: ToolConfigLike[] | null;
+  tools_config?: ToolsConfigLike | null;
 }
 
 interface PolicyEditorProps {
@@ -49,13 +52,41 @@ const EDITABLE_EFFECTS: PolicyEffect[] = ["cap", "deny", "approval", "safety"];
 
 type CapKind = "spend" | "service" | "tokens";
 type ScopeMode = "workspace" | "agents";
+type PolicyPeriod = "month" | "run";
+
+interface ToolConfigLike {
+  type?: string | null;
+  name?: string | null;
+  settings?: {
+    allowed_tools?: unknown;
+    disabled_methods?: unknown;
+  } | null;
+}
+
+interface ToolsConfigLike {
+  builtin_tools?: Array<{ tool_name?: string | null } | null> | null;
+  mcp_server_configs?: Array<{
+    allowed_tools?: unknown;
+    tools?: unknown;
+  } | null> | null;
+  openapi_configs?: Array<{
+    allowed_tools?: unknown;
+  } | null> | null;
+}
+
+interface ToolOption {
+  id: string;
+  label: string;
+  source: string;
+  agents: string[];
+}
 
 interface FormState {
   enabled: boolean;
   // cap
   capKind: CapKind;
   amountUsd: string;
-  period: "month" | "run";
+  period: PolicyPeriod;
   maxTokens: string;
   maxTokensPerCall: string;
   // deny / approval tools
@@ -107,6 +138,97 @@ function str(value: unknown): string {
   return "";
 }
 
+function asToolNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (item && typeof item === "object") {
+        const record = item as Record<string, unknown>;
+        return str(record.tool_name) || str(record.name);
+      }
+      return "";
+    })
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function humanizeToolName(name: string): string {
+  return name
+    .replace(/^tool:/, "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function addToolOption(
+  map: Map<string, ToolOption>,
+  id: string,
+  source: string,
+  agentName: string
+) {
+  const normalized = id.trim();
+  if (!normalized) return;
+  const existing = map.get(normalized);
+  if (existing) {
+    if (!existing.agents.includes(agentName)) existing.agents.push(agentName);
+    return;
+  }
+  map.set(normalized, {
+    id: normalized,
+    label: humanizeToolName(normalized),
+    source,
+    agents: [agentName],
+  });
+}
+
+function buildToolCatalog(agents: AgentOption[]): ToolOption[] {
+  const map = new Map<string, ToolOption>();
+  for (const agent of agents) {
+    const agentName = agent.name;
+
+    for (const tool of agent.tools ?? []) {
+      const name = str(tool?.name);
+      if (tool?.type === "mcp" || tool?.type === "openapi") {
+        const allowedTools = asToolNames(tool.settings?.allowed_tools);
+        for (const allowed of allowedTools) {
+          addToolOption(map, allowed, tool.type, agentName);
+        }
+        if (allowedTools.length === 0) {
+          addToolOption(map, name, tool.type, agentName);
+        }
+      } else {
+        addToolOption(
+          map,
+          name,
+          tool?.type === "code" ? "builtin" : "tool",
+          agentName
+        );
+      }
+    }
+
+    for (const builtin of agent.tools_config?.builtin_tools ?? []) {
+      addToolOption(map, str(builtin?.tool_name), "builtin", agentName);
+    }
+    for (const mcp of agent.tools_config?.mcp_server_configs ?? []) {
+      for (const name of [
+        ...asToolNames(mcp?.allowed_tools),
+        ...asToolNames(mcp?.tools),
+      ]) {
+        addToolOption(map, name, "mcp", agentName);
+      }
+    }
+    for (const openapi of agent.tools_config?.openapi_configs ?? []) {
+      for (const name of asToolNames(openapi?.allowed_tools)) {
+        addToolOption(map, name, "openapi", agentName);
+      }
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
+}
+
 // Seed the form from an existing rule (edit mode). Unknown shapes degrade
 // gracefully — fields that don't apply stay at their defaults.
 function policyToForm(policy: Policy): {
@@ -137,7 +259,8 @@ function policyToForm(policy: Policy): {
       ? [policy.target.slice("tool:".length)]
       : [];
   } else if (policy.effect === "approval") {
-    form.approvalAllActions = policy.target === "*";
+    form.approvalAllActions =
+      policy.target === "*" || policy.target === "tool:*";
     form.tools =
       policy.target.startsWith("tool:") && policy.target !== "tool:*"
         ? [policy.target.slice("tool:".length)]
@@ -356,6 +479,121 @@ function TagInput({
   );
 }
 
+function ToolSelector({
+  options,
+  values,
+  onChange,
+  emptyText,
+}: {
+  options: ToolOption[];
+  values: string[];
+  onChange: (next: string[]) => void;
+  emptyText: string;
+}) {
+  const visibleOptions = useMemo(() => {
+    const byId = new Map(options.map((option) => [option.id, option]));
+    for (const value of values) {
+      if (!byId.has(value)) {
+        byId.set(value, {
+          id: value,
+          label: humanizeToolName(value),
+          source: "custom",
+          agents: [],
+        });
+      }
+    }
+    return Array.from(byId.values()).sort((a, b) =>
+      a.label.localeCompare(b.label)
+    );
+  }, [options, values]);
+
+  const toggle = (toolId: string) => {
+    if (values.includes(toolId)) {
+      onChange(values.filter((value) => value !== toolId));
+    } else {
+      onChange([...values, toolId]);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {visibleOptions.length > 0 ? (
+        <div className="grid gap-2 md:grid-cols-2">
+          {visibleOptions.map((tool) => {
+            const selected = values.includes(tool.id);
+            const agentLabel =
+              tool.agents.length > 0
+                ? tool.agents.length === 1
+                  ? tool.agents[0]
+                  : `${tool.agents.length} agents`
+                : "not in current agent catalog";
+            return (
+              <div
+                key={tool.id}
+                role="checkbox"
+                tabIndex={0}
+                aria-checked={selected}
+                onClick={() => toggle(tool.id)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    toggle(tool.id);
+                  }
+                }}
+                className={cn(
+                  "cursor-pointer",
+                  "flex min-h-[58px] items-start gap-2 border border-border/70 bg-background px-3 py-2 text-left transition-colors hover:bg-muted/30",
+                  selected && "shadow-[inset_2px_0_0_hsl(var(--primary))]"
+                )}
+              >
+                <Checkbox
+                  checked={selected}
+                  tabIndex={-1}
+                  aria-hidden="true"
+                  className="pointer-events-none mt-0.5"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-foreground">
+                    {tool.label}
+                  </span>
+                  <span className="mt-1 flex flex-wrap gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                    <span>{tool.source}</span>
+                    <span>{agentLabel}</span>
+                  </span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
+          {emptyText}
+        </p>
+      )}
+
+      <details className="border-t border-border/60 pt-3">
+        <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          Advanced selector
+        </summary>
+        <div className="mt-3">
+          <TagInput
+            values={values.filter(
+              (value) => !options.some((option) => option.id === value)
+            )}
+            onChange={(customValues) => {
+              const catalogValues = values.filter((value) =>
+                options.some((option) => option.id === value)
+              );
+              onChange([...catalogValues, ...customValues]);
+            }}
+            placeholder="Tool name"
+          />
+        </div>
+      </details>
+    </div>
+  );
+}
+
 function MoneyField({
   id,
   label,
@@ -529,6 +767,11 @@ export default function PolicyEditor({
     if (subjectType === "workspace") return agents;
     return selectedAgents;
   }, [agents, selectedAgents, subjectType]);
+
+  const toolCatalog = useMemo(
+    () => buildToolCatalog(affectedAgents),
+    [affectedAgents]
+  );
 
   // Reset form whenever the route opens for a target.
   useEffect(() => {
@@ -950,7 +1193,7 @@ export default function PolicyEditor({
                         <Select
                           value={form.period}
                           onValueChange={(v) =>
-                            update("period", v as "month" | "run")
+                            update("period", v as PolicyPeriod)
                           }
                         >
                           <SelectTrigger id="cap-period">
@@ -958,7 +1201,7 @@ export default function PolicyEditor({
                           </SelectTrigger>
                           <SelectContent>
                             <SelectItem value="month">Per month</SelectItem>
-                            <SelectItem value="run">Per run</SelectItem>
+                            <SelectItem value="run">Per task</SelectItem>
                           </SelectContent>
                         </Select>
                       </div>
@@ -973,10 +1216,11 @@ export default function PolicyEditor({
             <BlueprintSection code={detailsCode} title="Deny List">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
                 <Label>Denied tools</Label>
-                <TagInput
+                <ToolSelector
+                  options={toolCatalog}
                   values={form.tools}
                   onChange={(next) => update("tools", next)}
-                  placeholder="Tool name (e.g. send_email or *)"
+                  emptyText="No tools are attached to the affected agents yet."
                 />
                 <p className="flex items-center gap-1 text-xs text-muted-foreground">
                   <LinkIcon className="h-3 w-3" />
@@ -1014,10 +1258,11 @@ export default function PolicyEditor({
                 {!form.approvalAllActions && (
                   <div className="space-y-1.5">
                     <Label>Tools requiring approval</Label>
-                    <TagInput
+                    <ToolSelector
+                      options={toolCatalog}
                       values={form.tools}
                       onChange={(next) => update("tools", next)}
-                      placeholder="Tool name (e.g. send_email)"
+                      emptyText="No tools are attached to the affected agents yet."
                     />
                   </div>
                 )}

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Link as LinkIcon, UsersRound, X } from "lucide-react";
+import { Link as LinkIcon, Plus, UsersRound, X } from "lucide-react";
 import { AgentIdentity } from "@/components/AgentIdentity";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -48,6 +48,7 @@ const EDITABLE_EFFECTS: PolicyEffect[] = ["cap", "deny", "approval", "safety"];
 // --- cap sub-form ---------------------------------------------------------
 
 type CapKind = "spend" | "service" | "tokens";
+type ScopeMode = "workspace" | "agents";
 
 interface FormState {
   enabled: boolean;
@@ -422,7 +423,9 @@ export default function PolicyEditor({
   const router = useRouter();
   const [effect, setEffect] = useState<PolicyEffect>("cap");
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
-  const [selectedAgentId, setSelectedAgentId] = useState<string>("");
+  const [scopeMode, setScopeMode] = useState<ScopeMode>("workspace");
+  const [selectedAgentIds, setSelectedAgentIds] = useState<string[]>([]);
+  const [agentToAddId, setAgentToAddId] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -431,19 +434,31 @@ export default function PolicyEditor({
   const subjectType = useMemo<"workspace" | "agent">(() => {
     if (target.mode === "edit")
       return target.policy.subject_type === "workspace" ? "workspace" : "agent";
-    if (target.mode === "create-agent") return "agent";
-    return "workspace";
-  }, [target]);
+    return scopeMode === "agents" ? "agent" : "workspace";
+  }, [scopeMode, target]);
 
-  const selectedAgent = useMemo(
-    () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
-    [agents, selectedAgentId]
+  const selectedAgents = useMemo(
+    () =>
+      selectedAgentIds
+        .map((agentId) => agents.find((agent) => agent.id === agentId))
+        .filter((agent): agent is AgentOption => Boolean(agent)),
+    [agents, selectedAgentIds]
+  );
+
+  const selectedAgentIdSet = useMemo(
+    () => new Set(selectedAgentIds),
+    [selectedAgentIds]
+  );
+
+  const addableAgents = useMemo(
+    () => agents.filter((agent) => !selectedAgentIdSet.has(agent.id)),
+    [agents, selectedAgentIdSet]
   );
 
   const affectedAgents = useMemo(() => {
     if (subjectType === "workspace") return agents;
-    return selectedAgent ? [selectedAgent] : [];
-  }, [agents, selectedAgent, subjectType]);
+    return selectedAgents;
+  }, [agents, selectedAgents, subjectType]);
 
   // Reset form whenever the route opens for a target.
   useEffect(() => {
@@ -451,15 +466,21 @@ export default function PolicyEditor({
       const seeded = policyToForm(target.policy);
       setEffect(seeded.effect);
       setForm(seeded.form);
-      setSelectedAgentId(
-        target.policy.subject_type === "agent" ? target.policy.subject_id : ""
+      setScopeMode(
+        target.policy.subject_type === "agent" ? "agents" : "workspace"
       );
+      setSelectedAgentIds(
+        target.policy.subject_type === "agent" ? [target.policy.subject_id] : []
+      );
+      setAgentToAddId("");
     } else {
       setEffect("cap");
       setForm(EMPTY_FORM);
-      setSelectedAgentId(
-        target.mode === "create-agent" ? (target.agentId ?? "") : ""
+      setScopeMode(target.mode === "create-agent" ? "agents" : "workspace");
+      setSelectedAgentIds(
+        target.mode === "create-agent" && target.agentId ? [target.agentId] : []
       );
+      setAgentToAddId("");
     }
     setError(null);
   }, [target]);
@@ -467,18 +488,48 @@ export default function PolicyEditor({
   const update = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
 
-  const resolveSubjectId = (): string | null => {
-    if (target?.mode === "edit") return target.policy.subject_id;
-    if (subjectType === "agent") return selectedAgentId || null;
-    return workspaceId;
+  const addSelectedAgent = () => {
+    if (!agentToAddId || selectedAgentIdSet.has(agentToAddId)) return;
+    setSelectedAgentIds((prev) => [...prev, agentToAddId]);
+    setAgentToAddId("");
+  };
+
+  const removeSelectedAgent = (agentId: string) => {
+    setSelectedAgentIds((prev) => prev.filter((id) => id !== agentId));
+    if (agentToAddId === agentId) setAgentToAddId("");
+  };
+
+  const resolveSubjects = (): Array<{
+    subject_type: "workspace" | "agent";
+    subject_id: string;
+  }> | null => {
+    if (target?.mode === "edit") {
+      return [
+        {
+          subject_type:
+            target.policy.subject_type === "workspace" ? "workspace" : "agent",
+          subject_id: target.policy.subject_id,
+        },
+      ];
+    }
+    if (subjectType === "agent") {
+      if (selectedAgentIds.length === 0) return null;
+      return selectedAgentIds.map((agentId) => ({
+        subject_type: "agent",
+        subject_id: agentId,
+      }));
+    }
+    return workspaceId
+      ? [{ subject_type: "workspace", subject_id: workspaceId }]
+      : null;
   };
 
   const save = async () => {
-    const subjectId = resolveSubjectId();
-    if (!subjectId) {
+    const subjects = resolveSubjects();
+    if (!subjects) {
       setError(
         subjectType === "agent"
-          ? "Select an agent for this policy."
+          ? "Add at least one agent for this policy."
           : "No workspace context available."
       );
       return;
@@ -516,23 +567,25 @@ export default function PolicyEditor({
           return;
         }
       } else {
-        // POST one rule per body (deny/approval may fan out over tools).
-        for (const body of built.bodies) {
-          const response = await fetch(`/api/proxy/v1/policies`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              subject_type: subjectType,
-              subject_id: subjectId,
-              target: body.target,
-              effect: body.effect,
-              params: body.params,
-              enabled: form.enabled,
-            }),
-          });
-          if (!response.ok) {
-            setError(await readDetail(response, "Save failed"));
-            return;
+        // POST one rule per scope/body pair (deny/approval may fan out over tools).
+        for (const subject of subjects) {
+          for (const body of built.bodies) {
+            const response = await fetch(`/api/proxy/v1/policies`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                subject_type: subject.subject_type,
+                subject_id: subject.subject_id,
+                target: body.target,
+                effect: body.effect,
+                params: body.params,
+                enabled: form.enabled,
+              }),
+            });
+            if (!response.ok) {
+              setError(await readDetail(response, "Save failed"));
+              return;
+            }
           }
         }
       }
@@ -573,7 +626,7 @@ export default function PolicyEditor({
   const title = isEdit
     ? "Edit policy rule"
     : subjectType === "agent"
-      ? "New agent rule"
+      ? "New agent policy"
       : "New workspace rule";
 
   return (
@@ -582,39 +635,121 @@ export default function PolicyEditor({
         <div className="space-y-1">
           <h2 className="text-lg font-semibold text-foreground">{title}</h2>
           <p className="text-sm text-muted-foreground">
-            A policy is a single rule. It applies to{" "}
+            This policy applies to{" "}
             {subjectType === "workspace"
               ? "every agent in this workspace"
-              : "the selected agent"}
+              : selectedAgents.length === 1
+                ? "the selected agent"
+                : "the selected agents"}
             . Tool access grants are managed in the Access view.
           </p>
         </div>
 
         <div className="mt-5 space-y-5">
-          {/* Agent picker — only in agent create mode without a fixed agent */}
-          {target?.mode === "create-agent" && (
-            <div className="space-y-1.5">
-              <Label htmlFor="policy-agent">Agent</Label>
-              <Select
-                value={selectedAgentId}
-                onValueChange={setSelectedAgentId}
-              >
-                <SelectTrigger id="policy-agent">
-                  <SelectValue placeholder="Select an agent" />
-                </SelectTrigger>
-                <SelectContent>
-                  {agents.map((agent) => (
-                    <SelectItem
-                      key={agent.id}
-                      value={agent.id}
-                      textValue={agent.name}
+          {!isEdit && (
+            <div className="space-y-2">
+              <Label>Applies to</Label>
+              <div className="inline-flex flex-wrap items-center gap-1 rounded-lg bg-muted p-1">
+                {[
+                  { value: "workspace" as const, label: "All agents" },
+                  { value: "agents" as const, label: "Selected agents" },
+                ].map((option) => {
+                  const active = scopeMode === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setScopeMode(option.value)}
+                      className={cn(
+                        "rounded-md px-3 py-1.5 text-sm transition",
+                        active
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
                     >
-                      <AgentIdentity agent={agent} size="xs" />
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
+          )}
+
+          {isEdit && (
+            <div className="rounded-lg border border-border p-4">
+              <Label>Applies to</Label>
+              <p className="mt-1 text-sm text-foreground">
+                {subjectType === "workspace"
+                  ? "All agents"
+                  : selectedAgents[0]?.name || target.policy.subject_id}
+              </p>
+            </div>
+          )}
+
+          {subjectType === "agent" && !isEdit && (
+            <section className="space-y-3 rounded-lg border border-border p-4">
+              <div className="flex items-end gap-2">
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <Label htmlFor="policy-agent">Agent</Label>
+                  <Select value={agentToAddId} onValueChange={setAgentToAddId}>
+                    <SelectTrigger id="policy-agent">
+                      <SelectValue placeholder="Select an agent" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {addableAgents.map((agent) => (
+                        <SelectItem
+                          key={agent.id}
+                          value={agent.id}
+                          textValue={agent.name}
+                        >
+                          <AgentIdentity agent={agent} size="xs" />
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  disabled={!agentToAddId}
+                  onClick={addSelectedAgent}
+                  aria-label="Add agent"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="space-y-2">
+                {selectedAgents.length > 0 ? (
+                  selectedAgents.map((agent) => (
+                    <div
+                      key={agent.id}
+                      className="flex items-center gap-2 rounded-md border border-border px-3 py-2"
+                    >
+                      <AgentIdentity
+                        agent={agent}
+                        size="xs"
+                        className="flex-1"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => removeSelectedAgent(agent.id)}
+                        aria-label={`Remove ${agent.name}`}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))
+                ) : (
+                  <p className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
+                    Add agents to scope this policy.
+                  </p>
+                )}
+              </div>
+            </section>
           )}
 
           {/* Effect */}
@@ -858,9 +993,9 @@ export default function PolicyEditor({
             <p className="text-xs text-muted-foreground">
               {subjectType === "workspace"
                 ? `${affectedAgents.length} workspace agent${affectedAgents.length === 1 ? "" : "s"}`
-                : selectedAgent
-                  ? "Selected agent"
-                  : "No agent selected"}
+                : affectedAgents.length > 0
+                  ? `${affectedAgents.length} selected agent${affectedAgents.length === 1 ? "" : "s"}`
+                  : "No agents selected"}
             </p>
           </div>
         </div>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Link as LinkIcon, Plus, UsersRound, X } from "lucide-react";
@@ -251,7 +251,7 @@ function EffectSegmented({
   disabled?: boolean;
 }) {
   return (
-    <div className="inline-flex flex-wrap items-center gap-1 rounded-lg bg-muted p-1">
+    <div className="inline-flex flex-wrap items-center gap-px border border-border/70 bg-muted/30 p-px">
       {EDITABLE_EFFECTS.map((effect) => {
         const style = EFFECT_STYLES[effect];
         const Icon = style.icon;
@@ -263,9 +263,9 @@ function EffectSegmented({
             disabled={disabled}
             onClick={() => onChange(effect)}
             className={cn(
-              "inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+              "inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60",
               active
-                ? "bg-background text-foreground shadow-sm"
+                ? "bg-background text-foreground shadow-[inset_0_-2px_0_hsl(var(--primary))]"
                 : "text-muted-foreground hover:text-foreground"
             )}
           >
@@ -317,7 +317,7 @@ function TagInput({
           {values.map((value) => (
             <span
               key={value}
-              className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-0.5 font-mono text-xs"
+              className="inline-flex items-center gap-1 border border-border/70 bg-muted/30 px-2 py-0.5 font-mono text-xs"
             >
               {value}
               <button
@@ -409,6 +409,33 @@ function NumberField({
         placeholder="optional"
       />
     </div>
+  );
+}
+
+function BlueprintSection({
+  code,
+  title,
+  children,
+  className,
+}: {
+  code: string;
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={cn(
+        "grid gap-3 border-t border-border/70 py-4 md:grid-cols-[104px_minmax(0,1fr)]",
+        className
+      )}
+    >
+      <div className="flex items-start gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        <span className="font-mono text-foreground/70">{code}</span>
+        <span>{title}</span>
+      </div>
+      <div className="min-w-0">{children}</div>
+    </section>
   );
 }
 
@@ -628,28 +655,55 @@ export default function PolicyEditor({
     : subjectType === "agent"
       ? "New agent policy"
       : "New workspace rule";
+  const hasAgentScopeEditor = subjectType === "agent" && !isEdit;
+  const effectCode = hasAgentScopeEditor ? "03" : "02";
+  const detailsCode = hasAgentScopeEditor ? "04" : "03";
+  const stateCode = hasAgentScopeEditor ? "05" : "04";
 
   return (
-    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
-      <section className="rounded-lg border border-border bg-background p-5">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
-          <p className="text-sm text-muted-foreground">
-            This policy applies to{" "}
-            {subjectType === "workspace"
-              ? "every agent in this workspace"
-              : selectedAgents.length === 1
-                ? "the selected agent"
-                : "the selected agents"}
-            . Tool access grants are managed in the Access view.
-          </p>
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
+      <section className="relative overflow-hidden border border-border/70 bg-background">
+        <div
+          className="pointer-events-none absolute inset-0 opacity-[0.035]"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)",
+            backgroundSize: "24px 24px",
+          }}
+          aria-hidden="true"
+        />
+        <div className="relative border-b border-border/70 bg-muted/20 px-5 py-4">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="min-w-0 space-y-1">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Policy Control Plane
+              </p>
+              <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+              <p className="max-w-2xl text-sm text-muted-foreground">
+                This policy applies to{" "}
+                {subjectType === "workspace"
+                  ? "every agent in this workspace"
+                  : selectedAgents.length === 1
+                    ? "the selected agent"
+                    : "the selected agents"}
+                . Tool access grants are managed in the Access view.
+              </p>
+            </div>
+            <div className="border border-border/70 bg-background px-3 py-2 text-right">
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                Scope
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                {subjectType === "workspace" ? "All agents" : "Selected"}
+              </p>
+            </div>
+          </div>
         </div>
 
-        <div className="mt-5 space-y-5">
+        <div className="relative px-5">
           {!isEdit && (
-            <div className="space-y-2">
-              <Label>Applies to</Label>
-              <div className="inline-flex flex-wrap items-center gap-1 rounded-lg bg-muted p-1">
+            <BlueprintSection code="01" title="Scope">
+              <div className="inline-flex flex-wrap items-center gap-px border border-border/70 bg-muted/30 p-px">
                 {[
                   { value: "workspace" as const, label: "All agents" },
                   { value: "agents" as const, label: "Selected agents" },
@@ -661,9 +715,9 @@ export default function PolicyEditor({
                       type="button"
                       onClick={() => setScopeMode(option.value)}
                       className={cn(
-                        "rounded-md px-3 py-1.5 text-sm transition",
+                        "px-3 py-1.5 text-sm transition",
                         active
-                          ? "bg-background text-foreground shadow-sm"
+                          ? "bg-background text-foreground shadow-[inset_0_-2px_0_hsl(var(--primary))]"
                           : "text-muted-foreground hover:text-foreground"
                       )}
                     >
@@ -672,89 +726,92 @@ export default function PolicyEditor({
                   );
                 })}
               </div>
-            </div>
+            </BlueprintSection>
           )}
 
           {isEdit && (
-            <div className="rounded-lg border border-border p-4">
-              <Label>Applies to</Label>
+            <BlueprintSection code="01" title="Scope">
               <p className="mt-1 text-sm text-foreground">
                 {subjectType === "workspace"
                   ? "All agents"
                   : selectedAgents[0]?.name || target.policy.subject_id}
               </p>
-            </div>
+            </BlueprintSection>
           )}
 
-          {subjectType === "agent" && !isEdit && (
-            <section className="space-y-3 rounded-lg border border-border p-4">
-              <div className="flex items-end gap-2">
-                <div className="min-w-0 flex-1 space-y-1.5">
-                  <Label htmlFor="policy-agent">Agent</Label>
-                  <Select value={agentToAddId} onValueChange={setAgentToAddId}>
-                    <SelectTrigger id="policy-agent">
-                      <SelectValue placeholder="Select an agent" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {addableAgents.map((agent) => (
-                        <SelectItem
-                          key={agent.id}
-                          value={agent.id}
-                          textValue={agent.name}
-                        >
-                          <AgentIdentity agent={agent} size="xs" />
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  disabled={!agentToAddId}
-                  onClick={addSelectedAgent}
-                  aria-label="Add agent"
-                >
-                  <Plus className="h-4 w-4" />
-                </Button>
-              </div>
-
-              <div className="space-y-2">
-                {selectedAgents.length > 0 ? (
-                  selectedAgents.map((agent) => (
-                    <div
-                      key={agent.id}
-                      className="flex items-center gap-2 rounded-md border border-border px-3 py-2"
+          {hasAgentScopeEditor && (
+            <BlueprintSection code="02" title="Agents">
+              <div className="space-y-3">
+                <div className="flex items-end gap-2">
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <Label htmlFor="policy-agent">Agent</Label>
+                    <Select
+                      value={agentToAddId}
+                      onValueChange={setAgentToAddId}
                     >
-                      <AgentIdentity
-                        agent={agent}
-                        size="xs"
-                        className="flex-1"
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => removeSelectedAgent(agent.id)}
-                        aria-label={`Remove ${agent.name}`}
+                      <SelectTrigger id="policy-agent">
+                        <SelectValue placeholder="Select an agent" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {addableAgents.map((agent) => (
+                          <SelectItem
+                            key={agent.id}
+                            value={agent.id}
+                            textValue={agent.name}
+                          >
+                            <AgentIdentity agent={agent} size="xs" />
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    disabled={!agentToAddId}
+                    onClick={addSelectedAgent}
+                    aria-label="Add agent"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                <div className="space-y-2">
+                  {selectedAgents.length > 0 ? (
+                    selectedAgents.map((agent) => (
+                      <div
+                        key={agent.id}
+                        className="flex items-center gap-2 border border-border/70 bg-muted/20 px-3 py-2"
                       >
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  ))
-                ) : (
-                  <p className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
-                    Add agents to scope this policy.
-                  </p>
-                )}
+                        <AgentIdentity
+                          agent={agent}
+                          size="xs"
+                          className="flex-1"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeSelectedAgent(agent.id)}
+                          aria-label={`Remove ${agent.name}`}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
+                      Add agents to scope this policy.
+                    </p>
+                  )}
+                </div>
               </div>
-            </section>
+            </BlueprintSection>
           )}
 
           {/* Effect */}
-          <div className="space-y-1.5">
-            <Label>Effect</Label>
+          <BlueprintSection code={effectCode} title="Effect">
             <EffectSegmented
               value={effect}
               onChange={setEffect}
@@ -765,186 +822,203 @@ export default function PolicyEditor({
                 The effect is fixed once a rule is created.
               </p>
             )}
-          </div>
+          </BlueprintSection>
 
           {/* Effect-specific fields */}
           {effect === "cap" && (
-            <section className="space-y-3 rounded-lg border border-border p-4">
-              <div className="space-y-1.5">
-                <Label htmlFor="cap-kind">Cap type</Label>
-                <Select
-                  value={form.capKind}
-                  onValueChange={(v) => update("capKind", v as CapKind)}
-                >
-                  <SelectTrigger id="cap-kind">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="spend">Spend budget</SelectItem>
-                    <SelectItem value="service">Per-service budget</SelectItem>
-                    <SelectItem value="tokens">Token cap</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+            <BlueprintSection code={detailsCode} title="Limits">
+              <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="cap-kind">Cap type</Label>
+                  <Select
+                    value={form.capKind}
+                    onValueChange={(v) => update("capKind", v as CapKind)}
+                  >
+                    <SelectTrigger id="cap-kind">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="spend">Spend budget</SelectItem>
+                      <SelectItem value="service">
+                        Per-service budget
+                      </SelectItem>
+                      <SelectItem value="tokens">Token cap</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
 
-              {form.capKind === "tokens" ? (
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <NumberField
-                    id="max-tokens"
-                    label="Max tokens"
-                    value={form.maxTokens}
-                    onChange={(v) => update("maxTokens", v)}
-                  />
-                  <NumberField
-                    id="max-tokens-call"
-                    label="Max tokens per call"
-                    value={form.maxTokensPerCall}
-                    onChange={(v) => update("maxTokensPerCall", v)}
-                  />
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <MoneyField
-                    id="cap-amount"
-                    label="Amount"
-                    value={form.amountUsd}
-                    onChange={(v) => update("amountUsd", v)}
-                  />
-                  {form.capKind === "spend" && (
-                    <div className="space-y-1.5">
-                      <Label htmlFor="cap-period">Period</Label>
-                      <Select
-                        value={form.period}
-                        onValueChange={(v) =>
-                          update("period", v as "month" | "run")
-                        }
-                      >
-                        <SelectTrigger id="cap-period">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="month">Per month</SelectItem>
-                          <SelectItem value="run">Per run</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )}
-                </div>
-              )}
-            </section>
+                {form.capKind === "tokens" ? (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <NumberField
+                      id="max-tokens"
+                      label="Max tokens"
+                      value={form.maxTokens}
+                      onChange={(v) => update("maxTokens", v)}
+                    />
+                    <NumberField
+                      id="max-tokens-call"
+                      label="Max tokens per call"
+                      value={form.maxTokensPerCall}
+                      onChange={(v) => update("maxTokensPerCall", v)}
+                    />
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <MoneyField
+                      id="cap-amount"
+                      label="Amount"
+                      value={form.amountUsd}
+                      onChange={(v) => update("amountUsd", v)}
+                    />
+                    {form.capKind === "spend" && (
+                      <div className="space-y-1.5">
+                        <Label htmlFor="cap-period">Period</Label>
+                        <Select
+                          value={form.period}
+                          onValueChange={(v) =>
+                            update("period", v as "month" | "run")
+                          }
+                        >
+                          <SelectTrigger id="cap-period">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="month">Per month</SelectItem>
+                            <SelectItem value="run">Per run</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </BlueprintSection>
           )}
 
           {effect === "deny" && (
-            <section className="space-y-3 rounded-lg border border-border p-4">
-              <Label>Denied tools</Label>
-              <TagInput
-                values={form.tools}
-                onChange={(next) => update("tools", next)}
-                placeholder="Tool name (e.g. send_email or *)"
-              />
-              <p className="flex items-center gap-1 text-xs text-muted-foreground">
-                <LinkIcon className="h-3 w-3" />
-                Granting tool access is managed in the{" "}
-                <Link
-                  href="/policies?view=access"
-                  className="text-primary underline-offset-4 hover:underline"
-                >
-                  Access view
-                </Link>
-                .
-              </p>
-            </section>
+            <BlueprintSection code={detailsCode} title="Deny List">
+              <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
+                <Label>Denied tools</Label>
+                <TagInput
+                  values={form.tools}
+                  onChange={(next) => update("tools", next)}
+                  placeholder="Tool name (e.g. send_email or *)"
+                />
+                <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <LinkIcon className="h-3 w-3" />
+                  Granting tool access is managed in the{" "}
+                  <Link
+                    href="/policies?view=access"
+                    className="text-primary underline-offset-4 hover:underline"
+                  >
+                    Access view
+                  </Link>
+                  .
+                </p>
+              </div>
+            </BlueprintSection>
           )}
 
           {effect === "approval" && (
-            <section className="space-y-3 rounded-lg border border-border p-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label htmlFor="approval-all">Require for all actions</Label>
-                  <p className="text-xs text-muted-foreground">
-                    Off to require approval for specific tools only.
-                  </p>
-                </div>
-                <Switch
-                  id="approval-all"
-                  checked={form.approvalAllActions}
-                  onCheckedChange={(v) => update("approvalAllActions", v)}
-                />
-              </div>
-              {!form.approvalAllActions && (
-                <div className="space-y-1.5">
-                  <Label>Tools requiring approval</Label>
-                  <TagInput
-                    values={form.tools}
-                    onChange={(next) => update("tools", next)}
-                    placeholder="Tool name (e.g. send_email)"
+            <BlueprintSection code={detailsCode} title="Approval">
+              <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label htmlFor="approval-all">
+                      Require for all actions
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Off to require approval for specific tools only.
+                    </p>
+                  </div>
+                  <Switch
+                    id="approval-all"
+                    checked={form.approvalAllActions}
+                    onCheckedChange={(v) => update("approvalAllActions", v)}
                   />
                 </div>
-              )}
-              <div className="space-y-1.5">
-                <Label>Approvers</Label>
-                <TagInput
-                  values={form.approvers}
-                  onChange={(next) => update("approvers", next)}
-                  placeholder="user:<id> or group:<id>#member"
-                  validate={(v) => SUBJECT_REF_RE.test(v)}
-                  invalidHint="Use a subject ref like user:<id> or group:<id>#member"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Leave empty to allow any workspace member to approve.
-                </p>
+                {!form.approvalAllActions && (
+                  <div className="space-y-1.5">
+                    <Label>Tools requiring approval</Label>
+                    <TagInput
+                      values={form.tools}
+                      onChange={(next) => update("tools", next)}
+                      placeholder="Tool name (e.g. send_email)"
+                    />
+                  </div>
+                )}
+                <div className="space-y-1.5">
+                  <Label>Approvers</Label>
+                  <TagInput
+                    values={form.approvers}
+                    onChange={(next) => update("approvers", next)}
+                    placeholder="user:<id> or group:<id>#member"
+                    validate={(v) => SUBJECT_REF_RE.test(v)}
+                    invalidHint="Use a subject ref like user:<id> or group:<id>#member"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Leave empty to allow any workspace member to approve.
+                  </p>
+                </div>
               </div>
-            </section>
+            </BlueprintSection>
           )}
 
           {effect === "safety" && (
-            <section className="space-y-3 rounded-lg border border-border p-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="prompt-injection" className="font-normal">
-                  Prompt-injection detection
-                </Label>
-                <Switch
-                  id="prompt-injection"
-                  checked={form.promptInjection}
-                  onCheckedChange={(v) => update("promptInjection", v)}
-                />
+            <BlueprintSection code={detailsCode} title="Safety">
+              <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="prompt-injection" className="font-normal">
+                    Prompt-injection detection
+                  </Label>
+                  <Switch
+                    id="prompt-injection"
+                    checked={form.promptInjection}
+                    onCheckedChange={(v) => update("promptInjection", v)}
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="output-sanitizer" className="font-normal">
+                    Output sanitizer
+                  </Label>
+                  <Switch
+                    id="output-sanitizer"
+                    checked={form.outputSanitizer}
+                    onCheckedChange={(v) => update("outputSanitizer", v)}
+                  />
+                </div>
               </div>
-              <div className="flex items-center justify-between">
-                <Label htmlFor="output-sanitizer" className="font-normal">
-                  Output sanitizer
-                </Label>
-                <Switch
-                  id="output-sanitizer"
-                  checked={form.outputSanitizer}
-                  onCheckedChange={(v) => update("outputSanitizer", v)}
-                />
-              </div>
-            </section>
+            </BlueprintSection>
           )}
 
           {/* Enabled */}
-          <div className="flex items-center justify-between rounded-lg border border-border p-4">
-            <div>
-              <Label htmlFor="policy-enabled">Rule enabled</Label>
-              <p className="text-xs text-muted-foreground">
-                Disabled rules are kept but not enforced.
-              </p>
+          <BlueprintSection code={stateCode} title="State">
+            <div className="flex items-center justify-between border border-border/70 bg-muted/20 p-4">
+              <div>
+                <Label htmlFor="policy-enabled">Rule enabled</Label>
+                <p className="text-xs text-muted-foreground">
+                  Disabled rules are kept but not enforced.
+                </p>
+              </div>
+              <Switch
+                id="policy-enabled"
+                checked={form.enabled}
+                onCheckedChange={(v) => update("enabled", v)}
+              />
             </div>
-            <Switch
-              id="policy-enabled"
-              checked={form.enabled}
-              onCheckedChange={(v) => update("enabled", v)}
-            />
-          </div>
+          </BlueprintSection>
         </div>
 
         {error && (
-          <p className="text-sm text-destructive" role="alert">
+          <p
+            className="relative mx-5 border-t border-destructive/30 py-3 text-sm text-destructive"
+            role="alert"
+          >
             {error}
           </p>
         )}
 
-        <div className="flex items-center justify-between gap-2 border-t border-border pt-4">
+        <div className="relative flex items-center justify-between gap-2 border-t border-border/70 bg-muted/20 px-5 py-4">
           {isEdit ? (
             <Button
               type="button"
@@ -981,9 +1055,14 @@ export default function PolicyEditor({
         </div>
       </section>
 
-      <aside className="h-fit rounded-lg border border-border bg-background p-4">
-        <div className="flex items-center gap-2">
-          <span className="grid h-8 w-8 place-items-center rounded-lg border border-border bg-muted/50">
+      <aside className="h-fit border border-border/70 bg-background">
+        <div className="border-b border-border/70 bg-muted/20 px-4 py-3">
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Impact Rail
+          </p>
+        </div>
+        <div className="flex items-center gap-2 border-b border-border/70 px-4 py-3">
+          <span className="grid h-8 w-8 place-items-center border border-border/70 bg-muted/40">
             <UsersRound className="h-4 w-4 text-muted-foreground" />
           </span>
           <div>
@@ -1000,12 +1079,12 @@ export default function PolicyEditor({
           </div>
         </div>
 
-        <div className="mt-4 space-y-2">
+        <div className="space-y-2 p-4">
           {affectedAgents.length > 0 ? (
             affectedAgents.slice(0, 8).map((agent) => (
               <div
                 key={agent.id}
-                className="rounded-md border border-border px-3 py-2"
+                className="border border-border/70 bg-muted/20 px-3 py-2"
               >
                 <AgentIdentity
                   agent={agent}
@@ -1019,7 +1098,7 @@ export default function PolicyEditor({
               </div>
             ))
           ) : (
-            <p className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
+            <p className="border border-dashed border-border/70 px-3 py-3 text-sm text-muted-foreground">
               {subjectType === "workspace"
                 ? "No agents in this workspace yet."
                 : "Select an agent to preview the affected scope."}

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -124,7 +124,6 @@ interface FormState {
   conditionOperator: ConditionOperator;
   conditionValue: string;
   // approval
-  approvalAllActions: boolean;
   approvers: string[];
   // safety
   promptInjection: boolean;
@@ -148,7 +147,6 @@ const EMPTY_FORM: FormState = {
   conditionParam: "",
   conditionOperator: "equals",
   conditionValue: "",
-  approvalAllActions: true,
   approvers: [],
   promptInjection: true,
   outputSanitizer: false,
@@ -460,8 +458,6 @@ function policyToForm(policy: Policy): {
       ? [policy.target.slice("tool:".length)]
       : [];
   } else if (policy.effect === "approval") {
-    form.approvalAllActions =
-      policy.target === "*" || policy.target === "tool:*";
     form.tools =
       policy.target.startsWith("tool:") && policy.target !== "tool:*"
         ? [policy.target.slice("tool:".length)]
@@ -543,10 +539,7 @@ function buildRuleBodies(
   if (effect === "approval") {
     const params: Record<string, unknown> = {};
     if (form.approvers.length > 0) params.approvers = form.approvers;
-    if (form.approvalAllActions)
-      return { bodies: [{ target: "*", effect, params }] };
-    if (form.tools.length === 0)
-      return { error: "Add a tool or require approval for all actions." };
+    if (form.tools.length === 0) return { error: "Add a tool." };
     const condition = buildCondition(form);
     return {
       bodies: form.tools.map((tool) => ({
@@ -1174,7 +1167,7 @@ function previewTarget(effect: PolicyEffect, form: FormState): string {
     return form.tools.length === 0 ? "tool:<pending>" : "tool";
   }
   if (effect === "approval") {
-    return form.approvalAllActions ? "*" : "tool";
+    return form.tools.length === 0 ? "tool:<pending>" : "tool";
   }
   return "content";
 }
@@ -1197,9 +1190,7 @@ function previewParams(effect: PolicyEffect, form: FormState): string {
       : "tools=pending";
   }
   if (effect === "approval") {
-    const scope = form.approvalAllActions
-      ? "actions=*"
-      : `tools=${form.tools.length || "pending"}`;
+    const scope = `tools=${form.tools.length || "pending"}`;
     const approvers =
       form.approvers.length > 0 ? ` approvers=${form.approvers.length}` : "";
     return `${scope}${approvers}`;
@@ -1911,39 +1902,22 @@ export default function PolicyEditor({
           {effect === "approval" && (
             <BlueprintSection code="02" title="Rule Config">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <Label htmlFor="approval-all">
-                      Require for all actions
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      Off to require approval for specific tools only.
-                    </p>
-                  </div>
-                  <Switch
-                    id="approval-all"
-                    checked={form.approvalAllActions}
-                    onCheckedChange={(v) => update("approvalAllActions", v)}
+                <div className="space-y-1.5">
+                  <Label>Tools requiring approval</Label>
+                  <ToolSelector
+                    options={toolCatalog}
+                    values={form.tools}
+                    onChange={(next) => update("tools", next)}
+                    emptyText="No tools are attached to the affected agents yet."
                   />
-                </div>
-                {!form.approvalAllActions && (
-                  <div className="space-y-1.5">
-                    <Label>Tools requiring approval</Label>
-                    <ToolSelector
-                      options={toolCatalog}
-                      values={form.tools}
-                      onChange={(next) => update("tools", next)}
-                      emptyText="No tools are attached to the affected agents yet."
+                  {form.tools.length > 0 && (
+                    <ToolConditionBuilder
+                      paramOptions={selectedToolParameterOptions}
+                      form={form}
+                      update={update}
                     />
-                    {form.tools.length > 0 && (
-                      <ToolConditionBuilder
-                        paramOptions={selectedToolParameterOptions}
-                        form={form}
-                        update={update}
-                      />
-                    )}
-                  </div>
-                )}
+                  )}
+                </div>
                 <div className="space-y-1.5">
                   <Label>Approvers</Label>
                   <ApproverSelector

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -48,8 +48,8 @@ interface PolicyEditorProps {
   mcpInstances: McpInstance[];
   mcpServers: McpServer[];
   openapiConnections: OpenAPIConnectionOption[];
+  members: MemberOption[];
   workspaceId: string | null;
-  currentUserId: string | null;
   returnHref?: string;
 }
 
@@ -72,6 +72,12 @@ interface OpenAPIConnectionOption {
     description?: string | null;
     inputSchema?: unknown;
   }> | null;
+}
+
+interface MemberOption {
+  user_id: string;
+  email?: string | null;
+  display_name?: string | null;
 }
 
 interface ToolConfigLike {
@@ -237,6 +243,23 @@ function humanizeToolName(name: string): string {
     .replace(/^tool:/, "")
     .replace(/[_-]+/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function memberLabel(member: MemberOption): string {
+  return member.display_name || member.email || member.user_id;
+}
+
+function approverLabel(ref: string, members: MemberOption[]): string {
+  if (ref.startsWith("user:")) {
+    const userId = ref.slice("user:".length);
+    const member = members.find((item) => item.user_id === userId);
+    return member ? memberLabel(member) : ref;
+  }
+  if (ref.startsWith("role:")) return ref.slice("role:".length);
+  if (ref.startsWith("group:")) {
+    return ref.slice("group:".length).replace("#member", "");
+  }
+  return ref;
 }
 
 function addToolOption(
@@ -869,6 +892,177 @@ function ToolConditionBuilder({
   );
 }
 
+function ApproverSelector({
+  members,
+  values,
+  onChange,
+}: {
+  members: MemberOption[];
+  values: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [subjectKind, setSubjectKind] = useState<"role" | "group">("role");
+  const [subjectName, setSubjectName] = useState("");
+
+  const toggle = (ref: string) => {
+    if (values.includes(ref)) {
+      onChange(values.filter((value) => value !== ref));
+    } else {
+      onChange([...values, ref]);
+    }
+  };
+
+  const addStructuredSubject = () => {
+    const name = subjectName.trim();
+    if (!name) return;
+    const ref =
+      subjectKind === "role" ? `role:${name}` : `group:${name}#member`;
+    if (!values.includes(ref)) onChange([...values, ref]);
+    setSubjectName("");
+  };
+
+  const memberRefs = new Set(members.map((member) => `user:${member.user_id}`));
+  const customValues = values.filter(
+    (value) =>
+      !memberRefs.has(value) &&
+      !value.startsWith("role:") &&
+      !value.startsWith("group:")
+  );
+
+  return (
+    <div className="space-y-3">
+      {values.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((ref) => (
+            <span
+              key={ref}
+              className="inline-flex items-center gap-1 border border-border/70 bg-muted/30 px-2 py-0.5 text-xs"
+            >
+              <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                {ref.split(":")[0]}
+              </span>
+              {approverLabel(ref, members)}
+              <button
+                type="button"
+                aria-label={`Remove ${ref}`}
+                onClick={() =>
+                  onChange(values.filter((value) => value !== ref))
+                }
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="grid gap-2 md:grid-cols-2">
+        {members.map((member) => {
+          const ref = `user:${member.user_id}`;
+          const selected = values.includes(ref);
+          const label = memberLabel(member);
+          return (
+            <div
+              key={member.user_id}
+              role="checkbox"
+              tabIndex={0}
+              aria-checked={selected}
+              onClick={() => toggle(ref)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  toggle(ref);
+                }
+              }}
+              className={cn(
+                "flex min-h-[58px] cursor-pointer items-start gap-2 border border-border/70 bg-background px-3 py-2 text-left transition-colors hover:bg-muted/30",
+                selected && "shadow-[inset_2px_0_0_hsl(var(--primary))]"
+              )}
+            >
+              <Checkbox
+                checked={selected}
+                tabIndex={-1}
+                aria-hidden="true"
+                className="pointer-events-none mt-0.5"
+              />
+              <span className="min-w-0">
+                <span className="block truncate text-sm font-medium text-foreground">
+                  {label}
+                </span>
+                <span className="mt-1 block truncate text-xs text-muted-foreground">
+                  {member.email && member.email !== label
+                    ? member.email
+                    : member.user_id}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="border-t border-border/60 pt-3">
+        <Label className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          Role or group
+        </Label>
+        <div className="mt-2 grid gap-2 sm:grid-cols-[160px_minmax(0,1fr)_auto]">
+          <Select
+            value={subjectKind}
+            onValueChange={(value) => setSubjectKind(value as "role" | "group")}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="role">Role</SelectItem>
+              <SelectItem value="group">Group members</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            value={subjectName}
+            onChange={(event) => setSubjectName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                addStructuredSubject();
+              }
+            }}
+            placeholder={subjectKind === "role" ? "admin" : "security"}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addStructuredSubject}
+          >
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <details className="border-t border-border/60 pt-3">
+        <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          Advanced subject ref
+        </summary>
+        <div className="mt-3">
+          <TagInput
+            values={customValues}
+            onChange={(nextCustom) => {
+              const standardValues = values.filter(
+                (value) => !customValues.includes(value)
+              );
+              onChange([...standardValues, ...nextCustom]);
+            }}
+            placeholder="user:<id>, role:<name>, or group:<id>#member"
+            validate={(value) => SUBJECT_REF_RE.test(value)}
+            invalidHint="Use a subject ref like user:<id>, role:<name>, or group:<id>#member"
+          />
+        </div>
+      </details>
+    </div>
+  );
+}
+
 function MoneyField({
   id,
   label,
@@ -1003,8 +1197,8 @@ export default function PolicyEditor({
   mcpInstances,
   mcpServers,
   openapiConnections,
+  members,
   workspaceId,
-  currentUserId,
   returnHref = "/policies",
 }: PolicyEditorProps) {
   const router = useRouter();
@@ -1108,13 +1302,6 @@ export default function PolicyEditor({
   const removeSelectedAgent = (agentId: string) => {
     setSelectedAgentIds((prev) => prev.filter((id) => id !== agentId));
     if (agentToAddId === agentId) setAgentToAddId("");
-  };
-
-  const addCurrentUserApprover = () => {
-    if (!currentUserId) return;
-    const ref = `user:${currentUserId}`;
-    if (form.approvers.includes(ref)) return;
-    update("approvers", [...form.approvers, ref]);
   };
 
   const resolveSubjects = (): Array<{
@@ -1592,25 +1779,11 @@ export default function PolicyEditor({
                   </div>
                 )}
                 <div className="space-y-1.5">
-                  <div className="flex items-center justify-between gap-2">
-                    <Label>Approvers</Label>
-                    {currentUserId && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={addCurrentUserApprover}
-                      >
-                        Me
-                      </Button>
-                    )}
-                  </div>
-                  <TagInput
+                  <Label>Approvers</Label>
+                  <ApproverSelector
+                    members={members}
                     values={form.approvers}
                     onChange={(next) => update("approvers", next)}
-                    placeholder="user:<id>, role:<name>, or group:<id>#member"
-                    validate={(v) => SUBJECT_REF_RE.test(v)}
-                    invalidHint="Use a subject ref like user:<id>, role:<name>, or group:<id>#member"
                   />
                   <p className="text-xs text-muted-foreground">
                     Leave empty to allow any workspace member to approve.

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -664,11 +664,11 @@ export default function PolicyEditor({
     <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
       <section className="relative overflow-hidden border border-border/70 bg-background">
         <div
-          className="pointer-events-none absolute inset-0 opacity-[0.035]"
+          className="pointer-events-none absolute inset-0 opacity-[0.025]"
           style={{
             backgroundImage:
               "linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)",
-            backgroundSize: "24px 24px",
+            backgroundSize: "18px 18px",
           }}
           aria-hidden="true"
         />

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -17,6 +17,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import {
+  resolveMcpRef,
+  type McpInstance,
+  type McpServer,
+} from "@/lib/mcp/resolveMcpRef";
 import { cn } from "@/lib/utils";
 import type { Policy, PolicyEffect } from "@/types/policies";
 import { EFFECT_STYLES } from "./policy-effects";
@@ -40,7 +45,11 @@ interface AgentOption {
 interface PolicyEditorProps {
   target: PolicyEditorTarget;
   agents: AgentOption[];
+  mcpInstances: McpInstance[];
+  mcpServers: McpServer[];
+  openapiConnections: OpenAPIConnectionOption[];
   workspaceId: string | null;
+  currentUserId: string | null;
   returnHref?: string;
 }
 
@@ -53,6 +62,17 @@ const EDITABLE_EFFECTS: PolicyEffect[] = ["cap", "deny", "approval", "safety"];
 type CapKind = "spend" | "service" | "tokens";
 type ScopeMode = "workspace" | "agents";
 type PolicyPeriod = "month" | "run";
+type ConditionOperator = "equals" | "not_equals" | "contains" | "exists";
+
+interface OpenAPIConnectionOption {
+  id: string;
+  name: string;
+  available_tools?: Array<{
+    name: string;
+    description?: string | null;
+    inputSchema?: unknown;
+  }> | null;
+}
 
 interface ToolConfigLike {
   type?: string | null;
@@ -78,6 +98,9 @@ interface ToolOption {
   id: string;
   label: string;
   source: string;
+  sourceLabel: string;
+  description?: string;
+  parameterKeys: string[];
   agents: string[];
 }
 
@@ -91,6 +114,9 @@ interface FormState {
   maxTokensPerCall: string;
   // deny / approval tools
   tools: string[];
+  conditionParam: string;
+  conditionOperator: ConditionOperator;
+  conditionValue: string;
   // approval
   approvalAllActions: boolean;
   approvers: string[];
@@ -107,6 +133,9 @@ const EMPTY_FORM: FormState = {
   maxTokens: "",
   maxTokensPerCall: "",
   tools: [],
+  conditionParam: "",
+  conditionOperator: "equals",
+  conditionValue: "",
   approvalAllActions: true,
   approvers: [],
   promptInjection: true,
@@ -138,6 +167,56 @@ function str(value: unknown): string {
   return "";
 }
 
+function parseCondition(condition: string | null | undefined): {
+  param: string;
+  operator: ConditionOperator;
+  value: string;
+} | null {
+  if (!condition) return null;
+  const match = condition.match(
+    /^args\.([a-zA-Z0-9_.-]+)\s*(==|!=|contains|exists)\s*(?:"([^"]*)"|(.+))?$/
+  );
+  if (!match) return null;
+  const op = match[2];
+  return {
+    param: match[1],
+    operator:
+      op === "!="
+        ? "not_equals"
+        : op === "contains"
+          ? "contains"
+          : op === "exists"
+            ? "exists"
+            : "equals",
+    value: match[3] ?? match[4] ?? "",
+  };
+}
+
+function buildCondition(form: FormState): string | null {
+  const param = form.conditionParam.trim();
+  if (!param) return null;
+  if (form.conditionOperator === "exists") return `args.${param} exists`;
+  const value = form.conditionValue.trim();
+  if (!value) return null;
+  const operator =
+    form.conditionOperator === "not_equals"
+      ? "!="
+      : form.conditionOperator === "contains"
+        ? "contains"
+        : "==";
+  return `args.${param} ${operator} ${JSON.stringify(value)}`;
+}
+
+function schemaParameterKeys(schema: unknown): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const record = schema as Record<string, unknown>;
+  const properties =
+    record.properties && typeof record.properties === "object"
+      ? (record.properties as Record<string, unknown>)
+      : null;
+  return properties ? Object.keys(properties).sort() : [];
+}
+
 function asToolNames(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -164,37 +243,110 @@ function addToolOption(
   map: Map<string, ToolOption>,
   id: string,
   source: string,
-  agentName: string
+  agentName: string,
+  metadata?: {
+    sourceLabel?: string;
+    description?: string | null;
+    parameterKeys?: string[];
+  }
 ) {
   const normalized = id.trim();
   if (!normalized) return;
   const existing = map.get(normalized);
   if (existing) {
     if (!existing.agents.includes(agentName)) existing.agents.push(agentName);
+    if (!existing.description && metadata?.description) {
+      existing.description = metadata.description;
+    }
+    if (metadata?.parameterKeys) {
+      existing.parameterKeys = Array.from(
+        new Set([...existing.parameterKeys, ...metadata.parameterKeys])
+      ).sort();
+    }
     return;
   }
   map.set(normalized, {
     id: normalized,
     label: humanizeToolName(normalized),
     source,
+    sourceLabel: metadata?.sourceLabel ?? source,
+    description: metadata?.description ?? undefined,
+    parameterKeys: metadata?.parameterKeys ?? [],
     agents: [agentName],
   });
 }
 
-function buildToolCatalog(agents: AgentOption[]): ToolOption[] {
+function buildToolCatalog(
+  agents: AgentOption[],
+  mcpInstances: McpInstance[],
+  mcpServers: McpServer[],
+  openapiConnections: OpenAPIConnectionOption[]
+): ToolOption[] {
   const map = new Map<string, ToolOption>();
+  const openapiById = new Map(
+    openapiConnections.map((connection) => [connection.id, connection])
+  );
+
   for (const agent of agents) {
     const agentName = agent.name;
 
     for (const tool of agent.tools ?? []) {
       const name = str(tool?.name);
-      if (tool?.type === "mcp" || tool?.type === "openapi") {
+      if (tool?.type === "mcp") {
+        const ref = resolveMcpRef(name, mcpInstances, mcpServers);
         const allowedTools = asToolNames(tool.settings?.allowed_tools);
-        for (const allowed of allowedTools) {
-          addToolOption(map, allowed, tool.type, agentName);
+        if (ref.status === "instance" && ref.availableTools.length > 0) {
+          const allowedSet =
+            allowedTools.length > 0 ? new Set(allowedTools) : null;
+          for (const available of ref.availableTools) {
+            if (allowedSet && !allowedSet.has(available.name)) continue;
+            addToolOption(map, available.name, "mcp", agentName, {
+              sourceLabel: `MCP · ${ref.displayName}`,
+              description: available.description,
+              parameterKeys: schemaParameterKeys(available.inputSchema),
+            });
+          }
+        } else {
+          for (const allowed of allowedTools) {
+            addToolOption(map, allowed, "mcp", agentName, {
+              sourceLabel: `MCP · ${ref.displayName}`,
+            });
+          }
+          if (allowedTools.length === 0) {
+            addToolOption(map, name, "mcp", agentName, {
+              sourceLabel: `MCP · ${ref.displayName}`,
+            });
+          }
         }
-        if (allowedTools.length === 0) {
-          addToolOption(map, name, tool.type, agentName);
+      } else if (tool?.type === "openapi") {
+        const connection = openapiById.get(name);
+        const allowedTools = asToolNames(tool.settings?.allowed_tools);
+        if (connection?.available_tools?.length) {
+          const allowedSet =
+            allowedTools.length > 0 ? new Set(allowedTools) : null;
+          for (const available of connection.available_tools) {
+            if (allowedSet && !allowedSet.has(available.name)) continue;
+            addToolOption(map, available.name, "openapi", agentName, {
+              sourceLabel: `OpenAPI · ${connection.name}`,
+              description: available.description,
+              parameterKeys: schemaParameterKeys(available.inputSchema),
+            });
+          }
+        } else {
+          for (const allowed of allowedTools) {
+            addToolOption(map, allowed, "openapi", agentName, {
+              sourceLabel: connection
+                ? `OpenAPI · ${connection.name}`
+                : "OpenAPI",
+            });
+          }
+          if (allowedTools.length === 0) {
+            addToolOption(map, name, "openapi", agentName, {
+              sourceLabel: connection
+                ? `OpenAPI · ${connection.name}`
+                : "OpenAPI",
+            });
+          }
         }
       } else {
         addToolOption(
@@ -207,19 +359,23 @@ function buildToolCatalog(agents: AgentOption[]): ToolOption[] {
     }
 
     for (const builtin of agent.tools_config?.builtin_tools ?? []) {
-      addToolOption(map, str(builtin?.tool_name), "builtin", agentName);
+      addToolOption(map, str(builtin?.tool_name), "builtin", agentName, {
+        sourceLabel: "Built-in",
+      });
     }
     for (const mcp of agent.tools_config?.mcp_server_configs ?? []) {
       for (const name of [
         ...asToolNames(mcp?.allowed_tools),
         ...asToolNames(mcp?.tools),
       ]) {
-        addToolOption(map, name, "mcp", agentName);
+        addToolOption(map, name, "mcp", agentName, { sourceLabel: "MCP" });
       }
     }
     for (const openapi of agent.tools_config?.openapi_configs ?? []) {
       for (const name of asToolNames(openapi?.allowed_tools)) {
-        addToolOption(map, name, "openapi", agentName);
+        addToolOption(map, name, "openapi", agentName, {
+          sourceLabel: "OpenAPI",
+        });
       }
     }
   }
@@ -273,6 +429,13 @@ function policyToForm(policy: Policy): {
     form.outputSanitizer = Boolean(p.output_sanitizer);
   }
 
+  const condition = parseCondition(policy.condition);
+  if (condition) {
+    form.conditionParam = condition.param;
+    form.conditionOperator = condition.operator;
+    form.conditionValue = condition.value;
+  }
+
   return { effect: policy.effect, form };
 }
 
@@ -282,6 +445,7 @@ interface RuleBody {
   target: string;
   effect: PolicyEffect;
   params: Record<string, unknown>;
+  condition?: string | null;
 }
 
 // Build the rule bodies the form describes. Returns an error string instead
@@ -320,11 +484,13 @@ function buildRuleBodies(
 
   if (effect === "deny") {
     if (form.tools.length === 0) return { error: "Add at least one tool." };
+    const condition = buildCondition(form);
     return {
       bodies: form.tools.map((tool) => ({
         target: `tool:${tool}`,
         effect,
         params: {},
+        condition,
       })),
     };
   }
@@ -336,11 +502,13 @@ function buildRuleBodies(
       return { bodies: [{ target: "*", effect, params }] };
     if (form.tools.length === 0)
       return { error: "Add a tool or require approval for all actions." };
+    const condition = buildCondition(form);
     return {
       bodies: form.tools.map((tool) => ({
         target: `tool:${tool}`,
         effect,
         params,
+        condition,
       })),
     };
   }
@@ -498,6 +666,8 @@ function ToolSelector({
           id: value,
           label: humanizeToolName(value),
           source: "custom",
+          sourceLabel: "Custom",
+          parameterKeys: [],
           agents: [],
         });
       }
@@ -557,9 +727,31 @@ function ToolSelector({
                     {tool.label}
                   </span>
                   <span className="mt-1 flex flex-wrap gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-                    <span>{tool.source}</span>
+                    <span>{tool.sourceLabel}</span>
                     <span>{agentLabel}</span>
                   </span>
+                  {tool.description && (
+                    <span className="mt-1 line-clamp-2 block text-xs text-muted-foreground">
+                      {tool.description}
+                    </span>
+                  )}
+                  {tool.parameterKeys.length > 0 && (
+                    <span className="mt-2 flex flex-wrap gap-1">
+                      {tool.parameterKeys.slice(0, 4).map((param) => (
+                        <span
+                          key={param}
+                          className="border border-border/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                        >
+                          {param}
+                        </span>
+                      ))}
+                      {tool.parameterKeys.length > 4 && (
+                        <span className="px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                          +{tool.parameterKeys.length - 4}
+                        </span>
+                      )}
+                    </span>
+                  )}
                 </span>
               </div>
             );
@@ -590,6 +782,89 @@ function ToolSelector({
           />
         </div>
       </details>
+    </div>
+  );
+}
+
+function ToolConditionBuilder({
+  paramOptions,
+  form,
+  update,
+}: {
+  paramOptions: string[];
+  form: FormState;
+  update: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}) {
+  const hasCondition = Boolean(form.conditionParam.trim());
+
+  return (
+    <div className="border-t border-border/60 pt-3">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <Label className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+          Parameter guard
+        </Label>
+        {hasCondition && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              update("conditionParam", "");
+              update("conditionValue", "");
+            }}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+      <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_160px_minmax(0,1fr)]">
+        <Select
+          value={form.conditionParam || "__none"}
+          onValueChange={(value) =>
+            update("conditionParam", value === "__none" ? "" : value)
+          }
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Parameter" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__none">Any parameter</SelectItem>
+            {paramOptions.map((param) => (
+              <SelectItem key={param} value={param}>
+                {param}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={form.conditionOperator}
+          onValueChange={(value) =>
+            update("conditionOperator", value as ConditionOperator)
+          }
+          disabled={!hasCondition}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="equals">Equals</SelectItem>
+            <SelectItem value="not_equals">Not equals</SelectItem>
+            <SelectItem value="contains">Contains</SelectItem>
+            <SelectItem value="exists">Exists</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          value={form.conditionValue}
+          disabled={!hasCondition || form.conditionOperator === "exists"}
+          onChange={(event) => update("conditionValue", event.target.value)}
+          placeholder="Value"
+        />
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Stored as a policy condition. Runtime enforcement for parameter
+        conditions needs the policy engine to evaluate rule conditions before
+        tool execution.
+      </p>
     </div>
   );
 }
@@ -725,7 +1000,11 @@ function previewParams(effect: PolicyEffect, form: FormState): string {
 export default function PolicyEditor({
   target,
   agents,
+  mcpInstances,
+  mcpServers,
+  openapiConnections,
   workspaceId,
+  currentUserId,
   returnHref = "/policies",
 }: PolicyEditorProps) {
   const router = useRouter();
@@ -769,8 +1048,27 @@ export default function PolicyEditor({
   }, [agents, selectedAgents, subjectType]);
 
   const toolCatalog = useMemo(
-    () => buildToolCatalog(affectedAgents),
-    [affectedAgents]
+    () =>
+      buildToolCatalog(
+        affectedAgents,
+        mcpInstances,
+        mcpServers,
+        openapiConnections
+      ),
+    [affectedAgents, mcpInstances, mcpServers, openapiConnections]
+  );
+
+  const selectedToolOptions = useMemo(
+    () => toolCatalog.filter((tool) => form.tools.includes(tool.id)),
+    [form.tools, toolCatalog]
+  );
+
+  const selectedToolParameterOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(selectedToolOptions.flatMap((tool) => tool.parameterKeys))
+      ).sort(),
+    [selectedToolOptions]
   );
 
   // Reset form whenever the route opens for a target.
@@ -810,6 +1108,13 @@ export default function PolicyEditor({
   const removeSelectedAgent = (agentId: string) => {
     setSelectedAgentIds((prev) => prev.filter((id) => id !== agentId));
     if (agentToAddId === agentId) setAgentToAddId("");
+  };
+
+  const addCurrentUserApprover = () => {
+    if (!currentUserId) return;
+    const ref = `user:${currentUserId}`;
+    if (form.approvers.includes(ref)) return;
+    update("approvers", [...form.approvers, ref]);
   };
 
   const resolveSubjects = (): Array<{
@@ -871,6 +1176,7 @@ export default function PolicyEditor({
               target: body.target,
               effect: body.effect,
               params: body.params,
+              condition: body.condition ?? null,
               enabled: form.enabled,
             }),
           }
@@ -892,6 +1198,7 @@ export default function PolicyEditor({
                 target: body.target,
                 effect: body.effect,
                 params: body.params,
+                condition: body.condition ?? null,
                 enabled: form.enabled,
               }),
             });
@@ -970,6 +1277,10 @@ export default function PolicyEditor({
     { label: "effect", value: EFFECT_STYLES[effect].label.toLowerCase() },
     { label: "target", value: previewTarget(effect, form) },
     { label: "params", value: previewParams(effect, form) },
+    {
+      label: "guard",
+      value: buildCondition(form) ?? "none",
+    },
     {
       label: "rules",
       value: compiledRuleCount === null ? "pending" : String(compiledRuleCount),
@@ -1222,6 +1533,13 @@ export default function PolicyEditor({
                   onChange={(next) => update("tools", next)}
                   emptyText="No tools are attached to the affected agents yet."
                 />
+                {form.tools.length > 0 && (
+                  <ToolConditionBuilder
+                    paramOptions={selectedToolParameterOptions}
+                    form={form}
+                    update={update}
+                  />
+                )}
                 <p className="flex items-center gap-1 text-xs text-muted-foreground">
                   <LinkIcon className="h-3 w-3" />
                   Granting tool access is managed in the{" "}
@@ -1264,16 +1582,35 @@ export default function PolicyEditor({
                       onChange={(next) => update("tools", next)}
                       emptyText="No tools are attached to the affected agents yet."
                     />
+                    {form.tools.length > 0 && (
+                      <ToolConditionBuilder
+                        paramOptions={selectedToolParameterOptions}
+                        form={form}
+                        update={update}
+                      />
+                    )}
                   </div>
                 )}
                 <div className="space-y-1.5">
-                  <Label>Approvers</Label>
+                  <div className="flex items-center justify-between gap-2">
+                    <Label>Approvers</Label>
+                    {currentUserId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={addCurrentUserApprover}
+                      >
+                        Me
+                      </Button>
+                    )}
+                  </div>
                   <TagInput
                     values={form.approvers}
                     onChange={(next) => update("approvers", next)}
-                    placeholder="user:<id> or group:<id>#member"
+                    placeholder="user:<id>, role:<name>, or group:<id>#member"
                     validate={(v) => SUBJECT_REF_RE.test(v)}
-                    invalidHint="Use a subject ref like user:<id> or group:<id>#member"
+                    invalidHint="Use a subject ref like user:<id>, role:<name>, or group:<id>#member"
                   />
                   <p className="text-xs text-muted-foreground">
                     Leave empty to allow any workspace member to approve.

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Link as LinkIcon, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -9,10 +10,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -20,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import type { Policy, PolicyEffect } from "@/types/policies";
 import { EFFECT_STYLES } from "./policy-effects";
@@ -47,12 +47,7 @@ interface PolicyEditorProps {
 
 // Effects the editor can author. (`allow` exists in the model but tool grants
 // live in the Access view; the editor focuses on restrictions.)
-const EDITABLE_EFFECTS: PolicyEffect[] = [
-  "cap",
-  "deny",
-  "approval",
-  "safety",
-];
+const EDITABLE_EFFECTS: PolicyEffect[] = ["cap", "deny", "approval", "safety"];
 
 // --- cap sub-form ---------------------------------------------------------
 
@@ -117,7 +112,10 @@ function str(value: unknown): string {
 
 // Seed the form from an existing rule (edit mode). Unknown shapes degrade
 // gracefully — fields that don't apply stay at their defaults.
-function policyToForm(policy: Policy): { effect: PolicyEffect; form: FormState } {
+function policyToForm(policy: Policy): {
+  effect: PolicyEffect;
+  form: FormState;
+} {
   const p =
     typeof policy.params === "object" && policy.params !== null
       ? (policy.params as Record<string, unknown>)
@@ -259,6 +257,7 @@ function EffectSegmented({
     <div className="inline-flex flex-wrap items-center gap-1 rounded-lg bg-muted p-1">
       {EDITABLE_EFFECTS.map((effect) => {
         const style = EFFECT_STYLES[effect];
+        const Icon = style.icon;
         const active = effect === value;
         return (
           <button
@@ -273,8 +272,9 @@ function EffectSegmented({
                 : "text-muted-foreground hover:text-foreground"
             )}
           >
-            <span
-              className={cn("h-2 w-2 shrink-0 rounded-full", style.dot)}
+            <Icon
+              className="h-3.5 w-3.5 shrink-0"
+              strokeWidth={1.8}
               aria-hidden
             />
             {style.label}
@@ -455,7 +455,7 @@ export default function PolicyEditor({
       setEffect("cap");
       setForm(EMPTY_FORM);
       setSelectedAgentId(
-        target.mode === "create-agent" ? target.agentId ?? "" : ""
+        target.mode === "create-agent" ? (target.agentId ?? "") : ""
       );
     }
     setError(null);
@@ -548,9 +548,12 @@ export default function PolicyEditor({
     setSaving(true);
     setError(null);
     try {
-      const response = await fetch(`/api/proxy/v1/policies/${target.policy.id}`, {
-        method: "DELETE",
-      });
+      const response = await fetch(
+        `/api/proxy/v1/policies/${target.policy.id}`,
+        {
+          method: "DELETE",
+        }
+      );
       if (!response.ok && response.status !== 204) {
         setError(await readDetail(response, "Delete failed"));
         return;
@@ -610,7 +613,11 @@ export default function PolicyEditor({
           {/* Effect */}
           <div className="space-y-1.5">
             <Label>Effect</Label>
-            <EffectSegmented value={effect} onChange={setEffect} disabled={isEdit} />
+            <EffectSegmented
+              value={effect}
+              onChange={setEffect}
+              disabled={isEdit}
+            />
             {isEdit && (
               <p className="text-xs text-muted-foreground">
                 The effect is fixed once a rule is created.
@@ -836,7 +843,10 @@ export default function PolicyEditor({
 }
 
 // Read a backend 4xx detail message, falling back to a status-based message.
-async function readDetail(response: Response, fallback: string): Promise<string> {
+async function readDetail(
+  response: Response,
+  fallback: string
+): Promise<string> {
   let detail = `${fallback} (${response.status})`;
   try {
     const body = (await response.json()) as { detail?: unknown };

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -295,7 +295,7 @@ function buildRuleBodies(
       const maxTokens = parseInt2(form.maxTokens);
       const perCall = parseInt2(form.maxTokensPerCall);
       if (maxTokens === null && perCall === null)
-        return { error: "Enter a token cap." };
+        return { error: "Enter a token budget." };
       const params: Record<string, unknown> = {};
       if (maxTokens !== null) params.max_tokens = maxTokens;
       if (perCall !== null) params.max_tokens_per_call = perCall;
@@ -967,7 +967,7 @@ export default function PolicyEditor({
           ? "workspace"
           : `${selectedAgentIds.length} agent${selectedAgentIds.length === 1 ? "" : "s"}`,
     },
-    { label: "effect", value: effect },
+    { label: "effect", value: EFFECT_STYLES[effect].label.toLowerCase() },
     { label: "target", value: previewTarget(effect, form) },
     { label: "params", value: previewParams(effect, form) },
     {
@@ -1146,7 +1146,7 @@ export default function PolicyEditor({
             <BlueprintSection code={detailsCode} title="Limits">
               <div className="space-y-3 border border-border/70 bg-muted/20 p-4">
                 <div className="space-y-1.5">
-                  <Label htmlFor="cap-kind">Cap type</Label>
+                  <Label htmlFor="cap-kind">Budget type</Label>
                   <Select
                     value={form.capKind}
                     onValueChange={(v) => update("capKind", v as CapKind)}
@@ -1159,7 +1159,7 @@ export default function PolicyEditor({
                       <SelectItem value="service">
                         Per-service budget
                       </SelectItem>
-                      <SelectItem value="tokens">Token cap</SelectItem>
+                      <SelectItem value="tokens">Token budget</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Link as LinkIcon, X } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Link as LinkIcon, UsersRound, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -37,12 +32,10 @@ interface AgentOption {
 }
 
 interface PolicyEditorProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  target: PolicyEditorTarget | null;
+  target: PolicyEditorTarget;
   agents: AgentOption[];
   workspaceId: string | null;
-  onSaved: () => void;
+  returnHref?: string;
 }
 
 // Effects the editor can author. (`allow` exists in the model but tool grants
@@ -418,13 +411,12 @@ function NumberField({
 // --- editor ---------------------------------------------------------------
 
 export default function PolicyEditor({
-  open,
-  onOpenChange,
   target,
   agents,
   workspaceId,
-  onSaved,
+  returnHref = "/policies",
 }: PolicyEditorProps) {
+  const router = useRouter();
   const [effect, setEffect] = useState<PolicyEffect>("cap");
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [selectedAgentId, setSelectedAgentId] = useState<string>("");
@@ -434,16 +426,24 @@ export default function PolicyEditor({
   const isEdit = target?.mode === "edit";
 
   const subjectType = useMemo<"workspace" | "agent">(() => {
-    if (!target) return "workspace";
     if (target.mode === "edit")
       return target.policy.subject_type === "workspace" ? "workspace" : "agent";
     if (target.mode === "create-agent") return "agent";
     return "workspace";
   }, [target]);
 
-  // Reset form whenever the editor opens for a (new) target.
+  const selectedAgent = useMemo(
+    () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
+    [agents, selectedAgentId]
+  );
+
+  const affectedAgents = useMemo(() => {
+    if (subjectType === "workspace") return agents;
+    return selectedAgent ? [selectedAgent] : [];
+  }, [agents, selectedAgent, subjectType]);
+
+  // Reset form whenever the route opens for a target.
   useEffect(() => {
-    if (!open || !target) return;
     if (target.mode === "edit") {
       const seeded = policyToForm(target.policy);
       setEffect(seeded.effect);
@@ -459,7 +459,7 @@ export default function PolicyEditor({
       );
     }
     setError(null);
-  }, [open, target]);
+  }, [target]);
 
   const update = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -534,8 +534,8 @@ export default function PolicyEditor({
         }
       }
 
-      onOpenChange(false);
-      onSaved();
+      router.push(returnHref);
+      router.refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to save policy");
     } finally {
@@ -558,8 +558,8 @@ export default function PolicyEditor({
         setError(await readDetail(response, "Delete failed"));
         return;
       }
-      onOpenChange(false);
-      onSaved();
+      router.push(returnHref);
+      router.refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to delete policy");
     } finally {
@@ -574,20 +574,20 @@ export default function PolicyEditor({
       : "New workspace rule";
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+      <section className="rounded-lg border border-border bg-background p-5">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <p className="text-sm text-muted-foreground">
             A policy is a single rule. It applies to{" "}
             {subjectType === "workspace"
               ? "every agent in this workspace"
               : "the selected agent"}
             . Tool access grants are managed in the Access view.
-          </DialogDescription>
-        </DialogHeader>
+          </p>
+        </div>
 
-        <div className="space-y-5 py-1">
+        <div className="mt-5 space-y-5">
           {/* Agent picker — only in agent create mode without a fixed agent */}
           {target?.mode === "create-agent" && (
             <div className="space-y-1.5">
@@ -703,12 +703,12 @@ export default function PolicyEditor({
               <p className="flex items-center gap-1 text-xs text-muted-foreground">
                 <LinkIcon className="h-3 w-3" />
                 Granting tool access is managed in the{" "}
-                <a
+                <Link
                   href="/policies?view=access"
                   className="text-primary underline-offset-4 hover:underline"
                 >
                   Access view
-                </a>
+                </Link>
                 .
               </p>
             </section>
@@ -822,7 +822,7 @@ export default function PolicyEditor({
               variant="outline"
               size="sm"
               disabled={saving}
-              onClick={() => onOpenChange(false)}
+              onClick={() => router.push(returnHref)}
             >
               Cancel
             </Button>
@@ -837,8 +837,57 @@ export default function PolicyEditor({
             </Button>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </section>
+
+      <aside className="h-fit rounded-lg border border-border bg-background p-4">
+        <div className="flex items-center gap-2">
+          <span className="grid h-8 w-8 place-items-center rounded-lg border border-border bg-muted/50">
+            <UsersRound className="h-4 w-4 text-muted-foreground" />
+          </span>
+          <div>
+            <h3 className="text-sm font-medium text-foreground">
+              Affected agents
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {subjectType === "workspace"
+                ? `${affectedAgents.length} workspace agent${affectedAgents.length === 1 ? "" : "s"}`
+                : selectedAgent
+                  ? "Selected agent"
+                  : "No agent selected"}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 space-y-2">
+          {affectedAgents.length > 0 ? (
+            affectedAgents.slice(0, 8).map((agent) => (
+              <div
+                key={agent.id}
+                className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
+              >
+                <span className="truncate text-sm text-foreground">
+                  {agent.name}
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">
+                  Agent
+                </span>
+              </div>
+            ))
+          ) : (
+            <p className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted-foreground">
+              {subjectType === "workspace"
+                ? "No agents in this workspace yet."
+                : "Select an agent to preview the affected scope."}
+            </p>
+          )}
+          {affectedAgents.length > 8 && (
+            <p className="text-xs text-muted-foreground">
+              +{affectedAgents.length - 8} more
+            </p>
+          )}
+        </div>
+      </aside>
+    </div>
   );
 }
 

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
@@ -1,10 +1,27 @@
 import { notFound } from "next/navigation";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
 import EmptyState from "@/components/EmptyState";
-import { listAgents, listPolicies } from "@/lib/api";
+import {
+  listAgents,
+  listMCPServerInstances,
+  listMCPServers,
+  listOpenAPIConnections,
+  listPolicies,
+} from "@/lib/api";
 import { getAuthContext } from "@/lib/getAuthContext";
+import type { McpInstance, McpServer } from "@/lib/mcp/resolveMcpRef";
 import type { Policy } from "@/types/policies";
 import PolicyEditor, { type PolicyEditorTarget } from "./PolicyEditor";
+
+interface OpenAPIConnectionLike {
+  id: string;
+  name: string;
+  available_tools?: Array<{
+    name: string;
+    description?: string | null;
+    inputSchema?: unknown;
+  }> | null;
+}
 
 interface AgentLike {
   id: string;
@@ -32,11 +49,30 @@ export async function PolicyEditorPageData({
 }: PolicyEditorPageDataProps) {
   let policies: Policy[] = [];
   let agents: AgentLike[] = [];
+  let mcpInstances: McpInstance[] = [];
+  let mcpServers: McpServer[] = [];
+  let openapiConnections: OpenAPIConnectionLike[] = [];
   let policiesError: string | null = null;
 
-  const [policiesRes, agentsRes, authContext] = await Promise.all([
+  const [
+    policiesRes,
+    agentsRes,
+    mcpInstancesRes,
+    mcpServersRes,
+    openapiConnectionsRes,
+    authContext,
+  ] = await Promise.all([
     listPolicies().catch((reason) => ({ data: null, error: reason })),
     listAgents().catch((reason) => ({ data: null, error: reason })),
+    listMCPServerInstances().catch((reason) => ({ data: null, error: reason })),
+    listMCPServers({ page_size: 100 }).catch((reason) => ({
+      data: null,
+      error: reason,
+    })),
+    listOpenAPIConnections().catch((reason) => ({
+      data: null,
+      error: reason,
+    })),
     getAuthContext(),
   ]);
 
@@ -61,6 +97,40 @@ export async function PolicyEditorPageData({
           ? agent.tools_config
           : null,
     }));
+  }
+
+  if (mcpInstancesRes.error) {
+    console.error(
+      "Failed to load MCP instances for policy editor:",
+      mcpInstancesRes.error
+    );
+  } else {
+    mcpInstances = ((mcpInstancesRes.data as McpInstance[] | null) ??
+      []) as McpInstance[];
+  }
+
+  if (mcpServersRes.error) {
+    console.error(
+      "Failed to load MCP servers for policy editor:",
+      mcpServersRes.error
+    );
+  } else {
+    const data = mcpServersRes.data as
+      | McpServer[]
+      | { items?: McpServer[] }
+      | null;
+    mcpServers = Array.isArray(data) ? data : (data?.items ?? []);
+  }
+
+  if (openapiConnectionsRes.error) {
+    console.error(
+      "Failed to load OpenAPI connections for policy editor:",
+      openapiConnectionsRes.error
+    );
+  } else {
+    openapiConnections = ((openapiConnectionsRes.data as
+      | OpenAPIConnectionLike[]
+      | null) ?? []) as OpenAPIConnectionLike[];
   }
 
   const target = resolveTarget({ policyId, policies });
@@ -88,7 +158,11 @@ export async function PolicyEditorPageData({
           <PolicyEditor
             target={target}
             agents={agents}
+            mcpInstances={mcpInstances}
+            mcpServers={mcpServers}
+            openapiConnections={openapiConnections}
             workspaceId={authContext.workspaceId}
+            currentUserId={authContext.userId}
           />
         )}
       </div>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
@@ -11,6 +11,16 @@ interface AgentLike {
   name: string;
   icon?: string | null;
   color_token?: string | null;
+  tools?: Array<{
+    type?: string | null;
+    name?: string | null;
+    settings?: Record<string, unknown> | null;
+  }> | null;
+  tools_config?: {
+    builtin_tools?: Array<Record<string, unknown>> | null;
+    mcp_server_configs?: Array<Record<string, unknown>> | null;
+    openapi_configs?: Array<Record<string, unknown>> | null;
+  } | null;
 }
 
 interface PolicyEditorPageDataProps {
@@ -45,6 +55,11 @@ export async function PolicyEditorPageData({
       name: agent.name,
       icon: agent.icon,
       color_token: agent.color_token,
+      tools: Array.isArray(agent.tools) ? agent.tools : null,
+      tools_config:
+        agent.tools_config && typeof agent.tools_config === "object"
+          ? agent.tools_config
+          : null,
     }));
   }
 

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
@@ -93,10 +93,5 @@ function resolveTarget({
     return policy ? { mode: "edit", policy } : null;
   }
 
-  const hasWorkspacePolicy = policies.some(
-    (policy) => policy.subject_type === "workspace"
-  );
-  return hasWorkspacePolicy
-    ? { mode: "create-agent" }
-    : { mode: "create-workspace" };
+  return { mode: "create-workspace" };
 }

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
@@ -7,6 +7,8 @@ import {
   listMCPServers,
   listOpenAPIConnections,
   listPolicies,
+  listWorkspaceMembers,
+  type WorkspaceMember,
 } from "@/lib/api";
 import { getAuthContext } from "@/lib/getAuthContext";
 import type { McpInstance, McpServer } from "@/lib/mcp/resolveMcpRef";
@@ -21,6 +23,12 @@ interface OpenAPIConnectionLike {
     description?: string | null;
     inputSchema?: unknown;
   }> | null;
+}
+
+interface MemberLike {
+  user_id: string;
+  email?: string | null;
+  display_name?: string | null;
 }
 
 interface AgentLike {
@@ -52,7 +60,9 @@ export async function PolicyEditorPageData({
   let mcpInstances: McpInstance[] = [];
   let mcpServers: McpServer[] = [];
   let openapiConnections: OpenAPIConnectionLike[] = [];
+  let members: MemberLike[] = [];
   let policiesError: string | null = null;
+  const authContext = await getAuthContext();
 
   const [
     policiesRes,
@@ -60,7 +70,7 @@ export async function PolicyEditorPageData({
     mcpInstancesRes,
     mcpServersRes,
     openapiConnectionsRes,
-    authContext,
+    membersRes,
   ] = await Promise.all([
     listPolicies().catch((reason) => ({ data: null, error: reason })),
     listAgents().catch((reason) => ({ data: null, error: reason })),
@@ -73,7 +83,12 @@ export async function PolicyEditorPageData({
       data: null,
       error: reason,
     })),
-    getAuthContext(),
+    authContext.workspaceId
+      ? listWorkspaceMembers(authContext.workspaceId).catch((reason) => ({
+          data: null,
+          error: reason,
+        }))
+      : Promise.resolve({ data: null, error: null }),
   ]);
 
   if (policiesRes.error) {
@@ -133,6 +148,36 @@ export async function PolicyEditorPageData({
       | null) ?? []) as OpenAPIConnectionLike[];
   }
 
+  if (membersRes.error) {
+    console.error(
+      "Failed to load members for policy editor:",
+      membersRes.error
+    );
+  } else {
+    members = (
+      ((membersRes.data as WorkspaceMember[] | null) ?? []) as WorkspaceMember[]
+    ).map((member) => ({
+      user_id: member.user_id,
+      email: member.email,
+      display_name: member.display_name,
+    }));
+  }
+
+  if (
+    authContext.userId &&
+    !members.some((member) => member.user_id === authContext.userId)
+  ) {
+    members = [
+      {
+        user_id: authContext.userId,
+        email: authContext.email,
+        display_name:
+          authContext.name || authContext.email || authContext.username || null,
+      },
+      ...members,
+    ];
+  }
+
   const target = resolveTarget({ policyId, policies });
   if (!target) notFound();
 
@@ -161,8 +206,8 @@ export async function PolicyEditorPageData({
             mcpInstances={mcpInstances}
             mcpServers={mcpServers}
             openapiConnections={openapiConnections}
+            members={members}
             workspaceId={authContext.workspaceId}
-            currentUserId={authContext.userId}
           />
         )}
       </div>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
@@ -9,6 +9,8 @@ import PolicyEditor, { type PolicyEditorTarget } from "./PolicyEditor";
 interface AgentLike {
   id: string;
   name: string;
+  icon?: string | null;
+  color_token?: string | null;
 }
 
 interface PolicyEditorPageDataProps {
@@ -41,6 +43,8 @@ export async function PolicyEditorPageData({
     agents = ((agentsRes.data as AgentLike[] | null) ?? []).map((agent) => ({
       id: agent.id,
       name: agent.name,
+      icon: agent.icon,
+      color_token: agent.color_token,
     }));
   }
 

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditorPageData.tsx
@@ -1,0 +1,98 @@
+import { notFound } from "next/navigation";
+import ContentBlock from "@/components/ContentBlock/ContentBlock";
+import EmptyState from "@/components/EmptyState";
+import { listAgents, listPolicies } from "@/lib/api";
+import { getAuthContext } from "@/lib/getAuthContext";
+import type { Policy } from "@/types/policies";
+import PolicyEditor, { type PolicyEditorTarget } from "./PolicyEditor";
+
+interface AgentLike {
+  id: string;
+  name: string;
+}
+
+interface PolicyEditorPageDataProps {
+  policyId?: string;
+}
+
+export async function PolicyEditorPageData({
+  policyId,
+}: PolicyEditorPageDataProps) {
+  let policies: Policy[] = [];
+  let agents: AgentLike[] = [];
+  let policiesError: string | null = null;
+
+  const [policiesRes, agentsRes, authContext] = await Promise.all([
+    listPolicies().catch((reason) => ({ data: null, error: reason })),
+    listAgents().catch((reason) => ({ data: null, error: reason })),
+    getAuthContext(),
+  ]);
+
+  if (policiesRes.error) {
+    console.error("Failed to fetch policies:", policiesRes.error);
+    policiesError = "Failed to load policies";
+  } else {
+    policies = ((policiesRes.data as Policy[] | null) ?? []) as Policy[];
+  }
+
+  if (agentsRes.error) {
+    console.error("Failed to load agents for policy editor:", agentsRes.error);
+  } else {
+    agents = ((agentsRes.data as AgentLike[] | null) ?? []).map((agent) => ({
+      id: agent.id,
+      name: agent.name,
+    }));
+  }
+
+  const target = resolveTarget({ policyId, policies });
+  if (!target) notFound();
+
+  const title = policyId ? "Edit policy rule" : "New policy rule";
+
+  return (
+    <ContentBlock
+      header={{
+        breadcrumb: [
+          { label: "Policies", href: "/policies" },
+          { label: title },
+        ],
+      }}
+    >
+      <div className="main-content">
+        {policiesError && policyId ? (
+          <EmptyState
+            title="Couldn't load policy"
+            description={policiesError}
+            iconsType="audit"
+          />
+        ) : (
+          <PolicyEditor
+            target={target}
+            agents={agents}
+            workspaceId={authContext.workspaceId}
+          />
+        )}
+      </div>
+    </ContentBlock>
+  );
+}
+
+function resolveTarget({
+  policyId,
+  policies,
+}: {
+  policyId?: string;
+  policies: Policy[];
+}): PolicyEditorTarget | null {
+  if (policyId) {
+    const policy = policies.find((item) => item.id === policyId);
+    return policy ? { mode: "edit", policy } : null;
+  }
+
+  const hasWorkspacePolicy = policies.some(
+    (policy) => policy.subject_type === "workspace"
+  );
+  return hasWorkspacePolicy
+    ? { mode: "create-agent" }
+    : { mode: "create-workspace" };
+}

--- a/agentarea-webapp/src/app/(main)/policies/components/policy-effects.ts
+++ b/agentarea-webapp/src/app/(main)/policies/components/policy-effects.ts
@@ -1,35 +1,42 @@
+import {
+  CheckCircle2,
+  ShieldCheck,
+  UserCheck,
+  Wallet,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
 import type { PolicyEffect } from "@/types/policies";
 
-// Shared effect tokens. Kept deliberately restrained to match the Skills page:
-// a single small status dot carries the only colour; chips stay neutral
-// (muted surface + foreground text) so the list reads calm, not rainbow.
+// Shared effect tokens. Keep them neutral; policy type is carried by the icon,
+// not by a separate colour system.
 export const EFFECT_STYLES: Record<
   PolicyEffect,
-  { label: string; dot: string; chip: string }
+  { label: string; icon: LucideIcon; chip: string }
 > = {
   allow: {
     label: "Allow",
-    dot: "bg-emerald-500/70",
+    icon: CheckCircle2,
     chip: "bg-muted text-foreground/70",
   },
   cap: {
     label: "Cap",
-    dot: "bg-sky-500/70",
+    icon: Wallet,
     chip: "bg-muted text-foreground/70",
   },
   approval: {
     label: "Approval",
-    dot: "bg-amber-500/70",
+    icon: UserCheck,
     chip: "bg-muted text-foreground/70",
   },
   deny: {
     label: "Deny",
-    dot: "bg-rose-500/70",
+    icon: Wrench,
     chip: "bg-muted text-foreground/70",
   },
   safety: {
     label: "Safety",
-    dot: "bg-zinc-400",
+    icon: ShieldCheck,
     chip: "bg-muted text-foreground/70",
   },
 };

--- a/agentarea-webapp/src/app/(main)/policies/components/policy-effects.ts
+++ b/agentarea-webapp/src/app/(main)/policies/components/policy-effects.ts
@@ -20,7 +20,7 @@ export const EFFECT_STYLES: Record<
     chip: "bg-muted text-foreground/70",
   },
   cap: {
-    label: "Cap",
+    label: "Budget",
     icon: Wallet,
     chip: "bg-muted text-foreground/70",
   },

--- a/agentarea-webapp/src/app/(main)/policies/components/policy-rules.ts
+++ b/agentarea-webapp/src/app/(main)/policies/components/policy-rules.ts
@@ -204,10 +204,9 @@ export type MatrixDimensionKey =
   | "safety"
   | "custom";
 
-// Classify a rule by effect + target into a matrix dimension. Anything that
-// isn't a known mapping (or carries a CEL condition) is "custom".
+// Classify a rule by effect + target into a matrix dimension. Unknown mappings
+// stay custom, but known tool rules may carry a condition and remain readable.
 export function ruleDimension(policy: Policy): MatrixDimensionKey {
-  if (policy.condition) return "custom";
   const { effect, target } = policy;
 
   if (effect === "cap") {
@@ -285,9 +284,10 @@ function describeRule(
   if (dimension === "tools") {
     const name = toolNameFromTarget(policy.target);
     const verb = policy.effect === "deny" ? "Deny" : "Allow";
+    const base = name === "*" ? "all tools" : name;
     return {
       label: `${verb} tool`,
-      value: name === "*" ? "all tools" : name,
+      value: policy.condition ? `${base} · when ${policy.condition}` : base,
     };
   }
 
@@ -300,9 +300,12 @@ function describeRule(
     if (policy.target === "*")
       return { label: "Approval for all actions", value: `by ${by}` };
     const name = toolNameFromTarget(policy.target);
+    const value = policy.condition
+      ? `by ${by} · when ${policy.condition}`
+      : `by ${by}`;
     return {
       label: `Approval for ${name === "*" ? "all tools" : name}`,
-      value: `by ${by}`,
+      value,
     };
   }
 

--- a/agentarea-webapp/src/app/(main)/policies/components/policy-rules.ts
+++ b/agentarea-webapp/src/app/(main)/policies/components/policy-rules.ts
@@ -4,10 +4,7 @@ import type {
   PolicyEffect,
   PolicyRule,
 } from "@/types/policies";
-import {
-  isToolTarget,
-  toolNameFromTarget,
-} from "@/types/policies";
+import { isToolTarget, toolNameFromTarget } from "@/types/policies";
 
 // Enforcement-stage labels, grounded in the governance engine's phases
 // (PRE_LLM_CALL, POST_LLM_CALL, PRE_TOOL_CALL, TOOL_DISCOVERY, …). The phase is
@@ -72,41 +69,104 @@ export function documentToRules(
   const b = doc.budget;
   if (b) {
     if (b.monthly_spend_cap_usd != null)
-      rules.push({ effect: "cap", category: "Budget", label: "Monthly spend cap", value: fmtMoney(b.monthly_spend_cap_usd), stage: STAGE.beforeLlmOrTool });
+      rules.push({
+        effect: "cap",
+        category: "Budget",
+        label: "Monthly budget",
+        value: fmtMoney(b.monthly_spend_cap_usd),
+        stage: STAGE.beforeLlmOrTool,
+      });
     if (b.run_budget_usd != null)
-      rules.push({ effect: "cap", category: "Budget", label: "Per-run budget", value: fmtMoney(b.run_budget_usd), stage: STAGE.beforeLlmOrTool });
+      rules.push({
+        effect: "cap",
+        category: "Budget",
+        label: "Per-task budget",
+        value: fmtMoney(b.run_budget_usd),
+        stage: STAGE.beforeLlmOrTool,
+      });
     if (b.service_budget_usd != null)
-      rules.push({ effect: "cap", category: "Budget", label: "Per-service budget", value: fmtMoney(b.service_budget_usd), stage: STAGE.beforeLlmOrTool });
+      rules.push({
+        effect: "cap",
+        category: "Budget",
+        label: "Per-service budget",
+        value: fmtMoney(b.service_budget_usd),
+        stage: STAGE.beforeLlmOrTool,
+      });
   }
 
   const t = doc.tokens;
   if (t) {
     if (t.max_tokens != null)
-      rules.push({ effect: "cap", category: "Tokens", label: "Max tokens", value: fmtNum(t.max_tokens), stage: STAGE.beforeLlm });
+      rules.push({
+        effect: "cap",
+        category: "Tokens",
+        label: "Token budget",
+        value: fmtNum(t.max_tokens),
+        stage: STAGE.beforeLlm,
+      });
     if (t.max_tokens_per_call != null)
-      rules.push({ effect: "cap", category: "Tokens", label: "Max tokens per call", value: fmtNum(t.max_tokens_per_call), stage: STAGE.beforeLlm });
+      rules.push({
+        effect: "cap",
+        category: "Tokens",
+        label: "Max tokens per call",
+        value: fmtNum(t.max_tokens_per_call),
+        stage: STAGE.beforeLlm,
+      });
   }
 
   const tools = doc.tools;
   if (tools) {
     if (tools.allowed && tools.allowed.length > 0)
-      rules.push({ effect: "allow", category: "Tools", label: "Allowed tools", value: tools.allowed.join(", "), stage: STAGE.toolDiscovery });
+      rules.push({
+        effect: "allow",
+        category: "Tools",
+        label: "Allowed tools",
+        value: tools.allowed.join(", "),
+        stage: STAGE.toolDiscovery,
+      });
     if (tools.denied && tools.denied.length > 0)
-      rules.push({ effect: "deny", category: "Tools", label: "Denied tools", value: tools.denied.join(", "), stage: STAGE.beforeTool });
+      rules.push({
+        effect: "deny",
+        category: "Tools",
+        label: "Denied tools",
+        value: tools.denied.join(", "),
+        stage: STAGE.beforeTool,
+      });
   }
 
   const a = doc.approval;
   if (a?.requires_human_approval) {
-    const approvers = a.approvers && a.approvers.length > 0 ? a.approvers.join(", ") : "any workspace member";
-    rules.push({ effect: "approval", category: "Approval", label: "Requires human approval", value: `by ${approvers}`, stage: STAGE.sensitiveAction });
+    const approvers =
+      a.approvers && a.approvers.length > 0
+        ? a.approvers.join(", ")
+        : "any workspace member";
+    rules.push({
+      effect: "approval",
+      category: "Approval",
+      label: "Requires human approval",
+      value: `by ${approvers}`,
+      stage: STAGE.sensitiveAction,
+    });
   }
 
   const cs = doc.content_safety;
   if (cs) {
     if (cs.prompt_injection_detection_enabled)
-      rules.push({ effect: "safety", category: "Safety", label: "Prompt-injection detection", value: "on", stage: STAGE.llmInput });
+      rules.push({
+        effect: "safety",
+        category: "Safety",
+        label: "Prompt-injection detection",
+        value: "on",
+        stage: STAGE.llmInput,
+      });
     if (cs.output_sanitizer_enabled)
-      rules.push({ effect: "safety", category: "Safety", label: "Output sanitizer", value: "on", stage: STAGE.llmOutput });
+      rules.push({
+        effect: "safety",
+        category: "Safety",
+        label: "Output sanitizer",
+        value: "on",
+        stage: STAGE.llmOutput,
+      });
   }
 
   return rules;
@@ -189,7 +249,10 @@ const STAGE_BY_DIMENSION: Record<MatrixDimensionKey, string> = {
 };
 
 // Build a human-readable label + value for a single rule.
-function describeRule(policy: Policy, dimension: MatrixDimensionKey): {
+function describeRule(
+  policy: Policy,
+  dimension: MatrixDimensionKey
+): {
   label: string;
   value: string;
 } {
@@ -199,7 +262,7 @@ function describeRule(policy: Policy, dimension: MatrixDimensionKey): {
     const amount = fmtMoney(p.amount_usd);
     if (policy.target === "spend") {
       const period = str(p.period);
-      const label = period === "run" ? "Per-run budget" : "Monthly spend cap";
+      const label = period === "run" ? "Per-task budget" : "Monthly budget";
       return { label, value: amount };
     }
     return { label: "Per-service budget", value: amount };
@@ -210,13 +273,13 @@ function describeRule(policy: Policy, dimension: MatrixDimensionKey): {
     const perCall = p.max_tokens_per_call;
     if (max != null && perCall != null)
       return {
-        label: "Token caps",
+        label: "Token budgets",
         value: `${fmtNum(max)} total · ${fmtNum(perCall)}/call`,
       };
     if (perCall != null)
       return { label: "Max tokens per call", value: fmtNum(perCall) };
     if (max != null) return { label: "Max tokens", value: fmtNum(max) };
-    return { label: "Token cap", value: "set" };
+    return { label: "Token budget", value: "set" };
   }
 
   if (dimension === "tools") {
@@ -433,7 +496,8 @@ function buildDimensions(rules: Policy[]): {
     };
   }
 
-  if (safetyInput && safetyOutput) dims.safety = { value: "on", effect: "safety" };
+  if (safetyInput && safetyOutput)
+    dims.safety = { value: "on", effect: "safety" };
   else if (safetyInput) dims.safety = { value: "input", effect: "safety" };
   else if (safetyOutput) dims.safety = { value: "output", effect: "safety" };
   else if (safetyOn) dims.safety = { value: "on", effect: "safety" };
@@ -493,7 +557,7 @@ export function policiesToMatrix(
     const subjectName = isWorkspace
       ? "Workspace"
       : type === "agent"
-        ? agentNameById.get(id) ?? id
+        ? (agentNameById.get(id) ?? id)
         : `${type}:${id}`;
 
     if (type === "agent") governedAgentIds.add(id);

--- a/agentarea-webapp/src/app/(main)/policies/new/page.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/new/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import { PolicyEditorPageData } from "../components/PolicyEditorPageData";
+
+export const metadata: Metadata = {
+  title: "New Policy",
+};
+
+export default function NewPolicyPage() {
+  return <PolicyEditorPageData />;
+}

--- a/agentarea-webapp/src/components/AgentAvatar.tsx
+++ b/agentarea-webapp/src/components/AgentAvatar.tsx
@@ -1,20 +1,22 @@
 import { createElement } from "react";
 import {
-  type AgentColorToken,
   agentColorVar,
   agentColorVarSoft,
   getAgentIconComponent,
   resolveAgentIdentity,
+  type AgentColorToken,
 } from "@/lib/agent-identity";
 import { cn } from "@/lib/utils";
 
+export type AgentAvatarAgent = {
+  id: string;
+  name?: string | null;
+  icon?: string | null;
+  color_token?: string | null;
+};
+
 type AgentAvatarProps = {
-  agent: {
-    id: string;
-    name?: string | null;
-    icon?: string | null;
-    color_token?: string | null;
-  };
+  agent: AgentAvatarAgent;
   size?: "xs" | "sm" | "md" | "lg";
   className?: string;
   status?: "idle" | "running" | "hitl" | "error" | "paused" | null;

--- a/agentarea-webapp/src/components/AgentIdentity.tsx
+++ b/agentarea-webapp/src/components/AgentIdentity.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { AgentAvatar, type AgentAvatarAgent } from "@/components/AgentAvatar";
+import { cn } from "@/lib/utils";
+
+interface AgentIdentityProps {
+  agent: AgentAvatarAgent;
+  size?: "xs" | "sm" | "md";
+  meta?: string | null;
+  right?: ReactNode;
+  className?: string;
+}
+
+const AVATAR_SIZE: Record<
+  NonNullable<AgentIdentityProps["size"]>,
+  "xs" | "sm" | "md"
+> = {
+  xs: "xs",
+  sm: "sm",
+  md: "md",
+};
+
+export function AgentIdentity({
+  agent,
+  size = "sm",
+  meta,
+  right,
+  className,
+}: AgentIdentityProps) {
+  return (
+    <div className={cn("flex min-w-0 items-center gap-2", className)}>
+      <AgentAvatar agent={agent} size={AVATAR_SIZE[size]} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm text-foreground">
+          {agent.name || agent.id}
+        </div>
+        {meta && (
+          <div className="truncate text-xs text-muted-foreground">{meta}</div>
+        )}
+      </div>
+      {right && <div className="shrink-0">{right}</div>}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/lib/getAuthContext.ts
+++ b/agentarea-webapp/src/lib/getAuthContext.ts
@@ -25,6 +25,26 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
   }
 }
 
+function getStringClaim(
+  payload: Record<string, unknown> | null,
+  key: string
+): string | null {
+  const value = payload?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function getNameClaim(payload: Record<string, unknown> | null): string | null {
+  const value = payload?.name;
+  if (typeof value === "string" && value.length > 0) return value;
+  if (!value || typeof value !== "object") return null;
+
+  const name = value as { first?: unknown; last?: unknown };
+  const parts = [name.first, name.last].filter(
+    (part): part is string => typeof part === "string" && part.length > 0
+  );
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
 async function getAuthContextImpl(): Promise<AuthContext> {
   const token = await getAuthToken();
   if (!token) {
@@ -38,10 +58,10 @@ async function getAuthContextImpl(): Promise<AuthContext> {
   }
 
   const payload = decodeJwtPayload(token);
-  const userId = (payload?.sub as string) ?? null;
-  const email = (payload?.email as string) ?? null;
-  const name = (payload?.name as string) ?? null;
-  const username = (payload?.username as string) ?? null;
+  const userId = getStringClaim(payload, "sub");
+  const email = getStringClaim(payload, "email");
+  const name = getNameClaim(payload);
+  const username = getStringClaim(payload, "username");
   // The backend falls back to user_id when the token has no workspace_id claim
   // (each user gets their own personal workspace by default).
   const workspaceId = (payload?.workspace_id as string) ?? userId;

--- a/agentarea-webapp/src/lib/mcp/resolveMcpRef.ts
+++ b/agentarea-webapp/src/lib/mcp/resolveMcpRef.ts
@@ -19,6 +19,7 @@ export interface McpAvailableTool {
   name: string;
   display_name?: string;
   description?: string;
+  inputSchema?: unknown;
 }
 
 export type McpRefResolution =
@@ -54,6 +55,8 @@ function toAvailableTools(raw: unknown): McpAvailableTool[] {
         name: string;
         display_name?: unknown;
         description?: unknown;
+        inputSchema?: unknown;
+        input_schema?: unknown;
       };
       tools.push({
         name: t.name,
@@ -61,6 +64,7 @@ function toAvailableTools(raw: unknown): McpAvailableTool[] {
           typeof t.display_name === "string" ? t.display_name : undefined,
         description:
           typeof t.description === "string" ? t.description : undefined,
+        inputSchema: t.inputSchema ?? t.input_schema,
       });
     }
   }


### PR DESCRIPTION
## Overview

This PR fixes the `/members` page for personal workspaces and reworks workspace
membership to be graph-owned, then rebuilds the `/policies` editor into a
full-page, rule-stack control surface.

## Members & workspace membership

- Fix `/members` rendering when the Kratos/OpenID `name` claim is an object
  instead of a string.
- Move workspace membership operations into
  `agentarea_common.workspaces.memberships`, backed by the configured
  relationship graph (Keto/OpenFGA), with product-level names: `grant`,
  `revoke`, `list`, `check`.
- Remove the DB membership fallback from members/invitations, workspace
  listing, and request-boundary accessible-workspace resolution; invitation
  tables now hold invitation state only.
- Make graph grant/revoke idempotent so repeated page loads no longer fail on
  existing tuples.

## Policy editor

- Replace the modal editor with URL-addressable `/policies/new` and
  `/policies/{policyId}` pages, including an affected-agents panel.
- Remodel the editor as a rule stack: target selection lives in the header,
  `+ Add rule` composes mixed rule types, and each draft rule owns its enabled
  state.
- Default to all agents, with an opt-in `Selected agents` list.
- Resolve tool scope from concrete MCP/OpenAPI operations (names, source,
  descriptions, schema parameter chips) and support structured
  parameter-condition authoring; keep raw custom selectors behind an advanced
  affordance.
- Make approval rules operation-scoped only: explicit tool selection is
  required and `target=*` approval rules can no longer be authored from the UI.
- Replace the approver shortcut with a selector for concrete workspace members
  plus structured role/group subject refs.
- Add a shared `AgentIdentity` component so selectors and affected-agent lists
  render consistent agent icons, labels, and metadata.
- Restyle as an industrial blueprint surface with section indices, a quiet grid
  background, and a compiled-output readout in the impact rail.
- User-facing copy: `Cap` -> `Budget` and `Per run` -> `Per task`, while the
  underlying policy payload (`effect=cap`, `period=run`) is unchanged.

## Notes

- Parameter conditions are authored and stored on `PolicyRule.condition`;
  runtime enforcement still requires the governance engine to evaluate rule
  conditions before tool execution.

## Verification

- Backend: `ruff check`, `ruff format --check`, and `pyright` pass on the
  changed scope; `pytest` for workspace unit/integration tests.
- Frontend: `eslint`, `prettier --check`, and `tsc --noEmit` pass on the
  changed files.
- `schema.d.ts` regenerated to match the backend OpenAPI spec.
- Manually browser-tested `/members`, `/policies`, and `/policies/new`.
