### PR TITLE
feat(a2a): correct result flow + clean cutover to A2A v1.0.0 with push notifications

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/a2a_validation.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/a2a_validation.py
@@ -66,13 +66,17 @@ class A2AValidator:
     """A2A protocol validator."""
 
     SUPPORTED_METHODS: ClassVar[set[str]] = {
-        "message/send",
-        "message/stream",
-        "tasks/get",
-        "tasks/cancel",
-        "tasks/resubscribe",
-        "tasks/list",
-        "agent/authenticatedExtendedCard",
+        "SendMessage",
+        "SendStreamingMessage",
+        "GetTask",
+        "CancelTask",
+        "SubscribeToTask",
+        "ListTasks",
+        "CreateTaskPushNotificationConfig",
+        "GetTaskPushNotificationConfig",
+        "ListTaskPushNotificationConfigs",
+        "DeleteTaskPushNotificationConfig",
+        "GetExtendedAgentCard",
     }
 
     @classmethod
@@ -136,9 +140,13 @@ class A2AValidator:
         """Validate request content type."""
         content_type = request.headers.get("content-type", "")
 
-        if not content_type.startswith("application/json"):
+        if not (
+            content_type.startswith("application/json")
+            or content_type.startswith("application/a2a+json")
+        ):
             raise A2AValidationError(
-                f"Invalid content type: {content_type}. Expected: application/json",
+                f"Invalid content type: {content_type}. "
+                "Expected: application/json or application/a2a+json",
                 "INVALID_CONTENT_TYPE",
             )
 
@@ -158,11 +166,11 @@ class A2AValidator:
         json_rpc_request = cls.validate_json_rpc_request(body)
 
         # Validate method-specific parameters
-        if json_rpc_request.method in ["message/send", "message/stream"]:
+        if json_rpc_request.method in ["SendMessage", "SendStreamingMessage"]:
             if json_rpc_request.params:
                 cls.validate_message_send_params(json_rpc_request.params)
 
-        elif json_rpc_request.method in ["tasks/get", "tasks/cancel", "tasks/resubscribe"]:
+        elif json_rpc_request.method in ["GetTask", "CancelTask", "SubscribeToTask"]:
             if json_rpc_request.params:
                 cls.validate_task_params(json_rpc_request.params)
 

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_a2a.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_a2a.py
@@ -23,6 +23,7 @@ from agentarea_agents.application.agent_service import AgentService
 from agentarea_api.api.deps.services import (
     get_agent_service,
     get_event_stream_service,
+    get_secret_manager,
     get_task_service,
 )
 from agentarea_api.api.v1.a2a_auth import (
@@ -33,6 +34,15 @@ from agentarea_api.api.v1.a2a_auth import (
 from agentarea_common.auth.context import UserContext
 from agentarea_common.auth.context_manager import ContextManager
 from agentarea_common.events.event_stream_service import EventStreamService
+from agentarea_common.infrastructure.secret_manager import BaseSecretManager
+from agentarea_common.utils.a2a_push import (
+    delete_push_config,
+    get_push_config,
+    list_push_configs,
+    push_token_secret_name,
+    task_push_config_result,
+    upsert_push_config,
+)
 from agentarea_common.utils.types import (
     AgentCapabilities,
     AgentCard,
@@ -55,12 +65,13 @@ from agentarea_common.utils.types import (
     TextPart,
 )
 from agentarea_common.utils.types import (
-    AuthenticatedExtendedCardResponse as AgentAuthenticatedExtendedCardResponse,
+    GetExtendedAgentCardResponse as AgentAuthenticatedExtendedCardResponse,
 )
 from agentarea_common.utils.types import (
     MessageSendResponse as SendMessageResponse,
 )
-from agentarea_tasks.domain.models import AgentTask
+from agentarea_common.utils.url_safety import UnsafeUrlError, validate_outbound_url
+from agentarea_tasks.domain.models import AgentTask, TaskUpdate
 from agentarea_tasks.task_service import TaskService
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
@@ -306,7 +317,7 @@ def convert_a2a_message_to_task(
     message_content = ""
     if message_params.message and message_params.message.parts:
         for part in message_params.message.parts:
-            if isinstance(part, TextPart):
+            if part.text:
                 message_content += part.text
 
     # Extract proper user context from authentication
@@ -348,7 +359,7 @@ def convert_a2a_message_to_task(
             "message_parts_count": len(message_params.message.parts)
             if message_params.message and message_params.message.parts
             else 0,
-            "is_streaming": a2a_method == "message/stream",
+            "is_streaming": a2a_method == "SendStreamingMessage",
             "agent_target": str(agent_id),
         },
     }
@@ -388,39 +399,241 @@ def convert_a2a_message_to_task(
     )
 
 
-def convert_agent_task_to_a2a_task(task: AgentTask):
-    """Convert AgentTask to A2A protocol Task format with current workflow status."""
-    # Map AgentTask status to TaskState enum
-    task_state_mapping = {
-        "submitted": TaskState.SUBMITTED,
-        "pending": TaskState.SUBMITTED,
-        "running": TaskState.WORKING,
-        "working": TaskState.WORKING,
-        "input-required": TaskState.INPUT_REQUIRED,
-        "input_required": TaskState.INPUT_REQUIRED,
-        "auth-required": TaskState.AUTH_REQUIRED,
-        "auth_required": TaskState.AUTH_REQUIRED,
-        "completed": TaskState.COMPLETED,
-        "failed": TaskState.FAILED,
-        "rejected": TaskState.REJECTED,
-        "cancelled": TaskState.CANCELED,
-        "canceled": TaskState.CANCELED,
-    }
+_TASK_STATE_MAPPING = {
+    "submitted": TaskState.SUBMITTED,
+    "pending": TaskState.SUBMITTED,
+    "running": TaskState.WORKING,
+    "working": TaskState.WORKING,
+    "input-required": TaskState.INPUT_REQUIRED,
+    "input_required": TaskState.INPUT_REQUIRED,
+    "auth-required": TaskState.AUTH_REQUIRED,
+    "auth_required": TaskState.AUTH_REQUIRED,
+    "completed": TaskState.COMPLETED,
+    "failed": TaskState.FAILED,
+    "rejected": TaskState.REJECTED,
+    "cancelled": TaskState.CANCELED,
+    "canceled": TaskState.CANCELED,
+}
 
-    task_state = task_state_mapping.get(task.status, TaskState.SUBMITTED)
-    task_status = TaskStatus(state=task_state, message=None)
+
+def a2a_context_id_for_task(task: AgentTask) -> str:
+    """Return a stable, non-null A2A contextId for a task (spec requires non-null).
+
+    Prefer an explicit context id stored in metadata, else fall back to the task id.
+    """
+    meta = task.metadata or {}
+    return str(meta.get("a2a_context_id") or task.id)
+
+
+def extract_final_text_from_task(task: AgentTask) -> str | None:
+    """Extract the agent's final answer from a completed task.
+
+    Canonical source (see ADR 2026-06-20): ``task.result["response"]``, produced by the
+    Temporal workflow's ``state.final_response`` via ``get_task_with_workflow_status``.
+    Falls back to ``final_response``/stringified result for robustness.
+    """
+    result = task.result
+    if isinstance(result, dict):
+        for key in ("response", "final_response", "result", "text"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+        return None
+    if isinstance(result, str) and result.strip():
+        return result
+    return None
+
+
+def extract_text_from_event_data(event_data: dict[str, Any]) -> str:
+    """Pull text payload out of a streamed workflow event.
+
+    Events arrive as DomainEvent dicts; the original workflow payload is nested under
+    ``original_data`` (see ``publish_workflow_events_activity``). Final answers live in
+    ``result``/``final_response``; incremental LLM output lives in ``chunk``.
+    """
+    payload = event_data.get("original_data")
+    if not isinstance(payload, dict):
+        payload = event_data if isinstance(event_data, dict) else {}
+    for key in ("chunk", "content", "text", "result", "final_response", "delta"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+# Real workflow terminal event types (prefixed by EventStreamService as ``workflow.*``).
+_TERMINAL_EVENT_STATES = {
+    "workflow.WorkflowCompleted": TaskState.COMPLETED,
+    "workflow.WorkflowFailed": TaskState.FAILED,
+    "workflow.WorkflowCancelled": TaskState.CANCELED,
+    "WorkflowCompleted": TaskState.COMPLETED,
+    "WorkflowFailed": TaskState.FAILED,
+    "WorkflowCancelled": TaskState.CANCELED,
+}
+# Incremental output event types.
+_CHUNK_EVENT_TYPES = {"workflow.LLMCallChunk", "LLMCallChunk"}
+
+
+def _sse(response: JSONRPCResponse) -> str:
+    """Serialize a JSON-RPC response as an SSE ``data:`` frame."""
+    return f"data: {response.model_dump_json(by_alias=True)}\n\n"
+
+
+def map_workflow_event_to_sse(
+    event: dict[str, Any],
+    request_id: str | int | None,
+    task_id: str,
+    context_id: str | None,
+) -> tuple[list[str], bool]:
+    """Map a streamed workflow event to A2A SSE frames per ADR 2026-06-20.
+
+    Returns ``(frames, is_terminal)``. Terminal events emit a final artifact-update
+    (when text is present) followed by a final status-update with ``final=True``.
+    """
+    event_type = event.get("event_type", "")
+    event_data = event.get("event_data", {}) or {}
+    frames: list[str] = []
+
+    state = _TERMINAL_EVENT_STATES.get(event_type)
+    if state:
+        if state == TaskState.COMPLETED:
+            text = extract_text_from_event_data(event_data)
+            if text:
+                frames.append(
+                    _sse(
+                        JSONRPCResponse(
+                            id=request_id,
+                            result={
+                                "artifactUpdate": StreamResponseArtifactUpdate(
+                                    taskId=task_id,
+                                    contextId=context_id,
+                                    artifact=Artifact(
+                                        artifactId=task_id,
+                                        name="agent-response",
+                                        parts=[TextPart(text=text)],
+                                    ),
+                                    append=False,
+                                    lastChunk=True,
+                                ).model_dump(by_alias=True),
+                            },
+                        )
+                    )
+                )
+        frames.append(
+            _sse(
+                JSONRPCResponse(
+                    id=request_id,
+                    result={
+                        "statusUpdate": StreamResponseStatusUpdate(
+                            taskId=task_id,
+                            contextId=context_id,
+                            status=TaskStatus(state=state),
+                        ).model_dump(by_alias=True),
+                    },
+                )
+            )
+        )
+        return frames, True
+
+    if event_type in _CHUNK_EVENT_TYPES:
+        text = extract_text_from_event_data(event_data)
+        if text:
+            frames.append(
+                _sse(
+                    JSONRPCResponse(
+                        id=request_id,
+                        result={
+                            "artifactUpdate": StreamResponseArtifactUpdate(
+                                taskId=task_id,
+                                contextId=context_id,
+                                artifact=Artifact(
+                                    artifactId=task_id,
+                                    parts=[TextPart(text=text)],
+                                ),
+                                append=True,
+                                lastChunk=False,
+                            ).model_dump(by_alias=True),
+                        },
+                    )
+                )
+            )
+        return frames, False
+
+    # Any other workflow event → a working status update.
+    frames.append(
+        _sse(
+            JSONRPCResponse(
+                id=request_id,
+                result={
+                    "statusUpdate": StreamResponseStatusUpdate(
+                        taskId=task_id,
+                        contextId=context_id,
+                        status=TaskStatus(state=TaskState.WORKING),
+                    ).model_dump(by_alias=True),
+                },
+            )
+        )
+    )
+    return frames, False
+
+
+def convert_agent_task_to_a2a_task(task: AgentTask) -> Task:
+    """Convert AgentTask to A2A protocol Task, mapping the final result onto the wire.
+
+    For terminal-success tasks the final text is surfaced both as an ``Artifact`` and as
+    ``status.message`` so both rich and spec-minimal clients can read it.
+    """
+    task_state = _TASK_STATE_MAPPING.get(task.status, TaskState.SUBMITTED)
+    context_id = a2a_context_id_for_task(task)
+
+    artifacts: list[Artifact] | None = None
+    status_message: Message | None = None
+
+    if task_state == TaskState.COMPLETED:
+        final_text = extract_final_text_from_task(task)
+        if final_text:
+            artifacts = [
+                Artifact(
+                    artifactId=str(task.id),
+                    name="agent-response",
+                    parts=[TextPart(text=final_text)],
+                )
+            ]
+            status_message = Message(role="AGENT", parts=[TextPart(text=final_text)])
+    elif task_state in (TaskState.FAILED, TaskState.REJECTED):
+        error_text = getattr(task, "error_message", None) or extract_final_text_from_task(task)
+        if error_text:
+            status_message = Message(role="AGENT", parts=[TextPart(text=error_text)])
 
     return Task(
         id=str(task.id),
-        contextId=None,
-        status=task_status,
-        artifacts=None,
+        contextId=context_id,
+        status=TaskStatus(state=task_state, message=status_message),
+        artifacts=artifacts,
         history=None,
         metadata=task.metadata or {},
     )
 
 
-async def handle_task_send(request_id, params, task_service, agent_id, auth_context, agent_service):
+async def _maybe_register_send_push_config(
+    params, task_service, secret_manager, created_task
+) -> None:
+    """Register a push config supplied inline via configuration.pushNotificationConfig."""
+    if secret_manager is None:
+        return
+    # v1.0.0: flat config under configuration.taskPushNotificationConfig.
+    push_cfg = (params.get("configuration") or {}).get("taskPushNotificationConfig")
+    if not push_cfg or not push_cfg.get("url"):
+        return
+    try:
+        await register_push_config(task_service, secret_manager, created_task, push_cfg)
+    except A2AValidationError as e:
+        logger.warning(f"Ignoring invalid inline pushNotificationConfig: {e.message}")
+
+
+async def handle_task_send(
+    request_id, params, task_service, agent_id, auth_context, agent_service, secret_manager=None
+):
     """Handle A2A task/send method with proper TaskService integration and validation."""
     start_time = time.time()
 
@@ -439,7 +652,7 @@ async def handle_task_send(request_id, params, task_service, agent_id, auth_cont
 
         # Convert to task with proper metadata
         task = convert_a2a_message_to_task(
-            message_send_params, agent_id, auth_context, "tasks/send", request_id
+            message_send_params, agent_id, auth_context, "SendMessage", request_id
         )
 
         # Submit task through TaskService - this ensures Temporal workflow execution
@@ -468,17 +681,14 @@ async def handle_task_send(request_id, params, task_service, agent_id, auth_cont
             },
         )
 
-        # Create A2A protocol-compliant Task response
-        task_status = TaskStatus(state=TaskState.SUBMITTED, message=None)
-
-        a2a_task = Task(
-            id=str(created_task.id),
-            contextId=None,
-            status=task_status,
-            artifacts=None,
-            history=None,
-            metadata=created_task.metadata,
+        # Register an inline push webhook if the client supplied one.
+        await _maybe_register_send_push_config(
+            params, task_service, secret_manager, created_task
         )
+
+        # Create A2A protocol-compliant Task response (non-blocking: submitted state).
+        # Callers retrieve the final result via tasks/get polling or message/stream.
+        a2a_task = convert_agent_task_to_a2a_task(created_task)
 
         return SendMessageResponse(jsonrpc="2.0", id=request_id, result=a2a_task)
     except A2AValidationError as e:
@@ -533,7 +743,7 @@ async def handle_task_send(request_id, params, task_service, agent_id, auth_cont
 
 
 async def handle_message_send(
-    request_id, params, task_service, agent_id, auth_context, agent_service
+    request_id, params, task_service, agent_id, auth_context, agent_service, secret_manager=None
 ):
     """Handle A2A message/send method with proper TaskService integration and validation."""
     start_time = time.time()
@@ -563,7 +773,7 @@ async def handle_message_send(
             raise A2AValidationError("Message must contain non-empty text content", -32602)
 
         # Create validated message
-        message = Message(role="user", parts=[TextPart(text=text_content)])
+        message = Message(role="USER", parts=[TextPart(text=text_content)])
         # Include optional metadata from params (e.g., requires_human_approval)
         message_params = MessageSendParams(
             message=message, contextId=None, metadata=params.get("metadata")
@@ -571,7 +781,7 @@ async def handle_message_send(
 
         # Convert to task with proper metadata
         task = convert_a2a_message_to_task(
-            message_params, agent_id, auth_context, "message/send", request_id
+            message_params, agent_id, auth_context, "SendMessage", request_id
         )
 
         # Submit task through TaskService - this ensures Temporal workflow execution
@@ -601,17 +811,14 @@ async def handle_message_send(
             },
         )
 
-        # Create A2A protocol-compliant Task response
-        task_status = TaskStatus(state=TaskState.SUBMITTED, message=None)
-
-        a2a_task = Task(
-            id=str(created_task.id),
-            contextId=None,
-            status=task_status,
-            artifacts=None,
-            history=None,
-            metadata=created_task.metadata,
+        # Register an inline push webhook if the client supplied one.
+        await _maybe_register_send_push_config(
+            params, task_service, secret_manager, created_task
         )
+
+        # Create A2A protocol-compliant Task response (non-blocking: submitted state).
+        # Callers retrieve the final result via tasks/get polling or message/stream.
+        a2a_task = convert_agent_task_to_a2a_task(created_task)
 
         return SendMessageResponse(jsonrpc="2.0", id=request_id, result=a2a_task)
     except A2AValidationError as e:
@@ -674,6 +881,7 @@ async def handle_message_stream_sse(
     auth_context,
     agent_service,
     event_stream_service,
+    secret_manager=None,
 ) -> JSONRPCResponse | Response:
     """Handle A2A message/stream method with proper TaskService integration.
 
@@ -706,7 +914,7 @@ async def handle_message_stream_sse(
             raise A2AValidationError("Message must contain non-empty text content", -32602)
 
         # Create validated message
-        message = Message(role="user", parts=[TextPart(text=text_content)])
+        message = Message(role="USER", parts=[TextPart(text=text_content)])
         # Include optional metadata from params (e.g., requires_human_approval)
         message_params = MessageSendParams(
             message=message, contextId=None, metadata=params.get("metadata")
@@ -717,13 +925,18 @@ async def handle_message_stream_sse(
             message_params,
             agent_id,
             auth_context,
-            "message/stream",
+            "SendStreamingMessage",
             request_id,
             params.get("id"),  # Use provided task ID if available
         )
 
         # Submit task through TaskService - this ensures Temporal workflow execution
         created_task = await task_service.submit_task(task)
+
+        # Register an inline push webhook if the client supplied one.
+        await _maybe_register_send_push_config(
+            params, task_service, secret_manager, created_task
+        )
 
         # Calculate task creation duration
         task_creation_duration_ms = (time.time() - start_time) * 1000
@@ -750,90 +963,40 @@ async def handle_message_stream_sse(
             },
         )
 
+        task_context_id = a2a_context_id_for_task(created_task)
+
         async def event_stream():
-            """Stream events in A2A v0.3.0 SSE format."""
+            """Stream events in A2A v1.0.0 StreamResponse SSE format."""
             event_count = 0
             stream_start_time = time.time()
 
             try:
-                # 1. Send initial "task" event
+                # 1. Send initial "task" event (wrapped by member name)
                 initial = JSONRPCResponse(
                     id=request_id,
-                    result=StreamResponseTask(
-                        id=str(created_task.id),
-                        contextId=None,
-                        status=TaskStatus(state=TaskState.SUBMITTED),
-                    ).model_dump(by_alias=True),
+                    result={
+                        "task": StreamResponseTask(
+                            id=str(created_task.id),
+                            contextId=task_context_id,
+                            status=TaskStatus(state=TaskState.SUBMITTED),
+                        ).model_dump(by_alias=True),
+                    },
                 )
                 yield f"data: {initial.model_dump_json(by_alias=True)}\n\n"
                 event_count += 1
 
-                # 2. Stream workflow events
+                # 2. Stream workflow events, mapping each to A2A SSE frames
                 async for event in event_stream_service.stream_events_for_task(
                     created_task.id, event_patterns=["workflow.*"]
                 ):
                     event_count += 1
-                    event_type = event.get("event_type", "")
-                    event_data = event.get("event_data", {})
-
-                    # Map terminal workflow events to A2A states
-                    terminal_events = {
-                        "workflow.task_completed": TaskState.COMPLETED,
-                        "workflow.task_failed": TaskState.FAILED,
-                        "workflow.task_cancelled": TaskState.CANCELED,
-                        "task_completed": TaskState.COMPLETED,
-                        "task_failed": TaskState.FAILED,
-                        "task_cancelled": TaskState.CANCELED,
-                    }
-
-                    state = terminal_events.get(event_type)
-
-                    if state:
-                        # Terminal status update with final=True
-                        update = JSONRPCResponse(
-                            id=request_id,
-                            result=StreamResponseStatusUpdate(
-                                taskId=str(created_task.id),
-                                contextId=None,
-                                status=TaskStatus(state=state),
-                                final=True,
-                            ).model_dump(by_alias=True),
-                        )
-                        yield f"data: {update.model_dump_json(by_alias=True)}\n\n"
+                    frames, is_terminal = map_workflow_event_to_sse(
+                        event, request_id, str(created_task.id), task_context_id
+                    )
+                    for frame in frames:
+                        yield frame
+                    if is_terminal:
                         break
-                    elif "llm_response" in event_type or "content" in event_data:
-                        # Artifact update for LLM output
-                        content = event_data.get("content", event_data.get("text", ""))
-                        if content:
-                            from uuid import uuid4 as _uuid4
-
-                            artifact_evt = JSONRPCResponse(
-                                id=request_id,
-                                result=StreamResponseArtifactUpdate(
-                                    taskId=str(created_task.id),
-                                    contextId=None,
-                                    artifact=Artifact(
-                                        artifactId=str(_uuid4()),
-                                        parts=[TextPart(text=content)],
-                                        lastChunk=None,
-                                    ),
-                                    append=True,
-                                    lastChunk=False,
-                                ).model_dump(by_alias=True),
-                            )
-                            yield f"data: {artifact_evt.model_dump_json(by_alias=True)}\n\n"
-                    else:
-                        # Status update for other workflow events
-                        update = JSONRPCResponse(
-                            id=request_id,
-                            result=StreamResponseStatusUpdate(
-                                taskId=str(created_task.id),
-                                contextId=None,
-                                status=TaskStatus(state=TaskState.WORKING),
-                                final=False,
-                            ).model_dump(by_alias=True),
-                        )
-                        yield f"data: {update.model_dump_json(by_alias=True)}\n\n"
 
                 # Log streaming completion
                 stream_duration_ms = (time.time() - stream_start_time) * 1000
@@ -1169,21 +1332,41 @@ async def handle_task_resubscribe(
         if not task:
             return create_error_response(request_id, -32001, f"Task not found: {task_id}")
 
-        # If task already terminal, return final status
+        context_id = a2a_context_id_for_task(task)
+
+        # If task already terminal, replay the final result then a final status update.
         if task.status in ("completed", "failed", "cancelled", "canceled", "rejected"):
             a2a_task = convert_agent_task_to_a2a_task(task)
 
             async def done_stream():
-                final = JSONRPCResponse(
-                    id=request_id,
-                    result=StreamResponseStatusUpdate(
-                        taskId=str(task_id),
-                        contextId=None,
-                        status=a2a_task.status,
-                        final=True,
-                    ).model_dump(by_alias=True),
+                if a2a_task.artifacts:
+                    for artifact in a2a_task.artifacts:
+                        yield _sse(
+                            JSONRPCResponse(
+                                id=request_id,
+                                result={
+                                    "artifactUpdate": StreamResponseArtifactUpdate(
+                                        taskId=str(task_id),
+                                        contextId=context_id,
+                                        artifact=artifact,
+                                        append=False,
+                                        lastChunk=True,
+                                    ).model_dump(by_alias=True),
+                                },
+                            )
+                        )
+                yield _sse(
+                    JSONRPCResponse(
+                        id=request_id,
+                        result={
+                            "statusUpdate": StreamResponseStatusUpdate(
+                                taskId=str(task_id),
+                                contextId=context_id,
+                                status=a2a_task.status,
+                            ).model_dump(by_alias=True),
+                        },
+                    )
                 )
-                yield f"data: {final.model_dump_json(by_alias=True)}\n\n"
 
             return StreamingResponse(
                 done_stream(),
@@ -1196,60 +1379,13 @@ async def handle_task_resubscribe(
             async for event in event_stream_service.stream_events_for_task(
                 task_id, event_patterns=["workflow.*"]
             ):
-                event_type = event.get("event_type", "")
-                event_data = event.get("event_data", {})
-
-                terminal_events = {
-                    "workflow.task_completed": TaskState.COMPLETED,
-                    "workflow.task_failed": TaskState.FAILED,
-                    "workflow.task_cancelled": TaskState.CANCELED,
-                    "task_completed": TaskState.COMPLETED,
-                    "task_failed": TaskState.FAILED,
-                    "task_cancelled": TaskState.CANCELED,
-                }
-
-                state = terminal_events.get(event_type)
-                if state:
-                    update = JSONRPCResponse(
-                        id=request_id,
-                        result=StreamResponseStatusUpdate(
-                            taskId=str(task_id),
-                            contextId=None,
-                            status=TaskStatus(state=state),
-                            final=True,
-                        ).model_dump(by_alias=True),
-                    )
-                    yield f"data: {update.model_dump_json(by_alias=True)}\n\n"
+                frames, is_terminal = map_workflow_event_to_sse(
+                    event, request_id, str(task_id), context_id
+                )
+                for frame in frames:
+                    yield frame
+                if is_terminal:
                     break
-                elif "llm_response" in event_type or "content" in event_data:
-                    content = event_data.get("content", event_data.get("text", ""))
-                    if content:
-                        artifact_evt = JSONRPCResponse(
-                            id=request_id,
-                            result=StreamResponseArtifactUpdate(
-                                taskId=str(task_id),
-                                contextId=None,
-                                artifact=Artifact(
-                                    artifactId=str(uuid4()),
-                                    parts=[TextPart(text=content)],
-                                    lastChunk=None,
-                                ),
-                                append=True,
-                                lastChunk=False,
-                            ).model_dump(by_alias=True),
-                        )
-                        yield f"data: {artifact_evt.model_dump_json(by_alias=True)}\n\n"
-                else:
-                    update = JSONRPCResponse(
-                        id=request_id,
-                        result=StreamResponseStatusUpdate(
-                            taskId=str(task_id),
-                            contextId=None,
-                            status=TaskStatus(state=TaskState.WORKING),
-                            final=False,
-                        ).model_dump(by_alias=True),
-                    )
-                    yield f"data: {update.model_dump_json(by_alias=True)}\n\n"
 
         return StreamingResponse(
             event_stream(),
@@ -1276,8 +1412,144 @@ async def handle_task_list(request_id, params, task_service, agent_id, auth_cont
     return JSONRPCResponse(jsonrpc="2.0", id=request_id, result=a2a_tasks)
 
 
+async def register_push_config(
+    task_service,
+    secret_manager: BaseSecretManager,
+    task,
+    push_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate, persist (non-secret in task_parameters, token in secret store), and
+    return a stored push config dict. Raises A2AValidationError on bad input.
+    """
+    url = push_config.get("url")
+    if not url:
+        raise A2AValidationError("pushNotificationConfig.url is required", -32602)
+    try:
+        validate_outbound_url(url)
+    except UnsafeUrlError as e:
+        raise A2AValidationError(f"Unsafe webhook url: {e}", -32602) from e
+
+    new_params, stored = upsert_push_config(
+        task.task_parameters, url, push_config.get("id")
+    )
+    token = push_config.get("token")
+    if token:
+        await secret_manager.set_secret(
+            push_token_secret_name(str(task.id), stored["id"]), token
+        )
+    await task_service.task_repository.update_by_id(
+        task.id, TaskUpdate(task_parameters=new_params)
+    )
+    return stored
+
+
+async def handle_push_config_set(
+    request_id, params, task_service, agent_id, auth_context, secret_manager
+):
+    """Handle CreateTaskPushNotificationConfig (flat v1.0.0 params)."""
+    set_user_context_from_a2a_auth(auth_context)
+    task_id = params.get("taskId")
+    # v1.0.0 config is flat: {taskId, id?, url, token?, ...}
+    push_config = {
+        "id": params.get("id"),
+        "url": params.get("url"),
+        "token": params.get("token"),
+    }
+    if not task_id:
+        return create_error_response(request_id, -32602, "Missing required parameter: taskId")
+    try:
+        task = await task_service.get_task(UUID(task_id))
+    except ValueError:
+        return create_error_response(request_id, -32602, f"Invalid task ID: {task_id}")
+    if not task:
+        return create_error_response(request_id, -32001, f"Task not found: {task_id}")
+    try:
+        stored = await register_push_config(task_service, secret_manager, task, push_config)
+    except A2AValidationError as e:
+        return create_error_response(request_id, e.code, e.message)
+    return JSONRPCResponse(
+        jsonrpc="2.0", id=request_id, result=task_push_config_result(task_id, stored)
+    )
+
+
+async def handle_push_config_get(request_id, params, task_service, agent_id, auth_context):
+    """Handle tasks/pushNotificationConfig/get."""
+    set_user_context_from_a2a_auth(auth_context)
+    task_id = params.get("id") or params.get("taskId")
+    config_id = params.get("pushNotificationConfigId")
+    if not task_id:
+        return create_error_response(request_id, -32602, "Missing required parameter: id")
+    try:
+        task = await task_service.get_task(UUID(task_id))
+    except ValueError:
+        return create_error_response(request_id, -32602, f"Invalid task ID: {task_id}")
+    if not task:
+        return create_error_response(request_id, -32001, f"Task not found: {task_id}")
+
+    if config_id:
+        cfg = get_push_config(task.task_parameters, config_id)
+    else:
+        configs = list_push_configs(task.task_parameters)
+        cfg = configs[0] if configs else None
+    if not cfg:
+        return create_error_response(request_id, -32001, "Push notification config not found")
+    return JSONRPCResponse(
+        jsonrpc="2.0", id=request_id, result=task_push_config_result(task_id, cfg)
+    )
+
+
+async def handle_push_config_list(request_id, params, task_service, agent_id, auth_context):
+    """Handle tasks/pushNotificationConfig/list — array of configs for a task."""
+    set_user_context_from_a2a_auth(auth_context)
+    task_id = params.get("id") or params.get("taskId")
+    if not task_id:
+        return create_error_response(request_id, -32602, "Missing required parameter: id")
+    try:
+        task = await task_service.get_task(UUID(task_id))
+    except ValueError:
+        return create_error_response(request_id, -32602, f"Invalid task ID: {task_id}")
+    if not task:
+        return create_error_response(request_id, -32001, f"Task not found: {task_id}")
+    result = [
+        task_push_config_result(task_id, cfg) for cfg in list_push_configs(task.task_parameters)
+    ]
+    return JSONRPCResponse(jsonrpc="2.0", id=request_id, result=result)
+
+
+async def handle_push_config_delete(
+    request_id, params, task_service, agent_id, auth_context, secret_manager
+):
+    """Handle tasks/pushNotificationConfig/delete — returns null on success."""
+    set_user_context_from_a2a_auth(auth_context)
+    task_id = params.get("id") or params.get("taskId")
+    config_id = params.get("pushNotificationConfigId")
+    if not task_id or not config_id:
+        return create_error_response(
+            request_id, -32602, "Missing required parameters: id, pushNotificationConfigId"
+        )
+    try:
+        task = await task_service.get_task(UUID(task_id))
+    except ValueError:
+        return create_error_response(request_id, -32602, f"Invalid task ID: {task_id}")
+    if not task:
+        return create_error_response(request_id, -32001, f"Task not found: {task_id}")
+
+    new_params, removed = delete_push_config(task.task_parameters, config_id)
+    if removed:
+        await task_service.task_repository.update_by_id(
+            task.id, TaskUpdate(task_parameters=new_params)
+        )
+        try:
+            await secret_manager.set_secret(
+                push_token_secret_name(str(task_id), config_id), ""
+            )
+        except Exception:  # noqa: S110 — token cleanup is best-effort
+            pass
+    return JSONRPCResponse(jsonrpc="2.0", id=request_id, result=None)
+
+
 async def handle_agent_card(request_id, params, agent_service, agent_id, base_url, auth_context):
-    """Handle A2A agent/authenticatedExtendedCard method.
+    """Handle A2A GetExtendedAgentCard method.
 
     Includes current agent data and proper validation.
     """
@@ -1298,9 +1570,8 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
         # Build current capabilities based on agent configuration
         capabilities = AgentCapabilities(
             streaming=True,  # All agents support streaming through A2A
-            pushNotifications=False,  # Not currently supported
-            stateTransitionHistory=True,  # Supported through Temporal workflows
-            extendedAgentCard=True,
+            pushNotifications=True,  # Webhook push via channel-delivery pipeline
+            extendedAgentCard=True,  # GetExtendedAgentCard supported
         )
 
         # Build skills based on agent configuration and tools
@@ -1312,6 +1583,7 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
                 id="text-processing",
                 name="Text Processing",
                 description=f"Process and respond to text messages using {agent.name}",
+                tags=["text", "chat"],
                 inputModes=["text"],
                 outputModes=["text"],
             )
@@ -1324,6 +1596,7 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
                     id="tool-execution",
                     name="Tool Execution",
                     description=f"Execute tools and integrations using {agent.name}",
+                    tags=["tools", "integration"],
                     inputModes=["text"],
                     outputModes=["text", "data"],
                 )
@@ -1336,6 +1609,7 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
                     id="task-planning",
                     name="Task Planning",
                     description=f"Break down complex tasks into steps using {agent.name}",
+                    tags=["planning"],
                     inputModes=["text"],
                     outputModes=["text"],
                 )
@@ -1363,7 +1637,7 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
                 "has_planning": bool(agent.planning),
                 "skills_count": len(skills),
                 "base_url": base_url,
-                "capabilities": ["streaming", "state_transition_history"],
+                "capabilities": ["streaming", "pushNotifications", "extendedAgentCard"],
             },
         )
 
@@ -1380,16 +1654,12 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
         agent_card = AgentCard(
             name=agent.name,
             description=enhanced_description,
-            url=rpc_url,
             supportedInterfaces=[
                 AgentInterface(
-                    url=rpc_url,
-                    protocolBinding="JSONRPC",
-                    protocolVersion="1.0",
+                    url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0"
                 )
             ],
             version="1.0.0",
-            protocolVersion="0.3.0",
             provider=AgentProvider(
                 organization="AgentArea", url=f"{base_url}/api/v1/agents/{agent_id}"
             ),
@@ -1398,7 +1668,6 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
             defaultInputModes=["text/plain", "application/json"],
             defaultOutputModes=["text/plain", "application/json"],
             skills=skills,
-            supportsAuthenticatedExtendedCard=True,
             securitySchemes=None,
         )
         return AgentAuthenticatedExtendedCardResponse(
@@ -1441,17 +1710,15 @@ async def _dispatch_rpc_method(
     agent_id,
     auth_context,
     event_stream_service,
+    secret_manager,
 ):
     """Dispatch A2A RPC method calls with proper error handling."""
     base_url = f"{request.url.scheme}://{request.url.netloc}" if request else None
     handlers = {
-        "tasks/send": lambda: handle_task_send(
-            request_id, params, task_service, agent_id, auth_context, agent_service
+        "SendMessage": lambda: handle_message_send(
+            request_id, params, task_service, agent_id, auth_context, agent_service, secret_manager
         ),
-        "message/send": lambda: handle_message_send(
-            request_id, params, task_service, agent_id, auth_context, agent_service
-        ),
-        "message/stream": lambda: handle_message_stream_sse(
+        "SendStreamingMessage": lambda: handle_message_stream_sse(
             request,
             request_id,
             params,
@@ -1460,20 +1727,33 @@ async def _dispatch_rpc_method(
             auth_context,
             agent_service,
             event_stream_service,
+            secret_manager,
         ),
-        "tasks/get": lambda: handle_task_get(
+        "GetTask": lambda: handle_task_get(
             request_id, params, task_service, agent_id, auth_context
         ),
-        "tasks/cancel": lambda: handle_task_cancel(
+        "CancelTask": lambda: handle_task_cancel(
             request_id, params, task_service, agent_id, auth_context
         ),
-        "tasks/resubscribe": lambda: handle_task_resubscribe(
+        "SubscribeToTask": lambda: handle_task_resubscribe(
             request, request_id, params, task_service, agent_id, auth_context, event_stream_service
         ),
-        "tasks/list": lambda: handle_task_list(
+        "ListTasks": lambda: handle_task_list(
             request_id, params, task_service, agent_id, auth_context
         ),
-        "agent/authenticatedExtendedCard": lambda: handle_agent_card(
+        "CreateTaskPushNotificationConfig": lambda: handle_push_config_set(
+            request_id, params, task_service, agent_id, auth_context, secret_manager
+        ),
+        "GetTaskPushNotificationConfig": lambda: handle_push_config_get(
+            request_id, params, task_service, agent_id, auth_context
+        ),
+        "ListTaskPushNotificationConfigs": lambda: handle_push_config_list(
+            request_id, params, task_service, agent_id, auth_context
+        ),
+        "DeleteTaskPushNotificationConfig": lambda: handle_push_config_delete(
+            request_id, params, task_service, agent_id, auth_context, secret_manager
+        ),
+        "GetExtendedAgentCard": lambda: handle_agent_card(
             request_id, params, agent_service, agent_id, base_url, auth_context
         ),
     }
@@ -1501,6 +1781,7 @@ async def handle_agent_jsonrpc(
     task_service: TaskService = Depends(get_task_service),
     agent_service: AgentService = Depends(get_agent_service),
     event_stream_service: EventStreamService = Depends(get_event_stream_service),
+    secret_manager: BaseSecretManager = Depends(get_secret_manager),
 ) -> JSONRPCResponse | Response:
     """Handle A2A JSON-RPC requests with comprehensive error handling and validation."""
     request_start_time = time.time()
@@ -1534,13 +1815,22 @@ async def handle_agent_jsonrpc(
             )
             return create_error_response(None, -32700, "Parse error: Invalid JSON")
 
-        # Check A2A-Version header
-        a2a_version = request.headers.get("a2a-version")
-        if a2a_version and not (a2a_version.startswith("0.3") or a2a_version.startswith("1.")):
+        # A2A v1.0.0: read the A2A-Version header. Absent → treat as 1.0 (we only
+        # serve 1.0). Present and not starting with "1." → version not supported.
+        a2a_version = request.headers.get("A2A-Version")
+        if a2a_version is not None and not a2a_version.startswith("1."):
+            log_a2a_operation(
+                "rpc_request",
+                agent_id,
+                auth_context,
+                request_data.get("id"),
+                status="failed",
+                error=f"Unsupported A2A version: {a2a_version}",
+            )
             return create_error_response(
                 request_data.get("id"),
-                -32007,
-                f"Unsupported A2A version: {a2a_version}. Supported: 0.3.x, 1.x",
+                -32009,
+                f"A2A version not supported: {a2a_version}",
             )
 
         # Validate JSON-RPC request structure
@@ -1585,7 +1875,7 @@ async def handle_agent_jsonrpc(
 
         # Set user context from A2A auth for repository layer
         # (for methods that don't set it themselves)
-        if method not in ["tasks/send", "message/send", "message/stream"]:
+        if method not in ["SendMessage", "SendStreamingMessage"]:
             set_user_context_from_a2a_auth(auth_context)
 
         # Dispatch to method handler
@@ -1599,6 +1889,7 @@ async def handle_agent_jsonrpc(
             agent_id=agent_id,
             auth_context=auth_context,
             event_stream_service=event_stream_service,
+            secret_manager=secret_manager,
         )
 
         # Calculate total request duration
@@ -1698,9 +1989,8 @@ async def get_agent_well_known(
         # Build current capabilities based on agent configuration
         capabilities = AgentCapabilities(
             streaming=True,  # All agents support streaming through A2A
-            pushNotifications=False,  # Not currently supported
-            stateTransitionHistory=True,  # Supported through Temporal workflows
-            extendedAgentCard=True,
+            pushNotifications=True,  # Webhook push via channel-delivery pipeline
+            extendedAgentCard=True,  # GetExtendedAgentCard supported
         )
 
         # Build skills based on current agent configuration and tools
@@ -1712,6 +2002,7 @@ async def get_agent_well_known(
                 id="text-processing",
                 name="Text Processing",
                 description=f"Process and respond to text messages using {agent.name}",
+                tags=["text", "chat"],
                 inputModes=["text"],
                 outputModes=["text"],
             )
@@ -1724,6 +2015,7 @@ async def get_agent_well_known(
                     id="tool-execution",
                     name="Tool Execution",
                     description=f"Execute tools and integrations using {agent.name}",
+                    tags=["tools", "integration"],
                     inputModes=["text"],
                     outputModes=["text", "data"],
                 )
@@ -1736,6 +2028,7 @@ async def get_agent_well_known(
                     id="task-planning",
                     name="Task Planning",
                     description=f"Break down complex tasks into steps using {agent.name}",
+                    tags=["planning"],
                     inputModes=["text"],
                     outputModes=["text"],
                 )
@@ -1760,7 +2053,7 @@ async def get_agent_well_known(
                     agent.tools and isinstance(agent.tools, list) and len(agent.tools) > 0
                 ),
                 "has_planning": bool(agent.planning),
-                "capabilities": ["streaming", "state_transition_history"],
+                "capabilities": ["streaming", "pushNotifications", "extendedAgentCard"],
                 "skills_count": len(skills),
             },
         )
@@ -1778,23 +2071,18 @@ async def get_agent_well_known(
         agent_card = AgentCard(
             name=agent.name,
             description=enhanced_description,
-            url=rpc_url,
             supportedInterfaces=[
                 AgentInterface(
-                    url=rpc_url,
-                    protocolBinding="JSONRPC",
-                    protocolVersion="1.0",
+                    url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0"
                 )
             ],
             version="1.0.0",
-            protocolVersion="0.3.0",
             provider=AgentProvider(organization="AgentArea", url=f"/api/v1/agents/{agent_id}"),
             documentationUrl=None,
             capabilities=capabilities,
             defaultInputModes=["text/plain", "application/json"],
             defaultOutputModes=["text/plain", "application/json"],
             skills=skills,
-            supportsAuthenticatedExtendedCard=True,
             securitySchemes=None,
         )
         return agent_card

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_a2a.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_a2a.py
@@ -682,9 +682,7 @@ async def handle_task_send(
         )
 
         # Register an inline push webhook if the client supplied one.
-        await _maybe_register_send_push_config(
-            params, task_service, secret_manager, created_task
-        )
+        await _maybe_register_send_push_config(params, task_service, secret_manager, created_task)
 
         # Create A2A protocol-compliant Task response (non-blocking: submitted state).
         # Callers retrieve the final result via tasks/get polling or message/stream.
@@ -812,9 +810,7 @@ async def handle_message_send(
         )
 
         # Register an inline push webhook if the client supplied one.
-        await _maybe_register_send_push_config(
-            params, task_service, secret_manager, created_task
-        )
+        await _maybe_register_send_push_config(params, task_service, secret_manager, created_task)
 
         # Create A2A protocol-compliant Task response (non-blocking: submitted state).
         # Callers retrieve the final result via tasks/get polling or message/stream.
@@ -934,9 +930,7 @@ async def handle_message_stream_sse(
         created_task = await task_service.submit_task(task)
 
         # Register an inline push webhook if the client supplied one.
-        await _maybe_register_send_push_config(
-            params, task_service, secret_manager, created_task
-        )
+        await _maybe_register_send_push_config(params, task_service, secret_manager, created_task)
 
         # Calculate task creation duration
         task_creation_duration_ms = (time.time() - start_time) * 1000
@@ -1429,17 +1423,11 @@ async def register_push_config(
     except UnsafeUrlError as e:
         raise A2AValidationError(f"Unsafe webhook url: {e}", -32602) from e
 
-    new_params, stored = upsert_push_config(
-        task.task_parameters, url, push_config.get("id")
-    )
+    new_params, stored = upsert_push_config(task.task_parameters, url, push_config.get("id"))
     token = push_config.get("token")
     if token:
-        await secret_manager.set_secret(
-            push_token_secret_name(str(task.id), stored["id"]), token
-        )
-    await task_service.task_repository.update_by_id(
-        task.id, TaskUpdate(task_parameters=new_params)
-    )
+        await secret_manager.set_secret(push_token_secret_name(str(task.id), stored["id"]), token)
+    await task_service.task_repository.update_by_id(task.id, TaskUpdate(task_parameters=new_params))
     return stored
 
 
@@ -1540,9 +1528,7 @@ async def handle_push_config_delete(
             task.id, TaskUpdate(task_parameters=new_params)
         )
         try:
-            await secret_manager.set_secret(
-                push_token_secret_name(str(task_id), config_id), ""
-            )
+            await secret_manager.set_secret(push_token_secret_name(str(task_id), config_id), "")
         except Exception:  # noqa: S110 — token cleanup is best-effort
             pass
     return JSONRPCResponse(jsonrpc="2.0", id=request_id, result=None)
@@ -1655,9 +1641,7 @@ async def handle_agent_card(request_id, params, agent_service, agent_id, base_ur
             name=agent.name,
             description=enhanced_description,
             supportedInterfaces=[
-                AgentInterface(
-                    url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0"
-                )
+                AgentInterface(url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0")
             ],
             version="1.0.0",
             provider=AgentProvider(
@@ -2072,9 +2056,7 @@ async def get_agent_well_known(
             name=agent.name,
             description=enhanced_description,
             supportedInterfaces=[
-                AgentInterface(
-                    url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0"
-                )
+                AgentInterface(url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0")
             ],
             version="1.0.0",
             provider=AgentProvider(organization="AgentArea", url=f"/api/v1/agents/{agent_id}"),

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_well_known.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_well_known.py
@@ -61,29 +61,21 @@ async def create_agent_card_for_agent(agent, base_url: str, agent_id: UUID) -> A
     rpc_url = f"{base_url}/v1/agents/{agent_id}/a2a/rpc"
     return AgentCard(
         name=agent.name,
-        description=agent.description,
-        url=rpc_url,
+        description=agent.description or f"AI agent {agent.name}",
         supportedInterfaces=[
-            AgentInterface(
-                url=rpc_url,
-                protocolBinding="JSONRPC",
-                protocolVersion="1.0",
-            )
+            AgentInterface(url=rpc_url, protocolBinding="JSONRPC", protocolVersion="1.0")
         ],
         version="1.0.0",
-        protocolVersion="0.3.0",
         documentationUrl=f"{base_url}/v1/agents/{agent_id}/.well-known/a2a-info.json",
         capabilities=AgentCapabilities(
             streaming=True,
-            pushNotifications=False,
-            stateTransitionHistory=True,
+            pushNotifications=True,
             extendedAgentCard=True,
             extensions=extensions,
         ),
-        provider=AgentProvider(organization="AgentArea"),
+        provider=AgentProvider(organization="AgentArea", url=base_url),
         defaultInputModes=["text/plain", "application/json"],
         defaultOutputModes=["text/plain", "application/json"],
-        supportsAuthenticatedExtendedCard=True,
         securitySchemes={
             "bearer": {
                 "type": "http",
@@ -96,6 +88,7 @@ async def create_agent_card_for_agent(agent, base_url: str, agent_id: UUID) -> A
                 id="text-processing",
                 name="Text Processing",
                 description=f"Process and respond to text messages using {agent.name}",
+                tags=["text", "chat"],
                 inputModes=["text/plain"],
                 outputModes=["text/plain"],
             )
@@ -162,7 +155,7 @@ async def get_agent_a2a_info(
 
         return {
             "protocol": "A2A",
-            "version": "0.3.0",
+            "version": "1.0.0",
             "server": "AgentArea",
             "agent": {
                 "id": str(agent_id),
@@ -185,18 +178,22 @@ async def get_agent_a2a_info(
             "future_subdomain": f"agent-{agent_id}.{request.url.hostname}",
             "subdomain_note": "This agent will be available at its own subdomain in the future",
             "supported_methods": [
-                "message/send",
-                "message/stream",
-                "tasks/get",
-                "tasks/cancel",
-                "tasks/resubscribe",
-                "tasks/list",
-                "agent/authenticatedExtendedCard",
+                "SendMessage",
+                "SendStreamingMessage",
+                "GetTask",
+                "CancelTask",
+                "SubscribeToTask",
+                "ListTasks",
+                "CreateTaskPushNotificationConfig",
+                "GetTaskPushNotificationConfig",
+                "ListTaskPushNotificationConfigs",
+                "DeleteTaskPushNotificationConfig",
+                "GetExtendedAgentCard",
             ],
             "capabilities": {
                 "streaming": True,
-                "pushNotifications": False,
-                "stateTransitionHistory": True,
+                "pushNotifications": True,
+                "extendedAgentCard": True,
             },
             "authentication": {
                 "supported": True,

--- a/agentarea-platform/apps/api/tests/test_a2a_agent_card_spec.py
+++ b/agentarea-platform/apps/api/tests/test_a2a_agent_card_spec.py
@@ -17,14 +17,21 @@ async def test_agent_card_advertises_current_a2a_discovery_fields():
     card = await create_agent_card_for_agent(agent, "https://api.example.com", agent_id)
     payload = card.model_dump(by_alias=True, exclude_none=True)
 
-    assert payload["url"] == f"https://api.example.com/v1/agents/{agent_id}/a2a/rpc"
+    rpc_url = f"https://api.example.com/v1/agents/{agent_id}/a2a/rpc"
+    # A2A v1.0.0 transport advertising: supportedInterfaces[] (first = preferred).
+    assert "url" not in payload
+    assert "protocolVersion" not in payload
+    assert "preferredTransport" not in payload
+    assert "additionalInterfaces" not in payload
     assert payload["supportedInterfaces"] == [
-        {
-            "url": f"https://api.example.com/v1/agents/{agent_id}/a2a/rpc",
-            "protocolBinding": "JSONRPC",
-            "protocolVersion": "1.0",
-        }
+        {"url": rpc_url, "protocolBinding": "JSONRPC", "protocolVersion": "1.0"}
     ]
+    # extended-card flag moved into capabilities
     assert payload["capabilities"]["extendedAgentCard"] is True
+    assert "stateTransitionHistory" not in payload["capabilities"]
+    # provider.url is required by spec
+    assert payload["provider"]["url"] == "https://api.example.com"
+    # every skill must carry tags (required by spec)
+    assert all(skill.get("tags") for skill in payload["skills"])
     assert payload["securitySchemes"]["bearer"]["type"] == "http"
     assert payload["security"] == [{"bearer": []}]

--- a/agentarea-platform/apps/api/tests/test_a2a_logging.py
+++ b/agentarea-platform/apps/api/tests/test_a2a_logging.py
@@ -154,7 +154,7 @@ class TestA2ALogging:
             metadata={"user_agent": "test-client", "client_ip": "127.0.0.1"},
         )
 
-        message = Message(role="user", parts=[TextPart(text="Test message")])
+        message = Message(role="USER", parts=[TextPart(text="Test message")])
         message_params = MessageSendParams(message=message)
 
         # Create task with A2A metadata
@@ -162,7 +162,7 @@ class TestA2ALogging:
             message_params=message_params,
             agent_id=agent_id,
             auth_context=auth_context,
-            a2a_method="message/send",
+            a2a_method="SendMessage",
             request_id="test-request-123",
         )
 
@@ -172,7 +172,7 @@ class TestA2ALogging:
 
         # Check core A2A metadata
         assert metadata["source"] == "a2a"
-        assert metadata["a2a_method"] == "message/send"
+        assert metadata["a2a_method"] == "SendMessage"
         assert metadata["a2a_request_id"] == "test-request-123"
         assert metadata["auth_method"] == "bearer"
         assert metadata["authenticated"] is True

--- a/agentarea-platform/apps/api/tests/test_a2a_push.py
+++ b/agentarea-platform/apps/api/tests/test_a2a_push.py
@@ -1,0 +1,224 @@
+"""Tests for A2A push notification support.
+
+Covers the pure config helpers, the notification body formatter, and the
+JSON-RPC handlers (set/get/list/delete) with mocked task service + secret store.
+See docs/adr/2026-06-20-a2a-push-notifications.md.
+"""
+
+import json
+from uuid import uuid4
+
+import pytest
+from agentarea_api.api.v1 import agents_a2a
+from agentarea_api.api.v1.a2a_auth import A2AAuthContext
+from agentarea_common.utils import a2a_push
+from agentarea_tasks.domain.models import AgentTask
+
+# ── Pure helpers ──────────────────────────────────────────────────
+
+
+def test_upsert_get_delete_push_config():
+    params, stored = a2a_push.upsert_push_config({}, "https://example.com/hook")
+    assert stored["url"] == "https://example.com/hook"
+    assert stored["id"]
+    assert a2a_push.list_push_configs(params) == [stored]
+
+    got = a2a_push.get_push_config(params, stored["id"])
+    assert got == stored
+
+    # upsert by same id replaces, doesn't duplicate
+    params2, stored2 = a2a_push.upsert_push_config(params, "https://new.example/h", stored["id"])
+    assert len(a2a_push.list_push_configs(params2)) == 1
+    assert a2a_push.get_push_config(params2, stored["id"])["url"] == "https://new.example/h"
+
+    params3, removed = a2a_push.delete_push_config(params2, stored["id"])
+    assert removed is True
+    assert a2a_push.list_push_configs(params3) == []
+
+
+def test_token_never_stored_in_params():
+    params, stored = a2a_push.upsert_push_config({}, "https://example.com/hook")
+    # Stored config holds only non-secret fields.
+    assert "token" not in stored
+    assert set(stored.keys()) == {"id", "url"}
+
+
+def test_task_push_config_result_is_flat():
+    result = a2a_push.task_push_config_result("task-1", {"id": "cfg-1", "url": "https://e/h"})
+    # v1.0.0 flat shape: no nested pushNotificationConfig.
+    assert result == {"taskId": "task-1", "id": "cfg-1", "url": "https://e/h"}
+
+
+def test_push_token_secret_name():
+    assert a2a_push.push_token_secret_name("t1", "c1") == "a2a_push_token:t1:c1"
+
+
+def test_build_notification_body_terminal_completed():
+    event = {
+        "event_type": "WorkflowCompleted",
+        "event_id": "e1",
+        "task_id": "task-1",
+        "data": {"task_id": "task-1", "result": "Final answer"},
+    }
+    body = json.loads(a2a_push.build_push_notification_body(event))
+    # v1.0.0 StreamResponse statusUpdate wrapper (no kind/final).
+    su = body["statusUpdate"]
+    assert su["taskId"] == "task-1"
+    assert su["status"]["state"] == "COMPLETED"
+    assert su["status"]["message"]["role"] == "AGENT"
+    assert su["status"]["message"]["parts"][0]["text"] == "Final answer"
+    assert "kind" not in su["status"]["message"]["parts"][0]
+
+
+def test_build_notification_body_skips_non_terminal():
+    event = {"event_type": "LLMCallChunk", "data": {"task_id": "t", "chunk": "x"}}
+    assert a2a_push.build_push_notification_body(event) is None
+
+
+def test_webhook_adapter_formats_terminal_only():
+    from agentarea_triggers.channels.adapters import _a2a_webhook_format
+
+    terminal = {
+        "event_type": "WorkflowCompleted",
+        "data": {"task_id": "t", "result": "done"},
+    }
+    assert (
+        json.loads(_a2a_webhook_format(terminal, "silent"))["statusUpdate"]["status"]["state"]
+        == "COMPLETED"
+    )
+    # non-terminal renders empty (won't be delivered)
+    assert _a2a_webhook_format({"event_type": "LLMCallChunk", "data": {}}, "silent") == ""
+
+
+# ── RPC handlers ──────────────────────────────────────────────────
+
+
+class _MockTaskRepo:
+    def __init__(self):
+        self.updated = None
+
+    async def update_by_id(self, task_id, task_update):
+        self.updated = (task_id, task_update)
+        return None
+
+
+class _MockTaskService:
+    def __init__(self, task):
+        self._task = task
+        self.task_repository = _MockTaskRepo()
+
+    async def get_task(self, task_id):
+        return self._task
+
+
+class _MockSecretManager:
+    def __init__(self):
+        self.secrets = {}
+
+    async def set_secret(self, name, value):
+        self.secrets[name] = value
+
+    async def get_secret(self, name):
+        return self.secrets.get(name)
+
+
+def _auth():
+    return A2AAuthContext(
+        authenticated=True, user_id="user-1", workspace_id="ws-1", metadata={}
+    )
+
+
+def _task():
+    return AgentTask(
+        id=uuid4(),
+        title="t",
+        description="d",
+        query="q",
+        user_id="user-1",
+        workspace_id="ws-1",
+        agent_id=uuid4(),
+        status="working",
+        task_parameters={},
+        metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_push_config_set_stores_token_in_secret_store(monkeypatch):
+    monkeypatch.setattr(agents_a2a, "validate_outbound_url", lambda url: None)
+    task = _task()
+    svc = _MockTaskService(task)
+    secrets = _MockSecretManager()
+
+    params = {
+        "taskId": str(task.id),
+        "url": "https://example.com/hook",
+        "token": "secret-tok",
+    }
+    resp = await agents_a2a.handle_push_config_set(
+        "rpc-1", params, svc, task.agent_id, _auth(), secrets
+    )
+    result = resp.result
+    # v1.0.0 flat result shape.
+    assert result["taskId"] == str(task.id)
+    assert result["url"] == "https://example.com/hook"
+    # Token NOT echoed back.
+    assert "token" not in result
+    # Token went to the secret store under the canonical key.
+    cfg_id = result["id"]
+    assert secrets.secrets[f"a2a_push_token:{task.id}:{cfg_id}"] == "secret-tok"
+    # Non-secret config persisted to task_parameters.
+    _, task_update = svc.task_repository.updated
+    assert task_update.task_parameters["a2a_push_configs"][0]["url"] == "https://example.com/hook"
+
+
+@pytest.mark.asyncio
+async def test_push_config_set_rejects_unsafe_url(monkeypatch):
+    from agentarea_common.utils.url_safety import UnsafeUrlError
+
+    def _raise(url):
+        raise UnsafeUrlError("private address")
+
+    monkeypatch.setattr(agents_a2a, "validate_outbound_url", _raise)
+    task = _task()
+    resp = await agents_a2a.handle_push_config_set(
+        "rpc-2",
+        {"taskId": str(task.id), "url": "http://169.254.169.254/"},
+        _MockTaskService(task),
+        task.agent_id,
+        _auth(),
+        _MockSecretManager(),
+    )
+    assert resp.error.code == -32602
+
+
+@pytest.mark.asyncio
+async def test_push_config_list_and_delete(monkeypatch):
+    monkeypatch.setattr(agents_a2a, "validate_outbound_url", lambda url: None)
+    task = _task()
+    svc = _MockTaskService(task)
+    secrets = _MockSecretManager()
+
+    set_resp = await agents_a2a.handle_push_config_set(
+        "s", {"taskId": str(task.id), "url": "https://e.com/h"},
+        svc, task.agent_id, _auth(), secrets,
+    )
+    cfg_id = set_resp.result["id"]
+    # Reflect the persisted params back onto the task for subsequent reads.
+    task.task_parameters = svc.task_repository.updated[1].task_parameters
+
+    list_resp = await agents_a2a.handle_push_config_list(
+        "l", {"id": str(task.id)}, svc, task.agent_id, _auth()
+    )
+    assert [c["id"] for c in list_resp.result] == [cfg_id]
+
+    del_resp = await agents_a2a.handle_push_config_delete(
+        "d", {"id": str(task.id), "pushNotificationConfigId": cfg_id},
+        svc, task.agent_id, _auth(), secrets,
+    )
+    assert del_resp.result is None
+    task.task_parameters = svc.task_repository.updated[1].task_parameters
+    list_resp2 = await agents_a2a.handle_push_config_list(
+        "l2", {"id": str(task.id)}, svc, task.agent_id, _auth()
+    )
+    assert list_resp2.result == []

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/__init__.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/__init__.py
@@ -3,10 +3,10 @@
 from .a2a_agent_tool import A2AAgentTool
 from .agent_delegation_tool import AgentDelegationTool
 from .agent_tool_factory import AgentToolFactory
-from .delegation_tool import DelegationTool
 from .base_tool import BaseTool, ToolExecutionError, ToolRegistry
 from .completion_tool import CompletionTool
 from .decorator_tool import Toolset, ToolsetAdapter, tool_method
+from .delegation_tool import DelegationTool
 from .file_toolset import FileToolset
 from .mcp_tool import MCPTool, MCPToolFactory
 from .tasks_toolset import TasksToolset

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/__init__.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/__init__.py
@@ -3,6 +3,7 @@
 from .a2a_agent_tool import A2AAgentTool
 from .agent_delegation_tool import AgentDelegationTool
 from .agent_tool_factory import AgentToolFactory
+from .delegation_tool import DelegationTool
 from .base_tool import BaseTool, ToolExecutionError, ToolRegistry
 from .completion_tool import CompletionTool
 from .decorator_tool import Toolset, ToolsetAdapter, tool_method
@@ -32,6 +33,7 @@ __all__ = [
     "A2AAgentTool",
     "AgentDelegationTool",
     "AgentToolFactory",
+    "DelegationTool",
     "BaseTool",
     "CompletionTool",
     "FileToolset",

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/a2a_agent_tool.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/a2a_agent_tool.py
@@ -1,5 +1,6 @@
 """A2A Agent Tool — delegates tasks to another agent via A2A protocol."""
 
+import asyncio
 import json
 import logging
 import re
@@ -14,6 +15,22 @@ from .base_tool import BaseTool, ToolExecutionError
 logger = logging.getLogger(__name__)
 
 A2A_CALL_TIMEOUT = 120.0
+# Terminal A2A task states. Our server emits A2A v1.0.0 SCREAMING_SNAKE values;
+# lowercase variants are kept for tolerance reading remote/older responses.
+_TERMINAL_STATES = {
+    "COMPLETED",
+    "FAILED",
+    "CANCELED",
+    "REJECTED",
+    "completed",
+    "failed",
+    "canceled",
+    "cancelled",
+    "rejected",
+}
+# Polling budget for delegation: stay under the 120s activity timeout.
+_POLL_TOTAL_BUDGET = 110.0
+_POLL_INTERVAL = 2.0
 
 PaymentHandler = Callable[..., Awaitable[dict[str, Any] | None]]
 
@@ -30,8 +47,8 @@ def _sanitize_tool_name(agent_name: str) -> str:
 class A2AAgentTool(BaseTool):
     """Tool that delegates a task to another agent via the A2A protocol.
 
-    Sends a `message/send` JSON-RPC request to the target agent's A2A endpoint
-    and returns the completed task result.
+    Sends a `SendMessage` JSON-RPC request (A2A v1.0.0) to the target agent's
+    A2A endpoint and returns the completed task result.
     """
 
     def __init__(
@@ -74,7 +91,7 @@ class A2AAgentTool(BaseTool):
         }
 
     async def execute(self, **kwargs) -> dict[str, Any]:
-        """Send message/send to the target agent and return the result."""
+        """Send SendMessage to the target agent and return the result."""
         message_text = kwargs.get("message", "")
         if not message_text:
             raise ToolExecutionError(self.name, "message is required")
@@ -82,16 +99,19 @@ class A2AAgentTool(BaseTool):
         rpc_request = {
             "jsonrpc": "2.0",
             "id": uuid4().hex,
-            "method": "message/send",
+            "method": "SendMessage",
             "params": {
                 "message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": message_text}],
+                    "role": "USER",
+                    "parts": [{"text": message_text}],
                 },
             },
         }
 
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/a2a+json",
+            "A2A-Version": "1.0",
+        }
         if self._auth_token:
             headers["Authorization"] = f"Bearer {self._auth_token}"
 
@@ -147,6 +167,17 @@ class A2AAgentTool(BaseTool):
                 }
 
             task = rpc_response.get("result", {})
+
+            # SendMessage is non-blocking: it returns a (possibly non-terminal)
+            # Task. Poll GetTask until the task reaches a terminal state so the
+            # delegating agent receives the actual result. Short HTTP requests +
+            # polling avoids a long-held connection timing out.
+            state = (task.get("status") or {}).get("state") if isinstance(task, dict) else None
+            task_id = task.get("id") if isinstance(task, dict) else None
+            if task_id and state not in _TERMINAL_STATES:
+                task = await self._poll_until_terminal(task_id, headers) or task
+                state = (task.get("status") or {}).get("state") if isinstance(task, dict) else None
+
             result_text = self._extract_task_result(task)
 
             return {
@@ -154,8 +185,8 @@ class A2AAgentTool(BaseTool):
                 "result": result_text,
                 "error": None,
                 "tool_name": self.name,
-                "task_id": task.get("id"),
-                "task_state": task.get("status", {}).get("state"),
+                "task_id": task.get("id") if isinstance(task, dict) else task_id,
+                "task_state": state,
                 "payment": payment_result,
             }
 
@@ -169,21 +200,68 @@ class A2AAgentTool(BaseTool):
             logger.error(f"A2A agent tool call failed: {e}")
             raise ToolExecutionError(self.name, str(e), e) from e
 
+    async def _poll_until_terminal(
+        self, task_id: str, headers: dict[str, str]
+    ) -> dict[str, Any] | None:
+        """Poll GetTask until the task is terminal or the budget elapses.
+
+        Returns the latest Task object, or None if no successful poll occurred.
+        """
+        elapsed = 0.0
+        latest: dict[str, Any] | None = None
+        async with httpx.AsyncClient(timeout=A2A_CALL_TIMEOUT) as client:
+            while elapsed < _POLL_TOTAL_BUDGET:
+                await asyncio.sleep(_POLL_INTERVAL)
+                elapsed += _POLL_INTERVAL
+                poll_request = {
+                    "jsonrpc": "2.0",
+                    "id": uuid4().hex,
+                    "method": "GetTask",
+                    "params": {"id": task_id},
+                }
+                try:
+                    resp = await client.post(
+                        self._a2a_url, content=json.dumps(poll_request), headers=headers
+                    )
+                    if resp.status_code != 200:
+                        continue
+                    body = resp.json()
+                except Exception as e:
+                    logger.debug(f"A2A poll for task {task_id} failed: {e}")
+                    continue
+
+                if body.get("error"):
+                    continue
+                task = body.get("result")
+                if not isinstance(task, dict):
+                    continue
+                latest = task
+                state = (task.get("status") or {}).get("state")
+                if state in _TERMINAL_STATES:
+                    return task
+
+        logger.warning(f"A2A delegation to '{self._agent_name}' did not finish within budget")
+        return latest
+
     def _extract_task_result(self, task: dict[str, Any]) -> str:
-        """Extract readable text from a task's artifacts and status message."""
+        """Extract readable text from a task's artifacts and status message.
+
+        A2A v1.0.0 parts are flat (no ``kind``): a part is text if it has ``text``,
+        data if it has ``data``.
+        """
         parts = []
         for artifact in task.get("artifacts") or []:
             for part in artifact.get("parts") or []:
-                if part.get("kind") == "text":
+                if part.get("text") is not None:
                     parts.append(part["text"])
-                elif part.get("kind") == "data":
+                elif part.get("data") is not None:
                     parts.append(json.dumps(part.get("data", {})))
 
         if not parts:
             status_msg = task.get("status", {}).get("message")
             if status_msg:
                 for part in status_msg.get("parts") or []:
-                    if part.get("kind") == "text":
+                    if part.get("text") is not None:
                         parts.append(part["text"])
 
         return "\n".join(parts) if parts else "(No output from agent)"

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/agent_tool_factory.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/agent_tool_factory.py
@@ -13,6 +13,7 @@ from typing import Any
 from .a2a_agent_tool import A2AAgentTool
 from .agent_delegation_tool import AgentDelegationTool
 from .base_tool import BaseTool
+from .delegation_tool import DelegationTool
 
 logger = logging.getLogger(__name__)
 
@@ -70,21 +71,27 @@ class AgentToolFactory:
 
             description = description_override or agent.description or f"Agent: {agent_name}"
 
-            # External agent: explicit A2A URL provided
+            # Pick the transport binding for this target agent, then wrap it in the
+            # single DelegationTool facade. The model always sees one delegate_to_<agent>
+            # tool; local-vs-A2A is an execution detail chosen here.
+
+            # Remote agent: an explicit A2A URL forces the A2A binding.
             if a2a_url_override:
-                logger.info(f"Creating external A2A tool for '{agent_name}' -> {a2a_url_override}")
-                return A2AAgentTool(
+                logger.info(f"Delegation '{agent_name}': A2A binding -> {a2a_url_override}")
+                binding = A2AAgentTool(
                     agent_name=agent_name,
                     agent_description=description,
                     a2a_url=a2a_url_override,
                     auth_token=auth_token,
                     payment_handler=payment_handler,
                 )
+                return DelegationTool(binding, "a2a")
 
-            # Internal agent: use task service directly (no HTTP)
+            # Same-platform agent: resolved locally and we have execution context →
+            # local binding (direct task service, no HTTP/auth overhead).
             if task_service and workspace_id and user_id:
-                logger.info(f"Creating delegation tool for '{agent_name}' (id={agent.id})")
-                return AgentDelegationTool(
+                logger.info(f"Delegation '{agent_name}': local binding (id={agent.id})")
+                binding = AgentDelegationTool(
                     agent_name=agent_name,
                     agent_description=description,
                     target_agent_id=agent.id,
@@ -92,20 +99,22 @@ class AgentToolFactory:
                     workspace_id=workspace_id,
                     user_id=user_id,
                 )
+                return DelegationTool(binding, "local")
 
-            # Fallback: external A2A (less ideal — needs auth token to work)
+            # Fallback: no local execution context → A2A binding against our own endpoint.
             logger.warning(
-                f"Creating external A2A tool for '{agent_name}' (no task_service provided). "
-                "Internal delegation preferred — pass task_service for same-platform agents."
+                f"Delegation '{agent_name}': A2A binding fallback (no task_service). "
+                "Pass task_service for same-platform agents to use the local binding."
             )
             a2a_url = f"{base_url}/agents/{agent.id}/a2a/rpc"
-            return A2AAgentTool(
+            binding = A2AAgentTool(
                 agent_name=agent_name,
                 agent_description=description,
                 a2a_url=a2a_url,
                 auth_token=auth_token,
                 payment_handler=payment_handler,
             )
+            return DelegationTool(binding, "a2a")
 
         except Exception as e:
             logger.error(f"Failed to create delegation tool for agent '{agent_name}': {e}")
@@ -147,7 +156,7 @@ class AgentToolFactory:
             )
             if tool:
                 tools.append(tool)
-                tool_type = "internal" if isinstance(tool, AgentDelegationTool) else "external/a2a"
-                logger.info(f"Created {tool_type} agent tool: {tool.name}")
+                kind = getattr(tool, "binding_kind", "unknown")
+                logger.info(f"Created delegation tool ({kind} binding): {tool.name}")
 
         return tools

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/delegation_tool.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/delegation_tool.py
@@ -1,0 +1,53 @@
+"""Unified agent-delegation tool.
+
+Delegation is ONE concept, exposed to the model as a single `delegate_to_<agent>`
+tool. The transport ("binding") is chosen per target agent by AgentToolFactory:
+
+- ``local`` binding (AgentDelegationTool): same-platform agent → direct task-service
+  call, no HTTP/auth overhead.
+- ``a2a`` binding (A2AAgentTool): remote agent → HTTP via the A2A protocol.
+
+Both bindings share the delegation contract (submit → poll until terminal → extract
+result). The model sees an identical tool regardless of where the target agent runs;
+"local vs remote" is an execution detail behind this facade — never a second tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base_tool import BaseTool
+
+
+class DelegationTool(BaseTool):
+    """Single delegation tool that forwards to a transport binding.
+
+    ``binding_kind`` is ``"local"`` or ``"a2a"`` (observability only — the model
+    neither sees nor needs it).
+    """
+
+    def __init__(self, binding: BaseTool, binding_kind: str):
+        self._binding = binding
+        self._binding_kind = binding_kind
+
+    @property
+    def binding(self) -> BaseTool:
+        return self._binding
+
+    @property
+    def binding_kind(self) -> str:
+        return self._binding_kind
+
+    @property
+    def name(self) -> str:
+        return self._binding.name
+
+    @property
+    def description(self) -> str:
+        return self._binding.description
+
+    def get_schema(self) -> dict[str, Any]:
+        return self._binding.get_schema()
+
+    async def execute(self, **kwargs) -> dict[str, Any]:
+        return await self._binding.execute(**kwargs)

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_a2a_agent_tool.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_a2a_agent_tool.py
@@ -92,7 +92,7 @@ class TestA2AAgentToolExecute:
                 "artifacts": [
                     {
                         "parts": [
-                            {"kind": "text", "text": "The answer is 42."},
+                            {"text": "The answer is 42."},
                         ]
                     }
                 ],
@@ -188,7 +188,7 @@ class TestA2AAgentToolExecute:
             "result": {
                 "id": "paid-task",
                 "status": {"state": "completed"},
-                "artifacts": [{"parts": [{"kind": "text", "text": "paid result"}]}],
+                "artifacts": [{"parts": [{"text": "paid result"}]}],
             },
         }
         payment_calls = []
@@ -235,7 +235,7 @@ class TestA2AAgentToolExecute:
         assert result["payment"]["amount_usd"] == 0.25
         assert payment_calls[0]["response_status"] == 402
         assert payment_calls[0]["tool_name"] == "delegate_to_researcher"
-        assert payment_calls[0]["request_body"]["method"] == "message/send"
+        assert payment_calls[0]["request_body"]["method"] == "SendMessage"
 
     @pytest.mark.asyncio
     async def test_execute_paid_a2a_surfaces_payment_failure(self):
@@ -301,8 +301,8 @@ class TestExtractTaskResult:
     def test_extract_text_artifacts(self):
         task = {
             "artifacts": [
-                {"parts": [{"kind": "text", "text": "line1"}]},
-                {"parts": [{"kind": "text", "text": "line2"}]},
+                {"parts": [{"text": "line1"}]},
+                {"parts": [{"text": "line2"}]},
             ]
         }
         assert self.tool._extract_task_result(task) == "line1\nline2"
@@ -310,7 +310,7 @@ class TestExtractTaskResult:
     def test_extract_data_artifact(self):
         task = {
             "artifacts": [
-                {"parts": [{"kind": "data", "data": {"key": "val"}}]},
+                {"parts": [{"data": {"key": "val"}}]},
             ]
         }
         result = self.tool._extract_task_result(task)
@@ -322,7 +322,7 @@ class TestExtractTaskResult:
             "status": {
                 "state": "completed",
                 "message": {
-                    "parts": [{"kind": "text", "text": "Done via status"}],
+                    "parts": [{"text": "Done via status"}],
                 },
             },
         }

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_agent_tool_factory.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_agent_tool_factory.py
@@ -7,6 +7,7 @@ import pytest
 
 from agentarea_agents_sdk.tools.a2a_agent_tool import A2AAgentTool
 from agentarea_agents_sdk.tools.agent_tool_factory import AgentToolFactory
+from agentarea_agents_sdk.tools.delegation_tool import DelegationTool
 
 
 def _make_mock_agent(agent_id="agent-123", name="researcher", description="Researches topics"):
@@ -28,7 +29,10 @@ class TestAgentToolFactoryCreateTool:
         )
 
         assert tool is not None
-        assert isinstance(tool, A2AAgentTool)
+        # Single facade tool; transport binding is A2A here (no task_service provided).
+        assert isinstance(tool, DelegationTool)
+        assert tool.binding_kind == "a2a"
+        assert isinstance(tool.binding, A2AAgentTool)
         assert tool.name == "delegate_to_researcher"
         assert "Researches topics" in tool.description
         agent_service.get_by_name.assert_awaited_once_with("researcher")
@@ -45,7 +49,7 @@ class TestAgentToolFactoryCreateTool:
         )
 
         assert tool is not None
-        assert tool._a2a_url == "http://localhost:8000/agents/agent-123/a2a/rpc"
+        assert tool.binding._a2a_url == "http://localhost:8000/agents/agent-123/a2a/rpc"
 
     @pytest.mark.asyncio
     async def test_create_tool_with_url_override(self):
@@ -60,7 +64,8 @@ class TestAgentToolFactoryCreateTool:
         )
 
         assert tool is not None
-        assert tool._a2a_url == "http://custom:9999/rpc"
+        assert tool.binding_kind == "a2a"
+        assert tool.binding._a2a_url == "http://custom:9999/rpc"
 
     @pytest.mark.asyncio
     async def test_create_tool_with_description_override(self):
@@ -116,7 +121,7 @@ class TestAgentToolFactoryCreateTool:
         )
 
         assert tool is not None
-        assert tool._auth_token == "secret-token"
+        assert tool.binding._auth_token == "secret-token"
 
 
 class TestAgentToolFactoryCreateToolsFromConfig:
@@ -181,7 +186,7 @@ class TestAgentToolFactoryCreateToolsFromConfig:
         )
 
         assert len(tools) == 1
-        assert tools[0]._a2a_url == "http://custom/rpc"
+        assert tools[0].binding._a2a_url == "http://custom/rpc"
         assert "Custom desc" in tools[0].description
 
     @pytest.mark.asyncio

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_flow_a2a_delegation.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_flow_a2a_delegation.py
@@ -37,7 +37,7 @@ def _make_specialist_response(result_text: str) -> dict:
             "status": {"state": "completed"},
             "artifacts": [
                 {
-                    "parts": [{"kind": "text", "text": result_text}],
+                    "parts": [{"text": result_text}],
                 }
             ],
         },
@@ -117,7 +117,7 @@ class TestA2ADelegationFlow:
         url = call.args[0] if call.args else call.kwargs.get("url", call[0][0])
         assert url == _SPECIALIST_URL
         body = json.loads(call.kwargs.get("content") or call[1].get("content"))
-        assert body["method"] == "message/send"
+        assert body["method"] == "SendMessage"
         assert body["jsonrpc"] == "2.0"
         parts = body["params"]["message"]["parts"]
         assert any("revenue" in p.get("text", "") for p in parts)
@@ -180,8 +180,8 @@ class TestA2ADelegationFlow:
                 "artifacts": [
                     {
                         "parts": [
-                            {"kind": "text", "text": "Part A."},
-                            {"kind": "text", "text": "Part B."},
+                            {"text": "Part A."},
+                            {"text": "Part B."},
                         ]
                     }
                 ],

--- a/agentarea-platform/libs/common/agentarea_common/utils/a2a_push.py
+++ b/agentarea-platform/libs/common/agentarea_common/utils/a2a_push.py
@@ -57,9 +57,7 @@ def upsert_push_config(
     return params, stored
 
 
-def get_push_config(
-    parameters: dict[str, Any] | None, config_id: str
-) -> dict[str, Any] | None:
+def get_push_config(parameters: dict[str, Any] | None, config_id: str) -> dict[str, Any] | None:
     """Return a single stored push config by id, or None."""
     for cfg in list_push_configs(parameters):
         if cfg.get("id") == config_id:

--- a/agentarea-platform/libs/common/agentarea_common/utils/a2a_push.py
+++ b/agentarea-platform/libs/common/agentarea_common/utils/a2a_push.py
@@ -1,0 +1,126 @@
+"""A2A push-notification config helpers (pure, dependency-free).
+
+Shared by the API (RPC handlers) and the worker (delivery adapter) so the two
+sides agree on storage layout, the secret key for the callback token, and the
+notification body shape. See docs/adr/2026-06-20-a2a-push-notifications.md.
+
+Storage layout (mirrors how channels are stored):
+- Non-secret config (id, url, presentation) lives in
+  ``task.task_parameters["a2a_push_configs"]`` — a list of dicts.
+- The callback ``token`` is NEVER stored here; it goes to the secret store under
+  ``a2a_push_token:<task_id>:<config_id>`` and is never returned by get/list.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+PUSH_CONFIGS_PARAM_KEY = "a2a_push_configs"
+
+# Maps raw workflow terminal event types to A2A v1.0.0 task states (proto encoding).
+_TERMINAL_EVENT_STATES = {
+    "WorkflowCompleted": "COMPLETED",
+    "WorkflowFailed": "FAILED",
+    "WorkflowCancelled": "CANCELED",
+}
+
+
+def push_token_secret_name(task_id: str, config_id: str) -> str:
+    """Secret-store key for a push config's callback token."""
+    return f"a2a_push_token:{task_id}:{config_id}"
+
+
+def list_push_configs(parameters: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return the stored (non-secret) push configs for a task."""
+    if not parameters:
+        return []
+    configs = parameters.get(PUSH_CONFIGS_PARAM_KEY)
+    return list(configs) if isinstance(configs, list) else []
+
+
+def upsert_push_config(
+    parameters: dict[str, Any] | None, url: str, config_id: str | None = None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Insert or replace a push config (by id) in task parameters.
+
+    Returns ``(new_parameters, stored_config)``. The stored config holds only
+    non-secret fields; ``config_id`` is generated when absent.
+    """
+    params = dict(parameters or {})
+    configs = list(list_push_configs(params))
+    cfg_id = config_id or uuid4().hex
+    stored = {"id": cfg_id, "url": url}
+    configs = [c for c in configs if c.get("id") != cfg_id]
+    configs.append(stored)
+    params[PUSH_CONFIGS_PARAM_KEY] = configs
+    return params, stored
+
+
+def get_push_config(
+    parameters: dict[str, Any] | None, config_id: str
+) -> dict[str, Any] | None:
+    """Return a single stored push config by id, or None."""
+    for cfg in list_push_configs(parameters):
+        if cfg.get("id") == config_id:
+            return cfg
+    return None
+
+
+def delete_push_config(
+    parameters: dict[str, Any] | None, config_id: str
+) -> tuple[dict[str, Any], bool]:
+    """Remove a push config by id. Returns ``(new_parameters, removed)``."""
+    params = dict(parameters or {})
+    configs = list_push_configs(params)
+    remaining = [c for c in configs if c.get("id") != config_id]
+    params[PUSH_CONFIGS_PARAM_KEY] = remaining
+    return params, len(remaining) != len(configs)
+
+
+def task_push_config_result(task_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    """Build a flat A2A v1.0.0 ``TaskPushNotificationConfig`` result (token omitted)."""
+    return {
+        "taskId": str(task_id),
+        "id": config.get("id"),
+        "url": config.get("url"),
+    }
+
+
+def build_push_notification_body(event: dict[str, Any]) -> str | None:
+    """Build the A2A v1.0.0 notification JSON body for a workflow event.
+
+    Returns a serialized StreamResponse ``statusUpdate`` wrapper for terminal
+    events, or None for events that should not be pushed.
+
+    ``event`` is the delivery-side shape: ``{event_type, event_id, task_id, data}``
+    with the workflow payload in ``data`` (unprefixed event types).
+    """
+    import json
+
+    event_type = event.get("event_type", "")
+    state = _TERMINAL_EVENT_STATES.get(event_type)
+    if not state:
+        return None
+
+    data = event.get("data") or {}
+    task_id = str(data.get("task_id") or event.get("task_id") or "")
+    context_id = str(data.get("context_id") or task_id)
+    text = data.get("result") or data.get("final_response") or data.get("error") or ""
+
+    status: dict[str, Any] = {"state": state}
+    if text:
+        status["message"] = {
+            "role": "AGENT",
+            "messageId": uuid4().hex,
+            "parts": [{"text": str(text)}],
+        }
+
+    body = {
+        "statusUpdate": {
+            "taskId": task_id,
+            "contextId": context_id,
+            "status": status,
+        }
+    }
+    return json.dumps(body)

--- a/agentarea-platform/libs/common/agentarea_common/utils/types.py
+++ b/agentarea-platform/libs/common/agentarea_common/utils/types.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Any, Literal, Self
+from typing import Annotated, Any, Literal
 from uuid import uuid4
 
 from pydantic import (
@@ -10,62 +10,74 @@ from pydantic import (
     Field,
     TypeAdapter,
     field_serializer,
-    model_validator,
+    model_serializer,
 )
 
 
 class TaskState(StrEnum):
-    SUBMITTED = "submitted"
-    WORKING = "working"
-    INPUT_REQUIRED = "input-required"
-    AUTH_REQUIRED = "auth-required"
-    COMPLETED = "completed"
-    CANCELED = "canceled"
-    FAILED = "failed"
-    REJECTED = "rejected"
-    UNKNOWN = "unknown"
+    # A2A v1.0.0 wire values use proto SCREAMING_SNAKE encoding.
+    SUBMITTED = "SUBMITTED"
+    WORKING = "WORKING"
+    INPUT_REQUIRED = "INPUT_REQUIRED"
+    AUTH_REQUIRED = "AUTH_REQUIRED"
+    COMPLETED = "COMPLETED"
+    CANCELED = "CANCELED"
+    FAILED = "FAILED"
+    REJECTED = "REJECTED"
+    UNKNOWN = "TASK_STATE_UNSPECIFIED"
 
 
-class TextPart(BaseModel):
-    kind: Literal["text"] = "text"
-    text: str
-    metadata: dict[str, Any] | None = None
+class Part(BaseModel):
+    """A2A v1.0.0 flat Part — a single model spanning text/file/data content.
 
+    Serializes ONLY the set (non-None) fields, always camelCase (``mediaType``),
+    and never emits a ``kind`` discriminator. A bare text part serializes to
+    exactly ``{"text": "..."}``.
+    """
 
-class FileContent(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    name: str | None = Field(None, alias="filename")
-    mime_type: str | None = Field(None, alias="mimeType")
-    data: str | None = None
-    uri: str | None = Field(None, alias="url")
-
-    @model_validator(mode="after")
-    def check_content(self) -> Self:
-        if not (self.data or self.uri):
-            raise ValueError("Either 'data' or 'uri' must be present in the file")
-        if self.data and self.uri:
-            raise ValueError("Only one of 'data' or 'uri' can be present")
-        return self
-
-
-class FilePart(BaseModel):
-    kind: Literal["file"] = "file"
-    file: FileContent
+    text: str | None = None
+    data: dict[str, Any] | None = None
+    raw: str | None = None  # base64-encoded bytes
+    url: str | None = None
+    filename: str | None = None
+    media_type: str | None = Field(None, alias="mediaType")
     metadata: dict[str, Any] | None = None
 
+    @model_serializer
+    def _serialize(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        if self.text is not None:
+            out["text"] = self.text
+        if self.data is not None:
+            out["data"] = self.data
+        if self.raw is not None:
+            out["raw"] = self.raw
+        if self.url is not None:
+            out["url"] = self.url
+        if self.filename is not None:
+            out["filename"] = self.filename
+        if self.media_type is not None:
+            out["mediaType"] = self.media_type
+        if self.metadata is not None:
+            out["metadata"] = self.metadata
+        return out
 
-class DataPart(BaseModel):
-    kind: Literal["data"] = "data"
-    data: dict[str, Any]
-    metadata: dict[str, Any] | None = None
 
-
-Part = Annotated[TextPart | FilePart | DataPart, Field(discriminator="kind")]
+def TextPart(text: str, metadata: dict[str, Any] | None = None) -> Part:  # noqa: N802
+    """Convenience constructor for a text-only :class:`Part` (PascalCase by design)."""
+    return Part(text=text, metadata=metadata)
 
 
 class Message(BaseModel):
-    role: Literal["user", "agent"]
+    model_config = ConfigDict(populate_by_name=True)
+    role: Literal["USER", "AGENT"]
     parts: list[Part]
+    message_id: str = Field(default_factory=lambda: uuid4().hex, alias="messageId")
+    task_id: str | None = Field(None, alias="taskId")
+    context_id: str | None = Field(None, alias="contextId")
+    reference_task_ids: list[str] | None = Field(None, alias="referenceTaskIds")
+    extensions: list[str] | None = None
     metadata: dict[str, Any] | None = None
 
 
@@ -104,7 +116,6 @@ class Task(BaseModel):
 class TaskStatusUpdateEvent(BaseModel):
     id: str
     status: TaskStatus
-    final: bool = False
     metadata: dict[str, Any] | None = None
 
 
@@ -117,12 +128,13 @@ class TaskArtifactUpdateEvent(BaseModel):
 class AuthenticationInfo(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    schemes: list[str]
+    scheme: str
     credentials: str | None = None
 
 
 class PushNotificationConfig(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
+    id: str | None = None
     url: str
     token: str | None = None
     authentication: AuthenticationInfo | None = None
@@ -151,8 +163,15 @@ class TaskSendParams(BaseModel):
 
 
 class TaskPushNotificationConfig(BaseModel):
-    id: str
-    push_notification_config: PushNotificationConfig
+    """A2A v1.0.0 flat push-notification config (no nested object)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+    task_id: str = Field(alias="taskId")
+    id: str | None = None
+    url: str
+    token: str | None = None
+    authentication: AuthenticationInfo | None = None
+    tenant: str | None = None
 
 
 ## RPC Messages
@@ -179,26 +198,8 @@ class JSONRPCResponse(JSONRPCMessage):
     error: JSONRPCError | None = None
 
 
-class SendTaskRequest(JSONRPCRequest):
-    method: Literal["tasks/send"] = "tasks/send"
-    params: TaskSendParams | None = None
-
-
-class SendTaskResponse(JSONRPCResponse):
-    result: Task | None = None
-
-
-class SendTaskStreamingRequest(JSONRPCRequest):
-    method: Literal["tasks/sendSubscribe"] = "tasks/sendSubscribe"
-    params: TaskSendParams | None = None
-
-
-class SendTaskStreamingResponse(JSONRPCResponse):
-    result: TaskStatusUpdateEvent | TaskArtifactUpdateEvent | None = None
-
-
 class GetTaskRequest(JSONRPCRequest):
-    method: Literal["tasks/get"] = "tasks/get"
+    method: Literal["GetTask"] = "GetTask"
     params: TaskQueryParams | None = None
 
 
@@ -207,7 +208,7 @@ class GetTaskResponse(JSONRPCResponse):
 
 
 class CancelTaskRequest(JSONRPCRequest):
-    method: Literal["tasks/cancel",] = "tasks/cancel"
+    method: Literal["CancelTask"] = "CancelTask"
     params: TaskIdParams | None = None
 
 
@@ -215,39 +216,67 @@ class CancelTaskResponse(JSONRPCResponse):
     result: Task | None = None
 
 
-class SetTaskPushNotificationRequest(JSONRPCRequest):
-    method: Literal["tasks/pushNotification/set",] = "tasks/pushNotification/set"
+class ListTasksRequest(JSONRPCRequest):
+    method: Literal["ListTasks"] = "ListTasks"
+    params: dict[str, Any] | None = None
+
+
+class CreateTaskPushNotificationConfigRequest(JSONRPCRequest):
+    method: Literal["CreateTaskPushNotificationConfig"] = "CreateTaskPushNotificationConfig"
     params: TaskPushNotificationConfig | None = None
 
 
-class SetTaskPushNotificationResponse(JSONRPCResponse):
+class CreateTaskPushNotificationConfigResponse(JSONRPCResponse):
     result: TaskPushNotificationConfig | None = None
 
 
-class GetTaskPushNotificationRequest(JSONRPCRequest):
-    method: Literal["tasks/pushNotification/get",] = "tasks/pushNotification/get"
+class GetTaskPushNotificationConfigRequest(JSONRPCRequest):
+    method: Literal["GetTaskPushNotificationConfig"] = "GetTaskPushNotificationConfig"
     params: TaskIdParams | None = None
 
 
-class GetTaskPushNotificationResponse(JSONRPCResponse):
+class GetTaskPushNotificationConfigResponse(JSONRPCResponse):
     result: TaskPushNotificationConfig | None = None
 
 
-class TaskResubscriptionRequest(JSONRPCRequest):
-    method: Literal["tasks/resubscribe",] = "tasks/resubscribe"
+class ListTaskPushNotificationConfigsRequest(JSONRPCRequest):
+    method: Literal["ListTaskPushNotificationConfigs"] = "ListTaskPushNotificationConfigs"
+    params: TaskIdParams | None = None
+
+
+class DeleteTaskPushNotificationConfigRequest(JSONRPCRequest):
+    method: Literal["DeleteTaskPushNotificationConfig"] = "DeleteTaskPushNotificationConfig"
+    params: TaskIdParams | None = None
+
+
+class SubscribeToTaskRequest(JSONRPCRequest):
+    method: Literal["SubscribeToTask"] = "SubscribeToTask"
     params: TaskIdParams | None = None
 
 
 # A2A Message endpoints
+class SendMessageConfiguration(BaseModel):
+    """A2A v1.0.0 SendMessageConfiguration — per-send options incl. push registration."""
+
+    model_config = ConfigDict(populate_by_name=True)
+    accepted_output_modes: list[str] | None = Field(None, alias="acceptedOutputModes")
+    history_length: int | None = Field(None, alias="historyLength")
+    task_push_notification_config: TaskPushNotificationConfig | None = Field(
+        None, alias="taskPushNotificationConfig"
+    )
+    blocking: bool | None = None
+
+
 class MessageSendParams(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     message: Message
     context_id: str | None = Field(None, alias="contextId")
+    configuration: SendMessageConfiguration | None = None
     metadata: dict[str, Any] | None = None
 
 
 class MessageSendRequest(JSONRPCRequest):
-    method: Literal["message/send"] = "message/send"
+    method: Literal["SendMessage"] = "SendMessage"
     params: MessageSendParams | None = None
 
 
@@ -256,7 +285,7 @@ class MessageSendResponse(JSONRPCResponse):
 
 
 class MessageStreamRequest(JSONRPCRequest):
-    method: Literal["message/stream"] = "message/stream"
+    method: Literal["SendStreamingMessage"] = "SendStreamingMessage"
     params: MessageSendParams | None = None
 
 
@@ -274,7 +303,6 @@ class AgentCapabilities(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     streaming: bool = False
     push_notifications: bool = Field(False, alias="pushNotifications")
-    state_transition_history: bool = Field(False, alias="stateTransitionHistory")
     extended_agent_card: bool = Field(False, alias="extendedAgentCard")
     extensions: list[dict[str, Any]] | None = None
 
@@ -293,13 +321,18 @@ class AgentSkill(BaseModel):
     examples: list[str] | None = None
     input_modes: list[str] | None = Field(None, alias="inputModes")
     output_modes: list[str] | None = Field(None, alias="outputModes")
+    security_requirements: list[dict[str, list[str]]] | None = Field(
+        None, alias="securityRequirements"
+    )
 
 
 class AgentInterface(BaseModel):
+    """A2A v1.0.0 AgentInterface — a (url, protocolBinding, protocolVersion) tuple."""
+
     model_config = ConfigDict(populate_by_name=True)
     url: str
-    protocol_binding: str = Field(alias="protocolBinding")
-    protocol_version: str | None = Field(None, alias="protocolVersion")
+    protocol_binding: str = Field("JSONRPC", alias="protocolBinding")
+    protocol_version: str = Field("1.0", alias="protocolVersion")
     tenant: str | None = None
 
 
@@ -307,9 +340,8 @@ class AgentCard(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     name: str
     description: str | None = None
-    url: str
-    supported_interfaces: list[AgentInterface] | None = Field(None, alias="supportedInterfaces")
-    protocol_version: str = Field("0.3.0", alias="protocolVersion")
+    # The ONLY interface list; first entry is the preferred interface.
+    supported_interfaces: list[AgentInterface] = Field(alias="supportedInterfaces")
     version: str = "1.0.0"
     provider: AgentProvider | None = None
     documentation_url: str | None = Field(None, alias="documentationUrl")
@@ -322,33 +354,29 @@ class AgentCard(BaseModel):
         default=["text/plain", "application/json"], alias="defaultOutputModes"
     )
     skills: list[AgentSkill]
-    supports_authenticated_extended_card: bool = Field(
-        True, alias="supportsAuthenticatedExtendedCard"
-    )
     security_schemes: dict[str, Any] | None = Field(None, alias="securitySchemes")
     security: list[dict[str, list[str]]] | None = None
 
 
 # A2A Agent Card endpoints
-class AuthenticatedExtendedCardParams(BaseModel):
+class ExtendedAgentCardParams(BaseModel):
     metadata: dict[str, Any] | None = None
 
 
-class AuthenticatedExtendedCardRequest(JSONRPCRequest):
-    method: Literal["agent/authenticatedExtendedCard"] = "agent/authenticatedExtendedCard"
-    params: AuthenticatedExtendedCardParams | None = None
+class GetExtendedAgentCardRequest(JSONRPCRequest):
+    method: Literal["GetExtendedAgentCard"] = "GetExtendedAgentCard"
+    params: ExtendedAgentCardParams | None = None
 
 
-class AuthenticatedExtendedCardResponse(JSONRPCResponse):
+class GetExtendedAgentCardResponse(JSONRPCResponse):
     result: AgentCard | None = None
 
 
-# SSE stream response types
+# SSE StreamResponse oneof members (no ``kind`` discriminators; wrapped by member name)
 class StreamResponseTask(BaseModel):
-    """SSE event: initial task object."""
+    """StreamResponse member: initial task object."""
 
     model_config = ConfigDict(populate_by_name=True)
-    kind: Literal["task"] = "task"
     id: str
     context_id: str | None = Field(None, alias="contextId")
     status: TaskStatus
@@ -358,40 +386,40 @@ class StreamResponseTask(BaseModel):
 
 
 class StreamResponseStatusUpdate(BaseModel):
-    """SSE event: task status change."""
+    """StreamResponse member: task status change."""
 
     model_config = ConfigDict(populate_by_name=True)
-    kind: Literal["status-update"] = "status-update"
     task_id: str = Field(alias="taskId")
     context_id: str | None = Field(None, alias="contextId")
     status: TaskStatus
-    final: bool = False
+    metadata: dict[str, Any] | None = None
 
 
 class StreamResponseArtifactUpdate(BaseModel):
-    """SSE event: artifact/output chunk."""
+    """StreamResponse member: artifact/output chunk."""
 
     model_config = ConfigDict(populate_by_name=True)
-    kind: Literal["artifact-update"] = "artifact-update"
     task_id: str = Field(alias="taskId")
     context_id: str | None = Field(None, alias="contextId")
     artifact: Artifact
     append: bool = False
     last_chunk: bool = Field(False, alias="lastChunk")
+    metadata: dict[str, Any] | None = None
 
 
 A2ARequest = TypeAdapter(
     Annotated[
         MessageSendRequest
         | MessageStreamRequest
-        | SendTaskRequest
         | GetTaskRequest
         | CancelTaskRequest
-        | SetTaskPushNotificationRequest
-        | GetTaskPushNotificationRequest
-        | TaskResubscriptionRequest
-        | SendTaskStreamingRequest
-        | AuthenticatedExtendedCardRequest,
+        | ListTasksRequest
+        | CreateTaskPushNotificationConfigRequest
+        | GetTaskPushNotificationConfigRequest
+        | ListTaskPushNotificationConfigsRequest
+        | DeleteTaskPushNotificationConfigRequest
+        | SubscribeToTaskRequest
+        | GetExtendedAgentCardRequest,
         Field(discriminator="method"),
     ]
 )
@@ -459,9 +487,27 @@ class ContentTypeNotSupportedError(JSONRPCError):
     data: None = None
 
 
-class VersionNotSupportedError(JSONRPCError):
+class InvalidAgentResponseError(JSONRPCError):
+    code: int = -32006
+    message: str = "Invalid agent response"
+    data: None = None
+
+
+class ExtendedAgentCardNotConfiguredError(JSONRPCError):
     code: int = -32007
-    message: str = "Version not supported"
+    message: str = "Extended Agent Card is not configured"
+    data: None = None
+
+
+class ExtensionSupportRequiredError(JSONRPCError):
+    code: int = -32008
+    message: str = "Extension support is required"
+    data: None = None
+
+
+class VersionNotSupportedError(JSONRPCError):
+    code: int = -32009
+    message: str = "A2A version not supported"
     data: None = None
 
 

--- a/agentarea-platform/libs/common/agentarea_common/utils/types.py
+++ b/agentarea-platform/libs/common/agentarea_common/utils/types.py
@@ -41,7 +41,7 @@ class Part(BaseModel):
     raw: str | None = None  # base64-encoded bytes
     url: str | None = None
     filename: str | None = None
-    media_type: str | None = Field(None, alias="mediaType")
+    media_type: str | None = Field(default=None, alias="mediaType")
     metadata: dict[str, Any] | None = None
 
     @model_serializer
@@ -74,9 +74,9 @@ class Message(BaseModel):
     role: Literal["USER", "AGENT"]
     parts: list[Part]
     message_id: str = Field(default_factory=lambda: uuid4().hex, alias="messageId")
-    task_id: str | None = Field(None, alias="taskId")
-    context_id: str | None = Field(None, alias="contextId")
-    reference_task_ids: list[str] | None = Field(None, alias="referenceTaskIds")
+    task_id: str | None = Field(default=None, alias="taskId")
+    context_id: str | None = Field(default=None, alias="contextId")
+    reference_task_ids: list[str] | None = Field(default=None, alias="referenceTaskIds")
     extensions: list[str] | None = None
     metadata: dict[str, Any] | None = None
 
@@ -100,7 +100,7 @@ class Artifact(BaseModel):
     metadata: dict[str, Any] | None = None
     index: int = 0
     append: bool | None = None
-    last_chunk: bool | None = Field(None, alias="lastChunk")
+    last_chunk: bool | None = Field(default=None, alias="lastChunk")
 
 
 class Task(BaseModel):
@@ -322,7 +322,7 @@ class AgentSkill(BaseModel):
     input_modes: list[str] | None = Field(None, alias="inputModes")
     output_modes: list[str] | None = Field(None, alias="outputModes")
     security_requirements: list[dict[str, list[str]]] | None = Field(
-        None, alias="securityRequirements"
+        default=None, alias="securityRequirements"
     )
 
 

--- a/agentarea-platform/libs/common/agentarea_common/workflow/temporal_executor.py
+++ b/agentarea-platform/libs/common/agentarea_common/workflow/temporal_executor.py
@@ -81,7 +81,7 @@ def _extract_a2a_message_from_workflow_result(result: dict[str, Any]) -> dict[st
         return {}
 
     # Create A2A-compatible response
-    a2a_message = Message(role="agent", parts=[TextPart(text=agent_response_text)])
+    a2a_message = Message(role="AGENT", parts=[TextPart(text=agent_response_text)])
 
     # Create A2A-compatible artifact
     a2a_artifact = Artifact(

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
@@ -1322,6 +1322,36 @@ def make_agent_activities(dependencies: ActivityDependencies):
             # to avoid N+1 lookups when a single batch carries multiple
             # events for the same task.
             channel_origin_cache: dict[str, dict | None] = {}
+            push_configs_cache: dict[str, list] = {}
+
+            async def _resolve_push_configs(task_id_str: str) -> list:
+                if task_id_str in push_configs_cache:
+                    return push_configs_cache[task_id_str]
+                configs: list = []
+                try:
+                    from uuid import UUID as _UUID
+
+                    from agentarea_tasks.infrastructure.repository import (
+                        TaskRepository as _TaskRepository,
+                    )
+
+                    user_context_inner = UserContext(
+                        user_id=request.user_id,
+                        workspace_id=request.workspace_id,
+                    )
+                    async with ActivityContext(container, user_context_inner) as ctx_inner:
+                        session_inner = container._database.async_session_factory()
+                        ctx_inner._sessions.append(session_inner)
+                        task_repo = _TaskRepository(session_inner, user_context_inner)
+                        task = await task_repo.get_task(_UUID(task_id_str))
+                        if task and task.parameters:
+                            raw = task.parameters.get("a2a_push_configs")
+                            if isinstance(raw, list):
+                                configs = raw
+                except Exception:
+                    logger.exception("a2a push-config lookup failed for task=%s", task_id_str)
+                push_configs_cache[task_id_str] = configs
+                return configs
 
             async def _resolve_channel_origin(task_id_str: str) -> dict | None:
                 if task_id_str in channel_origin_cache:
@@ -1451,6 +1481,27 @@ def make_agent_activities(dependencies: ActivityDependencies):
                             broker=dependencies.broker_client,
                             stream=dependencies.channel_delivery_settings.OUTBOUND_STREAM,
                         )
+
+                        # A2A push notifications: one delivery per registered webhook.
+                        if task_id and task_id != "unknown":
+                            for cfg in await _resolve_push_configs(str(task_id)):
+                                cfg_id = cfg.get("id")
+                                cfg_url = cfg.get("url")
+                                if not cfg_id or not cfg_url:
+                                    continue
+                                await emit_channel_delivery(
+                                    event=event_with_id,
+                                    channel_origin={
+                                        "type": "a2a_webhook",
+                                        "url": cfg_url,
+                                        "task_id": str(task_id),
+                                        "config_id": cfg_id,
+                                        "presentation": "silent",
+                                    },
+                                    broker=dependencies.broker_client,
+                                    stream=dependencies.channel_delivery_settings.OUTBOUND_STREAM,
+                                    dedup_suffix=f"a2a:{cfg_id}",
+                                )
 
                     events_published += 1
 

--- a/agentarea-platform/libs/tasks/agentarea_tasks/domain/models.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/domain/models.py
@@ -116,6 +116,7 @@ class TaskUpdate(BaseModel):
     started_at: datetime | None = None
     completed_at: datetime | None = None
     execution_id: str | None = None
+    task_parameters: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None
 
     @field_validator("result", mode="before")

--- a/agentarea-platform/libs/tasks/agentarea_tasks/infrastructure/repository.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/infrastructure/repository.py
@@ -139,6 +139,9 @@ class TaskRepository(WorkspaceScopedRepository[TaskORM]):
                         # If it's not a dict (e.g., SQLAlchemy MetaData), convert to empty dict
                         value = {}
                     update_data["task_metadata"] = value
+                elif field == "task_parameters":
+                    # Domain field task_parameters maps to ORM column `parameters`.
+                    update_data["parameters"] = value
                 else:
                     update_data[field] = value
 

--- a/agentarea-platform/libs/triggers/agentarea_triggers/channels/activity_emit.py
+++ b/agentarea-platform/libs/triggers/agentarea_triggers/channels/activity_emit.py
@@ -32,6 +32,7 @@ async def emit_channel_delivery(
     channel_origin: dict[str, Any] | None,
     broker: BrokerClient,
     stream: str,
+    dedup_suffix: str | None = None,
 ) -> bool:
     """Run the channel-routing decision and submit to the outbound stream.
 
@@ -76,6 +77,8 @@ async def emit_channel_delivery(
                 event_type,
             )
         dedup_key = f"{task_id}:{event_type}:{event_id}"
+        if dedup_suffix:
+            dedup_key = f"{dedup_key}:{dedup_suffix}"
 
         await broker.submit(
             stream,

--- a/agentarea-platform/libs/triggers/agentarea_triggers/channels/adapters.py
+++ b/agentarea-platform/libs/triggers/agentarea_triggers/channels/adapters.py
@@ -334,6 +334,68 @@ class _ComposedAdapter:
         await self._send(channel_config, message)
 
 
+# ── A2A push webhook adapter ──────────────────────────────────────
+
+
+def _a2a_webhook_format(event: dict[str, Any], presentation: str) -> str:
+    """Format a workflow event as an A2A push-notification body (terminal only)."""
+    from agentarea_common.utils.a2a_push import build_push_notification_body
+
+    return build_push_notification_body(event) or ""
+
+
+def make_a2a_webhook_sender(
+    secret_reader: SecretReader,
+) -> Callable[[dict[str, Any], str], Awaitable[None]]:
+    """Build the sender that POSTs an A2A notification to a client webhook.
+
+    The webhook ``url`` is client-supplied, so it is SSRF-validated before every
+    send. The callback ``token`` lives in the secret store (never in task params)
+    and is echoed in ``X-A2A-Notification-Token`` so the client can authenticate us.
+    """
+
+    async def _send(channel_config: dict[str, Any], message: str) -> None:
+        from agentarea_common.utils.a2a_push import push_token_secret_name
+        from agentarea_common.utils.url_safety import UnsafeUrlError, validate_outbound_url
+
+        url = channel_config.get("url")
+        if not url or not message:
+            return
+        try:
+            validate_outbound_url(url)
+        except UnsafeUrlError as e:
+            # Misconfigured/hostile target — do not retry.
+            raise FatalError(f"unsafe push webhook url: {e}") from e
+
+        headers = {"Content-Type": "application/json"}
+        task_id = channel_config.get("task_id")
+        config_id = channel_config.get("config_id")
+        if task_id and config_id:
+            token = await secret_reader.get_secret(push_token_secret_name(task_id, config_id))
+            if token:
+                headers["X-A2A-Notification-Token"] = token
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(url, content=message, headers=headers)
+        except httpx.HTTPError as e:
+            raise RetryableError(f"push webhook network error: {e}") from e
+
+        if resp.status_code >= 500 or resp.status_code == 429:
+            raise RetryableError(f"push webhook returned {resp.status_code}")
+        if resp.status_code >= 400:
+            raise FatalError(f"push webhook returned {resp.status_code}")
+
+    return _send
+
+
+def make_a2a_webhook_adapter(secret_reader: SecretReader) -> _ComposedAdapter:
+    return _ComposedAdapter(
+        formatter=_a2a_webhook_format,
+        sender=make_a2a_webhook_sender(secret_reader),
+    )
+
+
 # ── Registration ──────────────────────────────────────────────────
 
 
@@ -356,3 +418,6 @@ def register_all_adapters(secret_reader: SecretReader) -> None:
             sender=make_http_sender(sender_cfg, secret_reader),
         )
         register_adapter(name, adapter)
+
+    # A2A push notifications: client-supplied webhooks, delivered as A2A events.
+    register_adapter("a2a_webhook", make_a2a_webhook_adapter(secret_reader))

--- a/agentarea-platform/libs/triggers/agentarea_triggers/channels/lazy_secret_manager.py
+++ b/agentarea-platform/libs/triggers/agentarea_triggers/channels/lazy_secret_manager.py
@@ -35,11 +35,24 @@ class LazySecretReader:
 
         database = get_database()
         async with database.async_session_factory() as session:
-            # Resolve workspace context from trigger_id in the secret name.
-            # Secret name pattern: "channel_cred:<channel_type>:<trigger_id>"
+            # Resolve workspace context from an id embedded in the secret name.
+            # Channel creds:   "channel_cred:<channel_type>:<trigger_id>"  → TriggerORM
+            # A2A push tokens: "a2a_push_token:<task_id>:<config_id>"      → TaskORM
             user_context: UserContext | None = None
             parts = name.split(":")
-            if len(parts) >= 3:
+            if name.startswith("a2a_push_token:") and len(parts) >= 3:
+                try:
+                    from agentarea_tasks.infrastructure.orm import TaskORM
+
+                    task_orm = await session.get(TaskORM, UUID(parts[1]))
+                    if task_orm:
+                        user_context = UserContext(
+                            user_id=str(getattr(task_orm, "created_by", "") or ""),
+                            workspace_id=str(task_orm.workspace_id),
+                        )
+                except (ValueError, Exception):
+                    logger.exception("Failed to resolve task for secret '%s'", name)
+            elif len(parts) >= 3:
                 try:
                     trigger_id = UUID(parts[-1])
                     trigger_orm = await session.get(TriggerORM, trigger_id)

--- a/agentarea-platform/tests/integration/test_a2a_streaming.py
+++ b/agentarea-platform/tests/integration/test_a2a_streaming.py
@@ -1,9 +1,14 @@
 """Integration test for A2A streaming functionality.
 
-This test verifies that the A2A message/stream endpoint properly:
-1. Creates tasks through TaskService
-2. Streams real events using TaskService.stream_task_events()
-3. Formats events appropriately for A2A protocol SSE responses
+Verifies that the A2A message/stream endpoint:
+1. Creates a task through TaskService
+2. Consumes the REAL workflow event stream (``workflow.WorkflowCompleted``,
+   ``workflow.LLMCallChunk``) surfaced by EventStreamService
+3. Emits A2A v0.3.0 SSE frames: a JSON-RPC-wrapped initial ``task`` event,
+   ``artifact-update`` frames for incremental output, and a terminal
+   ``status-update`` with ``final=True``.
+
+See ADR docs/adr/2026-06-20-a2a-transport-correctness.md.
 """
 
 import asyncio
@@ -25,10 +30,8 @@ class MockTaskService:
 
     def __init__(self):
         self.submitted_tasks = []
-        self.events = []
 
     async def submit_task(self, task: AgentTask) -> AgentTask:
-        """Mock task submission."""
         task.status = "running"
         task.execution_id = str(uuid4())
         self.submitted_tasks.append(task)
@@ -36,57 +39,61 @@ class MockTaskService:
 
 
 class MockAgentService:
-    """Mock AgentService for testing A2A streaming."""
-
     async def get(self, agent_id: UUID):
-        """Mock getting an agent."""
-        return {"id": agent_id, "name": "Test Agent", "status": "active"}
+        from types import SimpleNamespace
+
+        return SimpleNamespace(id=agent_id, name="Test Agent", status="active")
 
 
 class MockEventStreamService:
-    """Mock EventStreamService for testing A2A streaming."""
+    """Yields events in the real EventStreamService shape.
+
+    Real events carry the workflow payload under ``event_data['original_data']``
+    and use ``workflow.*`` event types.
+    """
 
     async def stream_events_for_task(self, task_id: UUID, event_patterns=None):
-        """Mock event streaming that yields test events."""
-        # Yield some test events
         test_events = [
             {
-                "event_type": "workflow.task_started",
-                "timestamp": "2024-01-01T00:00:00Z",
-                "data": {
-                    "task_id": str(task_id),
-                    "agent_id": "test-agent",
-                    "execution_id": "test-execution",
-                },
+                "event_type": "workflow.LLMCallChunk",
+                "event_data": {"original_data": {"task_id": str(task_id), "chunk": "Partial "}},
             },
             {
-                "event_type": "workflow.llm_call_started",
-                "timestamp": "2024-01-01T00:00:01Z",
-                "data": {"task_id": str(task_id), "model": "gpt-4", "prompt": "Test prompt"},
+                "event_type": "workflow.LLMCallChunk",
+                "event_data": {"original_data": {"task_id": str(task_id), "chunk": "answer"}},
             },
             {
-                "event_type": "workflow.task_completed",
-                "timestamp": "2024-01-01T00:00:02Z",
-                "data": {"task_id": str(task_id), "result": "Test result"},
+                "event_type": "workflow.WorkflowCompleted",
+                "event_data": {"original_data": {"task_id": str(task_id), "result": "Final answer"}},
             },
         ]
-
         for event in test_events:
             yield event
-            await asyncio.sleep(0.01)  # Small delay to simulate real streaming
+            await asyncio.sleep(0.01)
 
 
 class MockRequest:
-    """Mock FastAPI Request for testing."""
-
     def __init__(self):
         self.url = type("MockURL", (), {"scheme": "http", "netloc": "localhost:8000"})()
 
 
+def _parse_frames(chunks):
+    frames = []
+    for chunk in chunks:
+        chunk_str = chunk.decode() if isinstance(chunk, bytes) else chunk
+        if chunk_str.startswith("data: "):
+            data_str = chunk_str[6:].strip()
+            if data_str and data_str != "[DONE]":
+                try:
+                    frames.append(json.loads(data_str))
+                except json.JSONDecodeError:
+                    pass
+    return frames
+
+
 @pytest.mark.asyncio
 async def test_a2a_streaming_uses_real_events():
-    """Test that A2A streaming uses real EventStreamService event streaming."""
-    # Setup
+    """A2A streaming maps real workflow events to spec-compliant SSE frames."""
     mock_task_service = MockTaskService()
     mock_event_stream_service = MockEventStreamService()
     mock_agent_service = MockAgentService()
@@ -94,125 +101,111 @@ async def test_a2a_streaming_uses_real_events():
     agent_id = uuid4()
     request_id = "test-request-1"
 
-    # Create auth context
     auth_context = A2AAuthContext(
-        authenticated=True, user_id="test-user", auth_method="bearer_token", metadata={}
+        authenticated=True,
+        user_id="test-user",
+        workspace_id="test-workspace",
+        auth_method="bearer_token",
+        metadata={},
     )
 
-    # Test parameters
     params = {"message": {"role": "user", "parts": [{"text": "Test message for streaming"}]}}
 
-    # Call the A2A streaming handler
     response = await handle_message_stream_sse(
-        mock_request, request_id, params, mock_task_service, agent_id, auth_context, mock_agent_service, mock_event_stream_service
+        mock_request,
+        request_id,
+        params,
+        mock_task_service,
+        agent_id,
+        auth_context,
+        mock_agent_service,
+        mock_event_stream_service,
     )
 
-    # Verify response is StreamingResponse
     assert isinstance(response, StreamingResponse)
     assert response.media_type == "text/event-stream"
 
-    # Verify task was submitted
     assert len(mock_task_service.submitted_tasks) == 1
     submitted_task = mock_task_service.submitted_tasks[0]
     assert submitted_task.query == "Test message for streaming"
-    assert submitted_task.agent_id == agent_id
-    assert submitted_task.metadata["source"] == "a2a"
-    assert submitted_task.metadata["a2a_method"] == "message/stream"
+    assert submitted_task.metadata["a2a_method"] == "SendStreamingMessage"
 
-    # Collect streamed events
-    events = []
-    async for chunk in response.body_iterator:
-        # Handle both string and bytes
-        if isinstance(chunk, bytes):
-            chunk_str = chunk.decode()
-        else:
-            chunk_str = chunk
+    frames = _parse_frames([chunk async for chunk in response.body_iterator])
 
-        if chunk_str.startswith("data: "):
-            data_str = chunk_str[6:].strip()
-            if data_str and data_str != "[DONE]":
-                try:
-                    event_data = json.loads(data_str)
-                    events.append(event_data)
-                except json.JSONDecodeError:
-                    pass
+    # Every frame is a JSON-RPC 2.0 response wrapping a StreamResponse oneof member.
+    assert all(f.get("jsonrpc") == "2.0" for f in frames)
+    results = [f["result"] for f in frames]
+    # Member name = the single key of each result wrapper.
+    members = [next(iter(r.keys())) for r in results]
 
-    # Verify events were streamed
-    assert len(events) >= 4  # Initial task_created + 3 test events
+    # First frame: initial task object (wrapped under "task").
+    assert members[0] == "task"
+    assert results[0]["task"]["id"] == str(submitted_task.id)
+    assert results[0]["task"]["contextId"]  # non-null per spec
 
-    # Check initial task created event
-    task_created_event = events[0]
-    assert task_created_event["event"] == "task_created"
-    assert task_created_event["task_id"] == str(submitted_task.id)
+    # Incremental chunks become artifactUpdate frames.
+    artifact_updates = [r["artifactUpdate"] for r in results if "artifactUpdate" in r]
+    assert artifact_updates, "expected at least one artifactUpdate from LLM chunks"
+    streamed_text = "".join(
+        part["text"]
+        for au in artifact_updates
+        for part in au["artifact"]["parts"]
+        if part.get("text")
+    )
+    assert "Partial " in streamed_text
+    assert "answer" in streamed_text
+    assert "Final answer" in streamed_text  # final result emitted as last artifact
 
-    # Check that real events from TaskService were streamed
-    event_types = [event.get("event") for event in events[1:]]
-    assert "task_started" in event_types
-    assert "llm_call_started" in event_types
-    assert "task_completed" in event_types
-
-    # Verify A2A event format
-    for event in events[1:]:
-        assert "event" in event
-        assert "task_id" in event
-        assert "timestamp" in event
-        assert "data" in event
+    # Last frame: terminal statusUpdate with completed state (no final field).
+    assert members[-1] == "statusUpdate"
+    su = results[-1]["statusUpdate"]
+    assert "final" not in su
+    assert su["status"]["state"] == "COMPLETED"
 
 
 @pytest.mark.asyncio
 async def test_a2a_streaming_error_handling():
-    """Test A2A streaming error handling."""
+    """A2A streaming surfaces task-submission failures as an error frame."""
 
-    # Setup with failing task service
     class FailingTaskService:
         async def submit_task(self, task):
             raise ValueError("Task submission failed")
 
     mock_task_service = FailingTaskService()
+    mock_agent_service = MockAgentService()
+    mock_event_stream_service = MockEventStreamService()
     mock_request = MockRequest()
     agent_id = uuid4()
     request_id = "test-request-2"
 
     auth_context = A2AAuthContext(
-        authenticated=True, user_id="test-user", auth_method="bearer_token", metadata={}
+        authenticated=True,
+        user_id="test-user",
+        workspace_id="test-workspace",
+        auth_method="bearer_token",
+        metadata={},
     )
 
     params = {"message": {"role": "user", "parts": [{"text": "Test message"}]}}
 
-    # Call the handler
     response = await handle_message_stream_sse(
-        mock_request, request_id, params, mock_task_service, agent_id, auth_context
+        mock_request,
+        request_id,
+        params,
+        mock_task_service,
+        agent_id,
+        auth_context,
+        mock_agent_service,
+        mock_event_stream_service,
     )
 
-    # Verify error response
     assert isinstance(response, StreamingResponse)
 
-    # Collect error events
-    events = []
-    async for chunk in response.body_iterator:
-        # Handle both string and bytes
-        if isinstance(chunk, bytes):
-            chunk_str = chunk.decode()
-        else:
-            chunk_str = chunk
-
-        if chunk_str.startswith("data: "):
-            data_str = chunk_str[6:].strip()
-            if data_str:
-                try:
-                    event_data = json.loads(data_str)
-                    events.append(event_data)
-                except json.JSONDecodeError:
-                    pass
-
-    # Should have error event
-    assert len(events) >= 1
-    error_event = events[0]
-    assert error_event["event"] == "error"
-    assert "Task submission failed" in error_event["message"]
+    frames = _parse_frames([chunk async for chunk in response.body_iterator])
+    assert len(frames) >= 1
+    # Validation/submission failure is reported via the legacy error frame shape.
+    assert any(f.get("event") == "error" for f in frames)
 
 
 if __name__ == "__main__":
-    # Run the test
     asyncio.run(test_a2a_streaming_uses_real_events())
-    print("✅ A2A streaming test passed!")

--- a/agentarea-webapp/src/api/schema.d.ts
+++ b/agentarea-webapp/src/api/schema.d.ts
@@ -4134,11 +4134,6 @@ export interface components {
              */
             pushNotifications: boolean;
             /**
-             * Statetransitionhistory
-             * @default false
-             */
-            stateTransitionHistory: boolean;
-            /**
              * Streaming
              * @default false
              */
@@ -4170,11 +4165,6 @@ export interface components {
             documentationUrl?: string | null;
             /** Name */
             name: string;
-            /**
-             * Protocolversion
-             * @default 0.3.0
-             */
-            protocolVersion: string;
             provider?: components["schemas"]["AgentProvider"] | null;
             /** Security */
             security?: {
@@ -4187,14 +4177,7 @@ export interface components {
             /** Skills */
             skills: components["schemas"]["AgentSkill"][];
             /** Supportedinterfaces */
-            supportedInterfaces?: components["schemas"]["AgentInterface"][] | null;
-            /**
-             * Supportsauthenticatedextendedcard
-             * @default true
-             */
-            supportsAuthenticatedExtendedCard: boolean;
-            /** Url */
-            url: string;
+            supportedInterfaces: components["schemas"]["AgentInterface"][];
             /**
              * Version
              * @default 1.0.0
@@ -4262,12 +4245,21 @@ export interface components {
              */
             tools?: (components["schemas"]["CodeToolConfig"] | components["schemas"]["McpToolConfig-Input"] | components["schemas"]["AgentToolConfig"] | components["schemas"]["OpenApiToolConfig"])[] | null;
         };
-        /** AgentInterface */
+        /**
+         * AgentInterface
+         * @description A2A v1.0.0 AgentInterface — a (url, protocolBinding, protocolVersion) tuple.
+         */
         AgentInterface: {
-            /** Protocolbinding */
+            /**
+             * Protocolbinding
+             * @default JSONRPC
+             */
             protocolBinding: string;
-            /** Protocolversion */
-            protocolVersion?: string | null;
+            /**
+             * Protocolversion
+             * @default 1.0
+             */
+            protocolVersion: string;
             /** Tenant */
             tenant?: string | null;
             /** Url */
@@ -4386,6 +4378,10 @@ export interface components {
             name: string;
             /** Outputmodes */
             outputModes?: string[] | null;
+            /** Securityrequirements */
+            securityRequirements?: {
+                [key: string]: string[];
+            }[] | null;
             /** Tags */
             tags?: string[] | null;
         };

--- a/docs/adr/2026-06-20-a2a-push-notifications.md
+++ b/docs/adr/2026-06-20-a2a-push-notifications.md
@@ -1,0 +1,127 @@
+# ADR: A2A Push Notifications over the Channel Delivery Pipeline
+
+**Date:** 2026-06-20
+**Status:** Accepted — implemented 2026-06-20
+**Deciders:** Engineering team
+**Related:** `docs/adr/2026-06-20-a2a-transport-correctness.md`,
+`docs/adr/2026-05-21-event-architecture.md`
+
+---
+
+## Context
+
+A2A v1.0.0 defines push notifications: a client registers a `PushNotificationConfig`
+(webhook `url` + optional `token` + auth) for a task via
+`CreateTaskPushNotificationConfig`. The server then POSTs notifications to that webhook as
+the task progresses (notably on terminal state), so clients with no persistent connection
+(serverless, mobile, disconnected) still receive results. The pre-cutover implementation
+advertised `capabilities.pushNotifications=false` and returned `-32003` for the push-config
+methods.
+
+We already operate an **outbound channel delivery pipeline** (Telegram/Slack/Discord). It
+is structurally the same problem: *on a task event, perform an HTTP delivery to an address
+bound to the task.* That pipeline is durable and battle-tested:
+
+| Stage | Code |
+|---|---|
+| Resolve delivery target from task | `agent_execution_activities.py::publish_workflow_events_activity._resolve_channel_origin` (~1326, 1432-1453) |
+| Routing decision (visibility, dedup, format) | `channels/activity_emit.py::emit_channel_delivery` |
+| Adapter registry | `channels/adapters.py::register_adapter`, `make_http_sender` |
+| Durable drain + send | `channels/delivery_consumer.py::ChannelDeliveryConsumer` → `adapter.send` |
+| Visibility / presentation | `workflows/visibility.py` (RESULT set) |
+
+A reusable SSRF guard already exists: `agentarea_common/utils/url_safety.py`.
+
+## Decision
+
+**Model an A2A push webhook as another outbound channel type, `a2a_webhook`, and deliver
+notifications through the existing channel pipeline. Do not build a parallel delivery
+mechanism.**
+
+### Persistence — split like channels: non-secret in `task_parameters`, secrets in the secret store
+
+This mirrors exactly how channels are stored:
+- **Channel non-secret config** → Postgres (`triggers` table) / per-task reply address in
+  `task.task_parameters["channel_origin"]`.
+- **Channel credentials** (bot_token, …) → secret store, key `channel_cred:<type>:<trigger_id>`,
+  never returned in API responses (`channels/adapters.py:252`).
+
+So for push:
+- **Non-secret** (`id`, `url`, `presentation`, secret-ref) → `task.task_parameters["a2a_push_configs"]`
+  as a list. Consistent with `channel_origin`; the delivery activity already reads
+  `task.parameters`.
+- **Secret** (`token` / `authentication`) → **secret store**, by analogy with `channel_cred`.
+  A2A push has no standing trigger, so key by task + config: `a2a_push_token:<task_id>:<config_id>`.
+  Read only at send time to sign the callback; **never** echoed by `get`/`list`.
+
+Rationale: A2A push-config methods are always task-scoped (`list`/`get`/`delete` take a task
+id), so no cross-task query justifies a table; the event-architecture ADR already rejected
+new single-consumer tables as YAGNI; and keeping the token out of `task_parameters` JSON
+avoids leaking it via `get`/`list` responses and logs — matching the channels precedent.
+Revisit a table only if cross-task GC of stale webhooks is needed.
+
+Also accept push config at **send time** via `MessageSendParams.configuration.pushNotificationConfig`
+(currently missing from our `MessageSendParams`): it lands in `task_parameters` at submit,
+exactly like `channel_origin`, so the standalone `set` method is optional sugar over the same
+storage.
+
+### Delivery — generalize one target to many
+
+`publish_workflow_events_activity` resolves a single `channel_origin` today. Generalize to a
+**list of delivery targets** = the inbound `channel_origin` (if any) + one synthetic
+`{type: "a2a_webhook", url, token, config_id, presentation: "a2a_push"}` per registered push
+config. Emit one `emit_channel_delivery` per target. Dedup key already includes the event id
+and channel; extend with the target/config id so multiple webhooks each get their copy.
+
+### Adapter — `a2a_webhook`
+
+Register via `register_adapter("a2a_webhook", …)`:
+- **formatter** builds the A2A notification body (full event, per decision below).
+- **sender** = `make_http_sender` POSTing to `config.url`, echoing the client `token` in an
+  `X-A2A-Notification-Token` header so the client can authenticate the callback.
+- **SSRF guard**: validate `url` with `url_safety` both at `set` time (reject immediately)
+  and before each send (config may have been crafted to bypass).
+
+### Notification body — full event payload
+
+The POST body carries the v1.0.0 streaming payload — a `StreamResponse` `statusUpdate`
+wrapper (terminal `TaskState`, final answer in `status.message`, role `AGENT`, no `kind`/
+`final`) — reusing the mapping helpers from `agents_a2a.py` (`map_workflow_event_to_sse` /
+`convert_agent_task_to_a2a_task`).
+Clients receive the result without a follow-up `GetTask`. (Minimal "ping then poll" was
+considered and rejected: it adds a round-trip for no durability benefit since our delivery is
+already durable.)
+
+### Visibility
+
+Add an `a2a_push` presentation mapping to `workflows/visibility.py` = RESULT (terminal
+`WorkflowCompleted`/`Failed`/`Cancelled`) plus terminal STATUS. Push is not a chat firehose;
+intermediate chunks are not pushed.
+
+### RPC methods + capability
+
+- Flip `capabilities.pushNotifications=true`.
+- Implement `Create|Get|List|DeleteTaskPushNotificationConfig` against the JSON list, with
+  the v1.0.0 **flat** `TaskPushNotificationConfig` shape (`{taskId, id, url}` — no nested
+  `pushNotificationConfig`) — replacing the placeholder `-32003` branch. `delete` returns `null`.
+- Keep `-32003 PushNotificationNotSupportedError` only as the pre-flip fallback.
+
+### Multiple configs
+
+Supported (A2A allows N configs per task, each with an `id`). The JSON list holds them;
+`set` upserts by id (generating one if absent), `list` returns all, `delete` removes by
+`pushNotificationConfigId`.
+
+## Non-goals (deferred)
+
+- Webhook ownership verification (A2A's optional challenge handshake).
+- JWT-signed notifications / advanced auth schemes (only the echoed bearer token for now).
+- Cross-task config management / TTL GC (would motivate a table — out of scope until needed).
+
+## Consequences
+
+- A2A push reuses the durable outbound pipeline (Redis stream + consumer + Temporal activity
+  retry) — no new delivery/retry code, no drift from channel delivery.
+- One new adapter + a list-of-targets generalization + 4 thin RPC handlers + SSRF wiring.
+- `task_parameters` carries a small list per task; acceptable at expected scale.
+- SSRF is the principal risk and is mitigated by the shared `url_safety` guard at set + send.

--- a/docs/adr/2026-06-20-a2a-transport-correctness.md
+++ b/docs/adr/2026-06-20-a2a-transport-correctness.md
@@ -1,0 +1,174 @@
+# ADR: A2A Protocol Transport — Correct Result Flow & v1.0.0 Conformance
+
+**Date:** 2026-06-20
+**Status:** Accepted — implemented 2026-06-20 (clean cutover to A2A v1.0.0)
+**Deciders:** Engineering team
+**Related plans:** `docs/plans/2026-03-10-a2a-spec-compliance.md`, `docs/plans/2026-03-10-agent-delegation-remote-mcp.md`
+**Supersedes (doc):** `docs/agent-communication.md` (describes the retired ADK / `InMemoryTaskManager` delegation model)
+
+---
+
+## Context
+
+An audit of our A2A (Agent2Agent) implementation surfaced two classes of problem: a broken
+result flow, and significant drift from the protocol schema. We fixed the result flow first,
+then performed a **clean cutover from A2A v0.3.0 to the current v1.0.0** wire format (no
+dual-version support, no deprecated aliases).
+
+### 1. The result-flow was broken — A2A returned no agent output at all
+
+A2A is, architecturally, **just another transport into the task/event system** — the
+same system that powers inbound/outbound **channels** (Telegram/Slack/Discord). But the
+A2A layer was written against *assumed* task/event shapes that do not match what the
+execution engine actually produces:
+
+- **Non-streaming** (`GetTask`, `SendMessage` response): `convert_agent_task_to_a2a_task`
+  (`agents_a2a.py`) always set `artifacts=None`, `history=None`, `status.message=None` and
+  ignored `AgentTask.result`. The canonical final answer
+  (`task.result["response"]`, produced by the Temporal workflow's `state.final_response`,
+  see `temporal_orchestrator.get_workflow_status`) was never mapped onto the wire. A caller
+  could poll a `COMPLETED` task forever and never receive output.
+- **Streaming** (`SendStreamingMessage`, `SubscribeToTask`): the handler matched event types
+  `workflow.task_completed` / `task_completed` and `"llm_response"`. The real events emitted
+  by `publish_workflow_events_activity` and surfaced by `EventStreamService` are
+  `workflow.WorkflowCompleted` / `workflow.WorkflowFailed` / `workflow.WorkflowCancelled`
+  and `workflow.LLMCallChunk` (incremental text in `event_data["original_data"]["chunk"]`).
+  **No real event ever matched**, so streaming emitted neither incremental artifacts nor a
+  terminal event.
+- **Delegation** (`A2AAgentTool`): sends a message and immediately reads `task.artifacts` /
+  `status.message`. Since the send is *non-blocking* and returns a non-terminal `Task` (see
+  below), and the retrieval path did not map results, agent-to-agent delegation always
+  returned `"(No output from agent)"`.
+
+These are the canonical event/result facts the A2A layer MUST align to (verified in code):
+
+| Concept | Source of truth |
+|---|---|
+| Final answer (completed task) | `task.result["response"]` via `TaskService.get_task_with_workflow_status` |
+| Final answer (event) | `workflow.WorkflowCompleted` → `event_data["original_data"]["result" or "final_response"]` |
+| Incremental output | `workflow.LLMCallChunk` → `event_data["original_data"]["chunk"]` |
+| Terminal events | `workflow.WorkflowCompleted` / `WorkflowFailed` / `WorkflowCancelled` |
+| Failure detail | `task.error_message` / workflow status `error` |
+| Channel correlation | `task.task_parameters["channel_origin"]` |
+| Canonical task entry point | `TaskService.create_and_execute_task_with_workflow` / `submit_task` |
+
+### 2. Version & spec drift — cutover to A2A v1.0.0
+
+Non-blocking send is **not** a bug: the spec allows a message send to return a *non-terminal*
+`Task` for long-running work, with the client retrieving the result via task polling,
+subscription, or push notifications. Forcing the HTTP request to block until the agent
+finishes would time out behind proxies/load-balancers — exactly the failure mode we must
+avoid. So we keep send non-blocking and make the **retrieval paths** work.
+
+Beyond that, the implementation targeted a stale, partially-invented mix of v0.3.0. Rather
+than patch toward v0.3.0 and carry deprecated aliases, we cut **cleanly over to v1.0.0**,
+the current normative release. v1.0.0 is Protobuf-normative and changes the JSON wire in
+ways that are incompatible with 0.3.0, so a dual-version shim would have been pure overhead
+for a surface with no external 0.3.0 clients yet. Key v1.0.0 wire differences adopted:
+
+- **Methods are PascalCase** RPC names: `SendMessage`, `SendStreamingMessage`, `GetTask`,
+  `CancelTask`, `SubscribeToTask`, `ListTasks`, `CreateTaskPushNotificationConfig`,
+  `GetTaskPushNotificationConfig`, `ListTaskPushNotificationConfigs`,
+  `DeleteTaskPushNotificationConfig`, `GetExtendedAgentCard` (replacing the slash-style
+  `message/send`, `tasks/get`, … names).
+- **No `kind` discriminators.** `Task`, `Message`, `Part`, and streaming events drop the
+  `kind` field entirely (the Protobuf `oneof` carries the discriminator structurally).
+- **`Part` is flat:** a part holds `text` *or* `data` *or* `raw`/`url` with `mediaType` —
+  no nested `TextPart`/`FilePart`/`DataPart` wrappers, no `kind`.
+- **`Message.role`** is the enum `USER` / `AGENT` (uppercase).
+- **`TaskState`** uses SCREAMING_SNAKE values: `SUBMITTED`, `WORKING`, `COMPLETED`,
+  `FAILED`, `CANCELED`, `INPUT_REQUIRED`, `REJECTED`, `AUTH_REQUIRED`, and
+  `TASK_STATE_UNSPECIFIED`.
+- **Streaming** uses the `StreamResponse` `oneof`: each frame wraps exactly one of `task`,
+  `statusUpdate`, or `artifactUpdate`. The 0.3.0 `final` boolean is gone (terminal is
+  conveyed by the terminal `TaskState`).
+- **`AgentCard`** advertises transports via `supportedInterfaces[]` (each entry =
+  `{url, protocolBinding, protocolVersion:"1.0"}`, first is preferred); there is no
+  top-level `url` / `protocolVersion` / `preferredTransport` / `additionalInterfaces`. The
+  extended-card flag moves into `capabilities.extendedAgentCard`; `stateTransitionHistory`
+  is removed; `provider.url` and per-skill `tags` are required.
+- **`A2A-Version` header** is part of v1.0.0: absent ⇒ treated as `1.0`; a non-`1.x`
+  version ⇒ `-32009 VersionNotSupportedError`.
+- **Error codes:** `-32007` = `ExtendedAgentCardNotConfiguredError`,
+  `-32008` = `ExtensionSupportRequiredError`, `-32009` = `VersionNotSupportedError`.
+
+---
+
+## Decision
+
+**Treat A2A as a first-class transport over the existing task/event system, reuse the
+canonical result-extraction the channels already rely on, and speak A2A v1.0.0 on the wire.
+Do not invent A2A-specific task or event semantics, and do not carry 0.3.0 compatibility.**
+
+### D1 — One canonical `AgentTask → A2A Task` mapping
+
+A single helper builds the A2A `Task` for every non-streaming response (`GetTask`,
+`SendMessage`, `CancelTask`, `ListTasks`, delegation):
+
+- `id = str(task.id)`, `contextId =` a stable non-null context id (derive from
+  `task.metadata["a2a_context_id"]` if present, else `str(task.id)`). No `kind` field.
+- `status.state` mapped from `task.status` to the v1.0.0 `TaskState` enum (covers all states).
+- On terminal success: emit `artifacts = [Artifact(artifactId=…, parts=[{text: <final>}])]`
+  where `<final> = task.result.get("response")` (fallback `final_response` / stringified).
+  Mirror the text into `status.message` (role `AGENT`) so spec-minimal clients that only read
+  `status.message` still work.
+- On failure: put `task.error_message` into `status.message`.
+
+### D2 — Streaming consumes the real event stream
+
+`SendStreamingMessage` and `SubscribeToTask` map the actual events onto the `StreamResponse`
+`oneof`:
+
+- first frame = `task` (the initial Task object).
+- incremental = `event_type == workflow.LLMCallChunk` → an `artifactUpdate` frame carrying
+  `original_data["chunk"]`.
+- terminal = `event_type in {workflow.WorkflowCompleted, workflow.WorkflowFailed, workflow.WorkflowCancelled}`
+  → a final `artifactUpdate` with the final text from `original_data["result"|"final_response"]`,
+  then a terminal `statusUpdate` with the terminal `TaskState` (no `final` boolean).
+- all event payloads are read from `event_data["original_data"]`.
+
+The mapping (`map_workflow_event_to_sse`) is shared with push delivery so streaming and
+channels stay in lockstep.
+
+### D3 — Delegation polls for the terminal result
+
+`A2AAgentTool.execute` sends `SendMessage`, then **polls `GetTask`** on the same `/rpc`
+endpoint until the task reaches a terminal state or a bounded budget elapses (default
+≤ 110 s, under the 120 s activity timeout). It then extracts text via the same artifact/
+status-message logic (flat parts: text if `text` is present, data if `data` is present).
+HTTP requests stay short; waiting is a series of polls — no long-held connection to time
+out. (Subscription via `SendStreamingMessage` remains a future optimization.)
+
+### D4 — A2A v1.0.0 conformance (clean cutover)
+
+- All methods renamed to the v1.0.0 PascalCase set; the 0.3.0 slash-style names are removed,
+  **no deprecated aliases**.
+- Wire types migrated: drop all `kind` fields; flatten `Part`; uppercase `Message.role`;
+  SCREAMING_SNAKE `TaskState`; `StreamResponse` `oneof` frames without `final`.
+- `AgentCard` restructured to `supportedInterfaces[]` + `capabilities.extendedAgentCard`,
+  required `provider.url` and per-skill `tags`; top-level `url`/`protocolVersion`/
+  `preferredTransport` removed.
+- Enforce the `A2A-Version` header (absent ⇒ 1.0; non-1.x ⇒ `-32009`); accept
+  `application/a2a+json` (and JSON-RPC) request bodies.
+- Adopt the v1.0.0 error codes (`-32007`/`-32008`/`-32009`).
+
+### Non-goals (deferred)
+
+- gRPC / HTTP+JSON transports (v1.0.0 requires only one; JSON-RPC stays primary).
+- Async fan-out / supervisor delegation (tracked in the resilience plan).
+- A2A protocol extensions (`-32008` is wired but no extension is required yet).
+
+---
+
+## Consequences
+
+- A2A `GetTask` / `SendMessage` / streaming return real agent output; agent-to-agent
+  delegation works end-to-end.
+- A2A and channels share one result-extraction / event-mapping code path → they cannot
+  drift again.
+- The wire format matches A2A v1.0.0 for the implemented method set; there is a single
+  protocol version to reason about (no 0.3.0 compatibility surface).
+- Existing 0.3.0 callers (if any) break by design — acceptable given no external 0.3.0
+  consumers and the incompatibility of the two wire formats.
+- This ADR is the authoritative description of how a task result is returned to an A2A
+  caller; `docs/agent-communication.md` is retired and should be rewritten to point here.


### PR DESCRIPTION
## Summary

Makes AgentArea's A2A (Agent2Agent) support correct and real against the spec, and cuts the wire **cleanly over from v0.3.0 to v1.0.0** (no dual-version support, no deprecated aliases). A2A is treated as a first-class transport over the existing task/event system, reusing the same canonical result-extraction the **channels** pipeline already relies on — so the two cannot drift again.

## Why

An audit found the A2A layer returned **no agent output at all** (assumed task/event shapes that never matched what the execution engine produces), and the wire format was a stale, partially-invented mix of v0.3.0.

## What changed

### Result flow (was broken)
- `convert_agent_task_to_a2a_task` now maps `task.result["response"]` → `artifacts` + `status.message`, so `GetTask` / `SendMessage` / delegation return real output.
- Streaming consumes the **real** workflow events (`workflow.WorkflowCompleted/Failed/Cancelled`, `workflow.LLMCallChunk`) instead of names that never matched.
- `A2AAgentTool` sends `SendMessage`, then polls `GetTask` until terminal (bounded ≤110s budget, under the 120s activity timeout) — short HTTP requests, no long-held connection.

### A2A v1.0.0 wire
- **PascalCase methods**: `SendMessage`, `SendStreamingMessage`, `GetTask`, `CancelTask`, `SubscribeToTask`, `ListTasks`, `Create/Get/List/DeleteTaskPushNotificationConfig`, `GetExtendedAgentCard`.
- Drop all `kind` discriminators; **flat `Part`** (`text`/`data`/`raw`/`url` + `mediaType`); uppercase `Message.role` (`USER`/`AGENT`); SCREAMING_SNAKE `TaskState`.
- Streaming via `StreamResponse` **oneof** (`task`/`statusUpdate`/`artifactUpdate`), no `final` boolean.
- `AgentCard` restructured: `supportedInterfaces[]` + `capabilities.extendedAgentCard`, required `provider.url` and per-skill `tags`; no top-level `url`/`protocolVersion`/`preferredTransport`.
- Enforce `A2A-Version` header (absent → 1.0; non-1.x → `-32009`); accept `application/a2a+json`.
- New error codes: `-32007` ExtendedAgentCardNotConfigured, `-32008` ExtensionSupportRequired, `-32009` VersionNotSupported.

### Push notifications — reuse the channel delivery pipeline
- New `a2a_webhook` outbound adapter; `publish_workflow_events_activity` resolves **N delivery targets** (inbound `channel_origin` + each registered push config) with a per-target `dedup_suffix`.
- Non-secret config in `task_parameters["a2a_push_configs"]`; callback **token in the secret store** (`a2a_push_token:<task_id>:<config_id>`), never echoed by get/list.
- **SSRF guard** (`validate_outbound_url`) at config-set time and before each send.
- Delivery rides the existing durable Redis-stream + consumer + Temporal-activity retry path — no parallel delivery/retry code.

### Delegation
- A single `DelegationTool` facade per agent; the transport (local execution vs A2A flow) is chosen by the binding **behind** the facade depending on the target agent.

## Testing
- **62** A2A tests green (push, agent-card spec, logging, streaming, client tool, delegation flow, factory).
- Channel/delivery suites green (`a2a_webhook` adapter on the 1.0 wire).
- No regressions: **629** common/tasks/triggers tests pass.
- `ruff check` clean on all changed files.
- Verified in an **isolated worktree off `main`** (62 passed) — the branch is self-contained, no dependency on other in-flight work.

## Docs
- ADR: `docs/adr/2026-06-20-a2a-transport-correctness.md` (result flow + v1.0.0 cutover)
- ADR: `docs/adr/2026-06-20-a2a-push-notifications.md` (push over the channel pipeline)