### PR TITLE
feat: trigger task-text fallback, MCP catalog + budgets/billing/audit webapp work

### DIFF
--- a/agentarea-platform/libs/execution/agentarea_execution/activities/trigger_execution_activities.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/trigger_execution_activities.py
@@ -283,6 +283,10 @@ def make_trigger_activities(dependencies: ActivityDependencies):
                         top_level_text = execution_data.get("text")
                         if top_level_text:
                             message_texts = [top_level_text]
+                    if not message_texts:
+                        task_text = trigger.task_parameters.get("text")
+                        if isinstance(task_text, str) and task_text.strip():
+                            message_texts = [task_text.strip()]
                     query = (
                         "\n".join(message_texts)
                         if message_texts
@@ -561,6 +565,10 @@ def make_trigger_activities(dependencies: ActivityDependencies):
                     top_level_text = execution_data.get("text")
                     if top_level_text:
                         message_texts = [top_level_text]
+                if not message_texts:
+                    task_text = trigger.task_parameters.get("text")
+                    if isinstance(task_text, str) and task_text.strip():
+                        message_texts = [task_text.strip()]
                 query = (
                     "\n".join(message_texts)
                     if message_texts

--- a/agentarea-platform/libs/execution/tests/unit/test_trigger_query_extraction.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_trigger_query_extraction.py
@@ -7,14 +7,24 @@ Covers webhook-based (Telegram, Slack, Discord, etc.) and poll-based (extractors
 class TestTriggerQueryFromWebhookParsedData:
     """Webhook parsers put text at top level of execution_data."""
 
-    def _extract_query(self, execution_data: dict, trigger_description: str = "Default trigger") -> str:
+    def _extract_query(
+        self,
+        execution_data: dict,
+        trigger_description: str = "Default trigger",
+        task_parameters: dict | None = None,
+    ) -> str:
         """Replicate the query extraction logic from trigger_execution_activities."""
+        task_parameters = task_parameters or {}
         extracted_events = execution_data.get("extracted_events", [])
         message_texts = [e.get("text") for e in extracted_events if e.get("text")]
         if not message_texts:
             top_level_text = execution_data.get("text")
             if top_level_text:
                 message_texts = [top_level_text]
+        if not message_texts:
+            task_text = task_parameters.get("text")
+            if isinstance(task_text, str) and task_text.strip():
+                message_texts = [task_text.strip()]
         return "\n".join(message_texts) if message_texts else (
             trigger_description or "Execute trigger"
         )
@@ -48,6 +58,19 @@ class TestTriggerQueryFromWebhookParsedData:
         }
         query = self._extract_query(execution_data, "Monitor GitHub pushes")
         assert query == "Monitor GitHub pushes"
+
+    def test_task_parameter_text_used_before_description(self):
+        """Task text configured on the trigger is used when event data has no text."""
+        execution_data = {
+            "webhook_type": "generic",
+            "body": {"event": "scheduled"},
+        }
+        query = self._extract_query(
+            execution_data,
+            "Fallback description",
+            {"text": "Run the scheduled report"},
+        )
+        assert query == "Run the scheduled report"
 
     def test_empty_text_falls_back_to_description(self):
         """Empty string text should fall back to description."""
@@ -99,14 +122,24 @@ class TestTriggerQueryFromWebhookParsedData:
 class TestTriggerServiceQueryExtraction:
     """Same logic in trigger_service.py uses 'events' key instead of 'extracted_events'."""
 
-    def _extract_query(self, trigger_data: dict, trigger_description: str = "Default trigger") -> str:
+    def _extract_query(
+        self,
+        trigger_data: dict,
+        trigger_description: str = "Default trigger",
+        task_parameters: dict | None = None,
+    ) -> str:
         """Replicate the query extraction logic from trigger_service."""
+        task_parameters = task_parameters or {}
         events = trigger_data.get("events", [])
         message_texts = [e.get("text") for e in events if e.get("text")]
         if not message_texts:
             top_level_text = trigger_data.get("text")
             if top_level_text:
                 message_texts = [top_level_text]
+        if not message_texts:
+            task_text = task_parameters.get("text")
+            if isinstance(task_text, str) and task_text.strip():
+                message_texts = [task_text.strip()]
         return "\n".join(message_texts) if message_texts else (
             trigger_description or "Execute trigger"
         )
@@ -131,3 +164,13 @@ class TestTriggerServiceQueryExtraction:
         trigger_data = {"raw_data": {}}
         query = self._extract_query(trigger_data, "Cron job trigger")
         assert query == "Cron job trigger"
+
+    def test_task_parameter_text_used_before_description(self):
+        """Cron/fallback trigger text becomes the task query before description."""
+        trigger_data = {"raw_data": {}}
+        query = self._extract_query(
+            trigger_data,
+            "Cron job trigger",
+            {"text": "Summarize yesterday's metrics"},
+        )
+        assert query == "Summarize yesterday's metrics"

--- a/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
+++ b/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
@@ -81,6 +81,82 @@ class TestDetectType:
             RegistryService._detect_type({"servers": {"not": "a list"}})
 
 
+class TestParseMCPServers:
+    def _telegram_entry(self):
+        # Mirrors data/catalog/mcp-servers.json (standard MCP registry format,
+        # pypi package → stdio command wrapped by mcp-bridge).
+        return {
+            "servers": [
+                {
+                    "server": {
+                        "name": "ai.agentarea.catalog/telegram",
+                        "title": "Telegram",
+                        "description": "Telegram MCP server (Telethon).",
+                        "version": "0.6.3",
+                        "packages": [
+                            {
+                                "registryType": "pypi",
+                                "identifier": "telegram-mcp",
+                                "name": "telegram-mcp",
+                                "version": "0.6.3",
+                                "environmentVariables": [
+                                    {"name": "TELEGRAM_API_ID", "required": True, "isSecret": True},
+                                    {"name": "TELEGRAM_API_HASH", "required": True, "isSecret": True},
+                                    {
+                                        "name": "TELEGRAM_SESSION_STRING",
+                                        "required": True,
+                                        "isSecret": True,
+                                    },
+                                    {
+                                        "name": "TELEGRAM_EXPOSED_TOOLS",
+                                        "required": False,
+                                        "isSecret": False,
+                                        "default": "read-only",
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                    "_meta": {
+                        "io.modelcontextprotocol.registry/official": {"isLatest": True}
+                    },
+                }
+            ]
+        }
+
+    def test_pypi_package_parses_to_uvx_command(self):
+        items = RegistryService._parse_mcp_servers(self._telegram_entry())
+
+        # Only the pypi package → a single command-type item.
+        assert len(items) == 1
+        spec = items[0]["spec"]
+        assert items[0]["name"] == "Telegram"
+        assert items[0]["external_id"] == "ai.agentarea.catalog/telegram/command"
+        assert spec["connection_type"] == "command"
+        assert spec["command"] == "uvx"
+        assert spec["args"] == ["telegram-mcp"]
+        assert spec["transport"] == "stdio"
+
+    def test_env_schema_preserved_for_ui_and_secret_routing(self):
+        items = RegistryService._parse_mcp_servers(self._telegram_entry())
+        env_schema = items[0]["spec"]["env_schema"]
+
+        names = [e["name"] for e in env_schema]
+        assert names == [
+            "TELEGRAM_API_ID",
+            "TELEGRAM_API_HASH",
+            "TELEGRAM_SESSION_STRING",
+            "TELEGRAM_EXPOSED_TOOLS",
+        ]
+        # Credentials route through the secret manager (isSecret) and are required.
+        by_name = {e["name"]: e for e in env_schema}
+        assert by_name["TELEGRAM_SESSION_STRING"]["isSecret"] is True
+        assert by_name["TELEGRAM_SESSION_STRING"]["required"] is True
+        # Read-only by default, user-overridable, not a secret.
+        assert by_name["TELEGRAM_EXPOSED_TOOLS"]["default"] == "read-only"
+        assert by_name["TELEGRAM_EXPOSED_TOOLS"]["isSecret"] is False
+
+
 class TestParseLLMProviders:
     def test_basic_provider(self):
         data = {

--- a/agentarea-platform/libs/triggers/agentarea_triggers/trigger_service.py
+++ b/agentarea-platform/libs/triggers/agentarea_triggers/trigger_service.py
@@ -1057,6 +1057,10 @@ class TriggerService:
                     top_level_text = trigger_data.get("text")
                     if top_level_text:
                         message_texts = [top_level_text]
+                if not message_texts:
+                    task_text = trigger.task_parameters.get("text")
+                    if isinstance(task_text, str) and task_text.strip():
+                        message_texts = [task_text.strip()]
                 query = (
                     "\n".join(message_texts)
                     if message_texts

--- a/agentarea-webapp/messages/en.json
+++ b/agentarea-webapp/messages/en.json
@@ -290,6 +290,76 @@
       "title": "Billing isn't available here",
       "description": "This deployment doesn't include the billing service. Subscription and usage are managed by your provider."
     },
+    "cloudMigration": {
+      "badge": "Self-hosted deployment",
+      "title": "Billing is managed in Agentarea Cloud",
+      "description": "This local deployment does not manage payments. In cloud, this page becomes a focused billing workspace for payment methods, payment history, and hosted controls around public agents.",
+      "openCloud": "Migrate to cloud",
+      "contactSales": "Talk to sales",
+      "benefits": {
+        "paymentMethods": {
+          "title": "Connect payment methods",
+          "description": "Cloud will show concrete ways to attach billing providers and keep payment setup outside the local app."
+        },
+        "paymentHistory": {
+          "title": "Payment history",
+          "description": "A compact table for invoices, charges, and billing events belongs in the hosted billing service."
+        },
+        "publicAgents": {
+          "title": "Make agents public",
+          "description": "Expose selected agents on the internet through hosted endpoints instead of running your own ingress and public auth layer."
+        },
+        "guardrails": {
+          "title": "Hosted guardrails",
+          "description": "Managed policy checks, quotas, approval paths, and audit trails travel with agents when they run in cloud."
+        }
+      }
+    },
+    "cloudBilling": {
+      "badge": "Cloud deployment",
+      "title": "Cloud billing workspace",
+      "description": "This page can show the hosted billing surface for the current workspace: migration entry point, payment setup, payment history, public agents, hosted guardrails, and infrastructure context.",
+      "openCloud": "Migrate to cloud",
+      "contactSales": "Talk to sales",
+      "estimate": {
+        "title": "Current setup in Agentarea Cloud",
+        "subtitle": "Infra estimate is based on CPU and RAM telemetry. Agent spend is shown separately.",
+        "infraLabel": "Estimated cloud infrastructure",
+        "telemetryPending": "Telemetry pending",
+        "basedOnResources": "CPU/RAM based",
+        "cpu": "CPU core-hours",
+        "memory": "RAM GB-hours",
+        "agents": "Agents",
+        "connections": "Connections",
+        "taskRuns": "Task runs tracked"
+      },
+      "agentUsage": {
+        "label": "Agent usage:",
+        "description": "{spend} month-to-date agent spend, projected {projected} by month end. This is usage context, not the infrastructure estimate."
+      },
+      "features": {
+        "paymentMethods": {
+          "title": "Connect payment methods",
+          "description": "Cloud can show concrete billing provider setup without mixing payment controls into the OSS app."
+        },
+        "paymentHistory": {
+          "title": "Payment history",
+          "description": "A hosted table for invoices, charges, and billing events can live here when cloud billing is enabled."
+        },
+        "publicAgents": {
+          "title": "Make agents public",
+          "description": "Expose selected agents to the internet through hosted endpoints, ingress, auth, and rate limits."
+        },
+        "guardrails": {
+          "title": "Hosted guardrails",
+          "description": "Managed policy checks, quotas, approvals, and audit trails stay attached to cloud-run agents."
+        },
+        "managedInfra": {
+          "title": "Guaranteed infrastructure",
+          "description": "Cloud can present managed runtime capacity, uptime posture, and support commitments in one place."
+        }
+      }
+    },
     "empty": {
       "title": "No billing data yet",
       "description": "Subscription and usage details will appear here once available."

--- a/agentarea-webapp/messages/ru.json
+++ b/agentarea-webapp/messages/ru.json
@@ -255,6 +255,76 @@
       "title": "Биллинг здесь недоступен",
       "description": "В этой инсталляции нет сервиса биллинга. Подпиской и потреблением управляет ваш провайдер."
     },
+    "cloudMigration": {
+      "badge": "Self-hosted инсталляция",
+      "title": "Биллинг управляется в Agentarea Cloud",
+      "description": "Локальная инсталляция не управляет оплатой. В cloud эта страница станет простой billing workspace: способы привязки оплаты, история платежей и hosted controls для публичных агентов.",
+      "openCloud": "Перейти в cloud",
+      "contactSales": "Связаться с отделом продаж",
+      "benefits": {
+        "paymentMethods": {
+          "title": "Привязка оплаты",
+          "description": "В cloud будут конкретные способы подключить billing providers, не смешивая payment setup с локальным приложением."
+        },
+        "paymentHistory": {
+          "title": "История платежей",
+          "description": "Компактная таблица invoice, charge и billing events должна жить в hosted billing service."
+        },
+        "publicAgents": {
+          "title": "Сделать агента публичным",
+          "description": "Открывайте выбранных агентов в интернете через hosted endpoints без своего ingress и публичного auth-слоя."
+        },
+        "guardrails": {
+          "title": "Hosted guardrails",
+          "description": "Managed policy checks, квоты, approval-пути и audit trail остаются рядом с агентами, когда они работают в cloud."
+        }
+      }
+    },
+    "cloudBilling": {
+      "badge": "Cloud инсталляция",
+      "title": "Cloud billing workspace",
+      "description": "Эта страница может показывать hosted billing surface для текущего workspace: migration entry point, привязку оплаты, историю платежей, публичных агентов, hosted guardrails и контекст инфраструктуры.",
+      "openCloud": "Migrate to cloud",
+      "contactSales": "Связаться с отделом продаж",
+      "estimate": {
+        "title": "Текущий setup в Agentarea Cloud",
+        "subtitle": "Оценка инфраструктуры считается по CPU и RAM telemetry. Agent spend показывается отдельно.",
+        "infraLabel": "Оценка cloud infrastructure",
+        "telemetryPending": "Ждём telemetry",
+        "basedOnResources": "По CPU/RAM",
+        "cpu": "CPU core-hours",
+        "memory": "RAM GB-hours",
+        "agents": "Агенты",
+        "connections": "Подключения",
+        "taskRuns": "Запуски задач"
+      },
+      "agentUsage": {
+        "label": "Agent usage:",
+        "description": "{spend} agent spend с начала месяца, прогноз {projected} к концу месяца. Это контекст использования, а не оценка инфраструктуры."
+      },
+      "features": {
+        "paymentMethods": {
+          "title": "Привязка оплаты",
+          "description": "Cloud может показывать конкретную настройку billing provider без payment controls внутри OSS приложения."
+        },
+        "paymentHistory": {
+          "title": "История платежей",
+          "description": "Hosted таблица invoice, charge и billing events появится здесь, когда cloud billing включён."
+        },
+        "publicAgents": {
+          "title": "Make agents public",
+          "description": "Открывайте выбранных агентов в интернет через hosted endpoints, ingress, auth и rate limits."
+        },
+        "guardrails": {
+          "title": "Hosted guardrails",
+          "description": "Managed policy checks, квоты, approvals и audit trails остаются привязанными к cloud-run агентам."
+        },
+        "managedInfra": {
+          "title": "Гарантированная инфраструктура",
+          "description": "Cloud может показывать managed runtime capacity, uptime posture и support commitments в одном месте."
+        }
+      }
+    },
     "empty": {
       "title": "Пока нет данных о биллинге",
       "description": "Информация о подписке и потреблении появится здесь, когда станет доступной."

--- a/agentarea-webapp/src/app/(main)/budgets/components/BudgetCapPanel.tsx
+++ b/agentarea-webapp/src/app/(main)/budgets/components/BudgetCapPanel.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, CheckCircle2, DollarSign, Gauge } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import { updateWorkspaceSettingsAction } from "@/lib/server-actions";
+import { cn } from "@/lib/utils";
+
+const fmt = (v: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: v > 0 && v < 0.01 ? 4 : 2,
+    maximumFractionDigits: v > 0 && v < 0.01 ? 4 : 2,
+  }).format(v);
+
+function parseCap(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return { value: null, error: null };
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return {
+      value: null,
+      error: "Enter a positive number, or leave it empty to remove the cap.",
+    };
+  }
+
+  return { value: parsed, error: null };
+}
+
+export function BudgetCapPanel({
+  initialCap,
+  mtdSpend,
+  settingsError,
+}: {
+  initialCap: number | null;
+  mtdSpend: number;
+  settingsError: string | null;
+}) {
+  const router = useRouter();
+  const [cap, setCap] = useState(initialCap);
+  const [capInput, setCapInput] = useState(
+    initialCap == null ? "" : String(initialCap)
+  );
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [message, setMessage] = useState<string | null>(settingsError);
+  const [isPending, startTransition] = useTransition();
+
+  const parsed = useMemo(() => parseCap(capInput), [capInput]);
+  const capPct = cap && cap > 0 ? (mtdSpend / cap) * 100 : null;
+  const displayPct = capPct == null ? 0 : Math.min(capPct, 100);
+  const isOverCap = capPct != null && capPct >= 100;
+  const isNearCap = capPct != null && capPct >= 80 && capPct < 100;
+
+  const saveCap = () => {
+    if (parsed.error) {
+      setStatus("error");
+      setMessage(parsed.error);
+      return;
+    }
+
+    setStatus("idle");
+    setMessage(null);
+
+    startTransition(async () => {
+      const { data, error } = await updateWorkspaceSettingsAction(parsed.value);
+      if (error || !data) {
+        setStatus("error");
+        setMessage(error || "Failed to update workspace cap");
+        return;
+      }
+
+      setCap(data.monthly_cap_usd);
+      setCapInput(
+        data.monthly_cap_usd == null ? "" : String(data.monthly_cap_usd)
+      );
+      setStatus("success");
+      setMessage("Workspace monthly cap updated.");
+      router.refresh();
+    });
+  };
+
+  return (
+    <section className="rounded-md border border-zinc-200/70 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-border bg-muted/30">
+              <Gauge className="h-4 w-4 text-primary dark:text-accent-foreground" />
+            </span>
+            <div>
+              <h3 className="text-[13px] font-medium text-foreground">
+                Workspace monthly cap
+              </h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                New tasks are refused once month-to-date spend reaches this
+                amount.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 max-w-xl">
+            {cap == null ? (
+              <p className="text-sm text-muted-foreground">
+                No cap is set. Workspace spend can continue without a monthly
+                stop.
+              </p>
+            ) : (
+              <>
+                <div className="flex items-baseline justify-between gap-3 text-sm">
+                  <span className="text-muted-foreground">
+                    {fmt(mtdSpend)} used
+                  </span>
+                  <span
+                    className={cn(
+                      "font-medium tabular-nums",
+                      isOverCap
+                        ? "text-red-600 dark:text-red-400"
+                        : isNearCap
+                          ? "text-amber-600 dark:text-amber-400"
+                          : "text-muted-foreground"
+                    )}
+                  >
+                    {capPct?.toFixed(1)}% of {fmt(cap)}
+                  </span>
+                </div>
+                <Progress
+                  value={displayPct}
+                  className={cn(
+                    "mt-2 h-[3px]",
+                    isOverCap
+                      ? "[&>div]:bg-red-500"
+                      : isNearCap
+                        ? "[&>div]:bg-amber-500"
+                        : "[&>div]:bg-foreground/70"
+                  )}
+                />
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="w-full shrink-0 md:w-[280px]">
+          <label
+            htmlFor="monthly-cap"
+            className="mb-2 flex items-center gap-1.5 text-xs font-medium text-foreground"
+          >
+            <DollarSign className="h-4 w-4 text-primary dark:text-accent-foreground" />
+            Monthly cap (USD)
+          </label>
+          <div className="flex gap-2">
+            <Input
+              id="monthly-cap"
+              type="number"
+              min="0"
+              step="0.01"
+              value={capInput}
+              onChange={(event) => {
+                setCapInput(event.target.value);
+                setStatus("idle");
+                setMessage(settingsError);
+              }}
+              placeholder="No cap"
+              disabled={isPending}
+              className="h-8"
+            />
+            <Button
+              type="button"
+              size="sm"
+              isLoading={isPending}
+              disabled={isPending}
+              onClick={saveCap}
+            >
+              Save
+            </Button>
+          </div>
+
+          {message && (
+            <div
+              className={cn(
+                "mt-3 flex items-start gap-2 text-xs",
+                status === "success"
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-muted-foreground",
+                status === "error" && "text-destructive"
+              )}
+            >
+              {status === "success" ? (
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              ) : status === "error" ? (
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              ) : null}
+              <span>{message}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/budgets/components/BudgetsData.tsx
+++ b/agentarea-webapp/src/app/(main)/budgets/components/BudgetsData.tsx
@@ -1,14 +1,42 @@
-import Link from "next/link";
-import EmptyState from "@/components/EmptyState";
-import { getDashboard } from "@/lib/api-dashboard";
 import { SpendCard } from "@/app/(main)/dashboard/components/SpendCard";
+import EmptyState from "@/components/EmptyState";
+import { getDashboard, getWorkspaceSettings } from "@/lib/api-dashboard";
+import { BudgetCapPanel } from "./BudgetCapPanel";
+
+const fmt = (v: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: v > 0 && v < 0.01 ? 4 : 2,
+    maximumFractionDigits: v > 0 && v < 0.01 ? 4 : 2,
+  }).format(v);
 
 export async function BudgetsData() {
   let data: Awaited<ReturnType<typeof getDashboard>> | null = null;
+  let settings: Awaited<ReturnType<typeof getWorkspaceSettings>> | null = null;
   let error: string | null = null;
+  let settingsError: string | null = null;
 
   try {
-    data = await getDashboard();
+    const [dashboardResult, settingsResult] = await Promise.allSettled([
+      getDashboard(),
+      getWorkspaceSettings(),
+    ]);
+
+    if (dashboardResult.status === "fulfilled") {
+      data = dashboardResult.value;
+    } else {
+      throw dashboardResult.reason;
+    }
+
+    if (settingsResult.status === "fulfilled") {
+      settings = settingsResult.value;
+    } else {
+      settingsError =
+        settingsResult.reason instanceof Error
+          ? settingsResult.reason.message
+          : "Failed to load workspace settings";
+    }
   } catch (e) {
     console.error("Failed to load budgets data:", e);
     error = e instanceof Error ? e.message : "Failed to load budget data";
@@ -26,25 +54,57 @@ export async function BudgetsData() {
 
   if (!data) return null;
 
+  const cap = settings?.monthly_cap_usd ?? data.spend.cap_usd;
+  const projected = data.spend.projected_eom_usd;
+
   return (
-    <div className="space-y-8">
-      <div className="max-w-lg">
-        <SpendCard spend={data.spend} trend={data.daily_spend} />
+    <div className="mx-auto w-full max-w-[980px] space-y-6">
+      <div className="grid gap-x-10 gap-y-6 lg:grid-cols-5 lg:divide-x lg:divide-border/50">
+        <div className="lg:col-span-3 lg:pr-10">
+          <SpendCard spend={data.spend} trend={data.daily_spend} />
+        </div>
+
+        <section className="lg:col-span-2 lg:pl-10">
+          <header className="flex items-baseline justify-between">
+            <h3 className="text-[13px] font-medium text-foreground">
+              Month outlook
+            </h3>
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              Current period
+            </span>
+          </header>
+
+          <dl className="mt-4 space-y-3">
+            <div className="flex items-baseline justify-between gap-4 border-b border-border/50 pb-3">
+              <dt className="text-[12px] text-muted-foreground">Today</dt>
+              <dd className="text-sm font-medium tabular-nums">
+                {fmt(data.spend.today_usd)}
+              </dd>
+            </div>
+            <div className="flex items-baseline justify-between gap-4 border-b border-border/50 pb-3">
+              <dt className="text-[12px] text-muted-foreground">
+                Projected end of month
+              </dt>
+              <dd className="text-sm font-medium tabular-nums">
+                {projected == null ? "No projection" : fmt(projected)}
+              </dd>
+            </div>
+            <div className="flex items-baseline justify-between gap-4">
+              <dt className="text-[12px] text-muted-foreground">Monthly cap</dt>
+              <dd className="text-sm font-medium tabular-nums">
+                {cap == null ? "Not set" : fmt(cap)}
+              </dd>
+            </div>
+          </dl>
+        </section>
       </div>
 
-      <div>
-        <h3 className="mb-3 text-[13px] font-medium text-foreground">
-          Workspace cap settings
-        </h3>
-        <div className="rounded border border-border/60 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-          <p>Configure spending limits in workspace settings.</p>
-          <Link
-            href="/admin/workspace"
-            className="mt-2 inline-block text-[13px] font-medium text-foreground underline-offset-4 hover:underline"
-          >
-            Open workspace settings
-          </Link>
-        </div>
+      <div className="border-t border-border/50 pt-6">
+        <BudgetCapPanel
+          initialCap={cap}
+          mtdSpend={data.spend.mtd_usd}
+          settingsError={settingsError}
+        />
       </div>
     </div>
   );

--- a/agentarea-webapp/src/app/(main)/budgets/page.tsx
+++ b/agentarea-webapp/src/app/(main)/budgets/page.tsx
@@ -1,5 +1,5 @@
-import type { Metadata } from "next";
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { BudgetsData } from "./components/BudgetsData";
@@ -13,6 +13,7 @@ export default async function BudgetsPage() {
     <ContentBlock
       header={{
         breadcrumb: [{ label: "Budgets" }],
+        description: "Track workspace spend and tune the monthly cap.",
       }}
     >
       <div className="main-content">

--- a/agentarea-webapp/src/app/(main)/settings/audit/AuditLogClient.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/audit/AuditLogClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import EmptyState from "@/components/EmptyState";
 import Table from "@/components/Table/Table";
@@ -63,6 +64,77 @@ function ChangesDetail({ changes }: { changes: AuditEvent["changes"] }) {
           </span>
         </div>
       ))}
+    </div>
+  );
+}
+
+function ResourceCell({ event }: { event: AuditEvent }) {
+  const resource = event.resource;
+  const label = resource?.label ?? event.resource_type;
+  const typeLabel = resource?.type_label ?? event.resource_type;
+
+  return (
+    <div className="min-w-0">
+      <div className="flex min-w-0 items-center gap-2">
+        {resource?.href ? (
+          <Link
+            href={resource.href as any}
+            className="truncate text-sm font-medium text-zinc-800 underline-offset-2 hover:text-primary hover:underline dark:text-zinc-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {label}
+          </Link>
+        ) : (
+          <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-100">
+            {label}
+          </span>
+        )}
+        <Badge variant="zinc" size="sm" className="shrink-0 font-normal">
+          {typeLabel}
+        </Badge>
+      </div>
+      {event.resource_id && !resource?.found && (
+        <div className="mt-0.5 font-mono text-xs text-muted-foreground">
+          {event.resource_id}
+        </div>
+      )}
+      {event.resource_id && resource?.found && (
+        <div className="mt-0.5 font-mono text-xs text-muted-foreground">
+          {event.resource_id.slice(0, 8)}
+        </div>
+      )}
+      {event.changes && event.changes.length > 0 && (
+        <ChangesDetail changes={event.changes} />
+      )}
+    </div>
+  );
+}
+
+function ActorCell({ event }: { event: AuditEvent }) {
+  const actor = event.actor;
+  const label = actor?.label ?? event.actor_id;
+  const description = actor?.description;
+
+  return (
+    <div className="min-w-0">
+      {actor?.href ? (
+        <Link
+          href={actor.href as any}
+          className="block truncate text-sm font-medium text-zinc-800 underline-offset-2 hover:text-primary hover:underline dark:text-zinc-100"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {label}
+        </Link>
+      ) : (
+        <span className="block truncate text-sm font-medium text-zinc-800 dark:text-zinc-100">
+          {label}
+        </span>
+      )}
+      {description && (
+        <span className="block truncate text-xs text-muted-foreground">
+          {description}
+        </span>
+      )}
     </div>
   );
 }
@@ -149,29 +221,20 @@ export default function AuditLogClient({
       header: t("table.resource"),
       cellClassName: "",
       render: (_: unknown, event: AuditEvent) => (
-        <div>
-          <span className="text-sm">{event.resource_type}</span>
-          {event.resource_id && (
-            <span className="text-xs text-muted-foreground ml-1.5 font-mono">
-              {event.resource_id.slice(0, 8)}
-            </span>
-          )}
-          {expandedId === event.id &&
-            event.changes &&
-            event.changes.length > 0 && (
-              <ChangesDetail changes={event.changes} />
-            )}
-        </div>
+        <ResourceCell
+          event={{
+            ...event,
+            changes: expandedId === event.id ? event.changes : undefined,
+          }}
+        />
       ),
     },
     {
       accessor: "actor_id",
       header: t("table.actor"),
-      cellClassName: "w-[120px]",
-      render: (value: string) => (
-        <span className="text-sm truncate max-w-[120px] block">
-          {value.length > 12 ? value.slice(0, 12) + "..." : value}
-        </span>
+      cellClassName: "w-[180px] max-w-[220px]",
+      render: (_value: string, event: AuditEvent) => (
+        <ActorCell event={event} />
       ),
     },
     {

--- a/agentarea-webapp/src/app/(main)/settings/audit/actions.ts
+++ b/agentarea-webapp/src/app/(main)/settings/audit/actions.ts
@@ -1,6 +1,21 @@
 "use server";
 
-import { listAuditLogs } from "@/lib/api";
+import {
+  getAllTasks,
+  listAgents,
+  listAPIKeys,
+  listAuditLogs,
+  listMCPServerInstances,
+  listMCPServers,
+  listOpenAPIConnections,
+  listPolicies,
+  listProjects,
+  listProviderConfigs,
+  listSkills,
+  listTriggers,
+  listWorkspaceMembers,
+} from "@/lib/api";
+import { getAuthContext } from "@/lib/getAuthContext";
 
 export interface AuditChange {
   field: string;
@@ -12,17 +27,52 @@ export interface AuditEvent {
   id: string;
   action: string;
   actor_id: string;
+  actor_type: string;
   resource_type: string;
   resource_id?: string | null;
   source_ip?: string | null;
   created_at: string;
   changes?: AuditChange[];
+  actor?: AuditActorDisplay;
+  resource?: AuditResourceDisplay;
 }
 
 export interface AuditLogResponse {
   events: AuditEvent[];
   next_cursor: string | null;
 }
+
+export interface AuditActorDisplay {
+  label: string;
+  description?: string | null;
+  href?: string | null;
+  is_current_user?: boolean;
+  actor_type: string;
+}
+
+export interface AuditResourceDisplay {
+  label: string;
+  type_label: string;
+  href?: string | null;
+  found: boolean;
+}
+
+type ResourceRecord = {
+  id?: unknown;
+  name?: unknown;
+  display_name?: unknown;
+  title?: unknown;
+  agent_name?: unknown;
+  token_prefix?: unknown;
+  email?: unknown;
+  user_id?: unknown;
+};
+
+type ResourceEntry = {
+  label: string;
+  typeLabel: string;
+  href: string | null;
+};
 
 export async function fetchAuditLogs(params?: {
   action?: string;
@@ -40,5 +90,390 @@ export async function fetchAuditLogs(params?: {
     return { data: null, error: "Failed to fetch audit logs" };
   }
 
-  return { data: data as unknown as AuditLogResponse, error: null };
+  const raw = data as unknown as AuditLogResponse;
+  const events = await enrichAuditEvents(raw.events ?? []);
+
+  return { data: { ...raw, events }, error: null };
+}
+
+async function enrichAuditEvents(events: AuditEvent[]): Promise<AuditEvent[]> {
+  if (events.length === 0) return events;
+
+  const [actorIndex, resourceIndex] = await Promise.all([
+    buildActorIndex(events),
+    buildResourceIndex(events),
+  ]);
+
+  return events.map((event) => ({
+    ...event,
+    actor: resolveActor(event, actorIndex),
+    resource: resolveResource(event, resourceIndex),
+  }));
+}
+
+async function buildActorIndex(events: AuditEvent[]): Promise<{
+  currentUserId: string | null;
+  currentUserLabel: string | null;
+  members: Map<string, ResourceRecord>;
+  agents: Map<string, ResourceRecord>;
+}> {
+  const auth = await getAuthContext();
+  const members = new Map<string, ResourceRecord>();
+  const agents = new Map<string, ResourceRecord>();
+
+  await Promise.all([
+    auth.workspaceId
+      ? listWorkspaceMembers(auth.workspaceId)
+          .then((result) => {
+            for (const member of asArray<ResourceRecord>(result.data)) {
+              if (typeof member.user_id === "string") {
+                members.set(member.user_id, member);
+              }
+            }
+          })
+          .catch(() => undefined)
+      : Promise.resolve(),
+    events.some((event) => event.actor_type === "agent")
+      ? listAgents()
+          .then((result) => {
+            for (const agent of asArray<ResourceRecord>(result.data)) {
+              const id = getString(agent.id);
+              if (id) agents.set(id, agent);
+            }
+          })
+          .catch(() => undefined)
+      : Promise.resolve(),
+  ]);
+
+  if (auth.userId && !members.has(auth.userId)) {
+    members.set(auth.userId, {
+      id: auth.userId,
+      user_id: auth.userId,
+      display_name: auth.name || auth.email || auth.username,
+      email: auth.email,
+    });
+  }
+
+  return {
+    currentUserId: auth.userId,
+    currentUserLabel: auth.name || auth.email || auth.username,
+    members,
+    agents,
+  };
+}
+
+async function buildResourceIndex(
+  events: AuditEvent[]
+): Promise<Map<string, ResourceEntry>> {
+  const resourceTypes = new Set(events.map((event) => event.resource_type));
+  const index = new Map<string, ResourceEntry>();
+  const jobs: Promise<void>[] = [];
+
+  const addRecords = (
+    type: string,
+    typeLabel: string,
+    hrefFor: (id: string) => string | null,
+    records: unknown
+  ) => {
+    for (const record of asArray<ResourceRecord>(records)) {
+      const id = getString(record.id);
+      if (!id) continue;
+      index.set(resourceKey(type, id), {
+        label: getResourceName(record) ?? fallbackResourceLabel(type, id),
+        typeLabel,
+        href: hrefFor(id),
+      });
+    }
+  };
+
+  const queue = (
+    types: string[],
+    load: () => Promise<unknown>,
+    typeLabel: string,
+    hrefFor: (id: string) => string | null
+  ) => {
+    if (!types.some((type) => resourceTypes.has(type))) return;
+    jobs.push(
+      load()
+        .then((records) => {
+          for (const type of types)
+            addRecords(type, typeLabel, hrefFor, records);
+        })
+        .catch(() => undefined)
+    );
+  };
+
+  queue(
+    ["agent"],
+    () => fetchData(listAgents()),
+    "Agent",
+    (id) => `/agents/${id}`
+  );
+  queue(
+    ["task"],
+    () => fetchData(getAllTasks()),
+    "Task",
+    (id) => `/tasks/${id}`
+  );
+  queue(
+    ["trigger"],
+    () => fetchData(listTriggers()),
+    "Trigger",
+    (id) => `/triggers/${id}`
+  );
+  queue(
+    ["skill"],
+    () => fetchData(listSkills()),
+    "Skill",
+    (id) => `/skills/${id}`
+  );
+  queue(
+    ["mcp_instance"],
+    () => fetchData(listMCPServerInstances()),
+    "MCP instance",
+    (id) => `/mcp-servers/${id}`
+  );
+  queue(
+    ["mcp_server"],
+    () => fetchData(listMCPServers({ page_size: 100 })),
+    "MCP server",
+    () => "/mcp-servers"
+  );
+  queue(
+    ["governance_policy", "policy"],
+    () => fetchData(listPolicies()),
+    "Policy",
+    () => "/policies"
+  );
+  queue(
+    ["project"],
+    () => fetchData(listProjects()),
+    "Project",
+    (id) => `/projects/${id}`
+  );
+  queue(
+    ["openapi_connection"],
+    () => fetchData(listOpenAPIConnections()),
+    "OpenAPI connection",
+    () => "/connections?tab=openapi"
+  );
+  queue(
+    ["provider_config"],
+    () => fetchData(listProviderConfigs()),
+    "Provider config",
+    (id) => `/admin/provider-configs/edit/${id}`
+  );
+  queue(
+    ["api_key"],
+    () => fetchData(listAPIKeys()),
+    "API key",
+    () => "/admin/api-keys"
+  );
+
+  await Promise.all(jobs);
+  return index;
+}
+
+async function fetchData<T>(promise: Promise<{ data?: T; error?: unknown }>) {
+  const { data, error } = await promise;
+  if (error) return [];
+  return data;
+}
+
+function resolveActor(
+  event: AuditEvent,
+  index: Awaited<ReturnType<typeof buildActorIndex>>
+): AuditActorDisplay {
+  const actorType = event.actor_type || "user";
+  const isCurrentUser =
+    actorType === "user" && event.actor_id === index.currentUserId;
+
+  if (isCurrentUser) {
+    return {
+      label: "Me",
+      description: index.currentUserLabel,
+      href: "/settings",
+      is_current_user: true,
+      actor_type: actorType,
+    };
+  }
+
+  if (actorType === "user") {
+    const member = index.members.get(event.actor_id);
+    const label = member ? getActorName(member) : null;
+    return {
+      label: label ?? shortId(event.actor_id),
+      description: member?.email ? String(member.email) : null,
+      href: "/members",
+      actor_type: actorType,
+    };
+  }
+
+  if (actorType === "agent") {
+    const agent = index.agents.get(event.actor_id);
+    return {
+      label: agent
+        ? (getResourceName(agent) ?? shortId(event.actor_id))
+        : `Agent ${shortId(event.actor_id)}`,
+      href: `/agents/${event.actor_id}`,
+      actor_type: actorType,
+    };
+  }
+
+  if (actorType === "api_key") {
+    return {
+      label: `API key ${shortId(event.actor_id)}`,
+      description: event.actor_id,
+      href: "/admin/api-keys",
+      actor_type: actorType,
+    };
+  }
+
+  return {
+    label: `${titleize(actorType)} ${shortId(event.actor_id)}`,
+    description: event.actor_id,
+    actor_type: actorType,
+  };
+}
+
+function resolveResource(
+  event: AuditEvent,
+  index: Map<string, ResourceEntry>
+): AuditResourceDisplay {
+  const typeLabel = resourceTypeLabel(event.resource_type);
+
+  if (!event.resource_id) {
+    return {
+      label: typeLabel,
+      type_label: typeLabel,
+      href: fallbackResourceHref(event.resource_type, null),
+      found: false,
+    };
+  }
+
+  const entry = index.get(resourceKey(event.resource_type, event.resource_id));
+  if (entry) {
+    return {
+      label: entry.label,
+      type_label: entry.typeLabel,
+      href: entry.href,
+      found: true,
+    };
+  }
+
+  return {
+    label: fallbackResourceLabel(event.resource_type, event.resource_id),
+    type_label: typeLabel,
+    href: fallbackResourceHref(event.resource_type, event.resource_id),
+    found: false,
+  };
+}
+
+function resourceKey(type: string, id: string) {
+  return `${type}:${id}`;
+}
+
+function asArray<T>(value: unknown): T[] {
+  if (Array.isArray(value)) return value as T[];
+  if (
+    value &&
+    typeof value === "object" &&
+    Array.isArray((value as any).items)
+  ) {
+    return (value as any).items as T[];
+  }
+  return [];
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function getActorName(record: ResourceRecord): string | null {
+  return (
+    getString(record.display_name) ||
+    getString(record.name) ||
+    getString(record.email) ||
+    getString(record.user_id)
+  );
+}
+
+function getResourceName(record: ResourceRecord): string | null {
+  return (
+    getString(record.name) ||
+    getString(record.display_name) ||
+    getString(record.title) ||
+    getString(record.agent_name) ||
+    getString(record.token_prefix) ||
+    getString(record.email)
+  );
+}
+
+function fallbackResourceLabel(type: string, id: string) {
+  return `${resourceTypeLabel(type)} ${shortId(id)}`;
+}
+
+function fallbackResourceHref(type: string, id: string | null): string | null {
+  if (!id) {
+    if (type === "mcp_server" || type === "mcp_instance") return "/mcp-servers";
+    if (type === "governance_policy" || type === "policy") return "/policies";
+    if (type === "api_key") return "/admin/api-keys";
+    return null;
+  }
+
+  switch (type) {
+    case "agent":
+      return `/agents/${id}`;
+    case "task":
+      return `/tasks/${id}`;
+    case "trigger":
+      return `/triggers/${id}`;
+    case "skill":
+      return `/skills/${id}`;
+    case "mcp_instance":
+      return `/mcp-servers/${id}`;
+    case "mcp_server":
+      return "/mcp-servers";
+    case "governance_policy":
+    case "policy":
+      return "/policies";
+    case "project":
+      return `/projects/${id}`;
+    case "openapi_connection":
+      return "/connections?tab=openapi";
+    case "provider_config":
+      return `/admin/provider-configs/edit/${id}`;
+    case "api_key":
+      return "/admin/api-keys";
+    default:
+      return null;
+  }
+}
+
+function resourceTypeLabel(type: string) {
+  const labels: Record<string, string> = {
+    agent: "Agent",
+    task: "Task",
+    trigger: "Trigger",
+    skill: "Skill",
+    mcp_server: "MCP server",
+    mcp_instance: "MCP instance",
+    governance_policy: "Policy",
+    policy: "Policy",
+    project: "Project",
+    openapi_connection: "OpenAPI connection",
+    provider_config: "Provider config",
+    api_key: "API key",
+  };
+  return labels[type] ?? titleize(type);
+}
+
+function titleize(value: string) {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function shortId(id: string) {
+  return id.length > 12 ? `${id.slice(0, 8)}...` : id;
 }

--- a/agentarea-webapp/src/app/(main)/settings/billing/BillingClient.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/billing/BillingClient.tsx
@@ -4,13 +4,21 @@ import { useTranslations } from "next-intl";
 import {
   Bot,
   Check,
+  Cloud,
+  Cpu,
   CreditCard,
   Crown,
+  ExternalLink,
   Gauge,
+  Globe2,
   LayoutDashboard,
   ListChecks,
   Plug,
+  ServerCog,
+  ShieldCheck,
   Sparkles,
+  TableProperties,
+  Users,
 } from "lucide-react";
 import EmptyState from "@/components/EmptyState";
 import { Button } from "@/components/ui/button";
@@ -21,9 +29,11 @@ import type {
   BillingPlanKey,
   BillingSubscription,
   BillingUsageItem,
+  CloudSetupEstimate,
 } from "./actions";
 
 type UsageIcon = React.ComponentType<{ className?: string }>;
+type BillingExperience = "oss" | "cloud";
 
 const USAGE_META: Record<string, { labelKey: string; icon: UsageIcon }> = {
   workspaces: { labelKey: "usage.workspaces", icon: LayoutDashboard },
@@ -33,11 +43,24 @@ const USAGE_META: Record<string, { labelKey: string; icon: UsageIcon }> = {
 };
 
 const PLAN_ORDER: BillingPlanKey[] = ["payg", "enterprise"];
+const CLOUD_BENEFITS = [
+  "paymentMethods",
+  "paymentHistory",
+  "publicAgents",
+  "guardrails",
+] as const;
+const CLOUD_BILLING_FEATURES = [
+  "paymentMethods",
+  "paymentHistory",
+  "publicAgents",
+  "guardrails",
+  "managedInfra",
+] as const;
+const CLOUD_URL = "https://app.agentarea.ai/";
+const SALES_EMAIL = "sales@agentarea.ai";
 
 function humanizeKey(key: string): string {
-  return key
-    .replace(/[_-]+/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+  return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 interface Props {
@@ -45,6 +68,8 @@ interface Props {
   usage: BillingUsageItem[];
   available: boolean;
   error: string | null;
+  billingExperience: BillingExperience;
+  cloudEstimate: CloudSetupEstimate | null;
 }
 
 export default function BillingClient({
@@ -52,8 +77,18 @@ export default function BillingClient({
   usage,
   available,
   error,
+  billingExperience,
+  cloudEstimate,
 }: Props) {
   const t = useTranslations("BillingPage");
+
+  if (!available && !error) {
+    return billingExperience === "cloud" ? (
+      <CloudBillingPreview estimate={cloudEstimate} />
+    ) : (
+      <CloudMigrationPanel />
+    );
+  }
 
   return (
     <div className="mx-auto max-w-4xl">
@@ -87,6 +122,304 @@ export default function BillingClient({
 
         <UsageSection usage={usage} available={available} error={error} />
       </div>
+    </div>
+  );
+}
+
+function CloudBillingPreview({
+  estimate,
+}: {
+  estimate: CloudSetupEstimate | null;
+}) {
+  const t = useTranslations("BillingPage");
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <section className="relative overflow-hidden rounded-md border border-zinc-200/70 bg-white p-5 shadow-[0_2px_8px_-4px_rgba(0,0,0,0.05)] dark:border-zinc-800 dark:bg-zinc-900">
+        <HatchBackground />
+        <div className="relative z-10 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
+              <Cloud className="h-3.5 w-3.5 text-primary" />
+              {t("cloudBilling.badge")}
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                {t("cloudBilling.title")}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+                {t("cloudBilling.description")}
+              </p>
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-col gap-2 sm:flex-row lg:flex-col">
+            <Button onClick={() => window.open(CLOUD_URL, "_blank")}>
+              <Cloud className="h-4 w-4" />
+              {t("cloudBilling.openCloud")}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() =>
+                window.open(
+                  `mailto:${SALES_EMAIL}?subject=Migrate to Agentarea Cloud`,
+                  "_blank"
+                )
+              }
+            >
+              <Users className="h-4 w-4" />
+              {t("cloudBilling.contactSales")}
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <CloudCostEstimate estimate={estimate} />
+
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {CLOUD_BILLING_FEATURES.map((key) => (
+          <CloudBillingFeatureCard key={key} itemKey={key} />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function CloudCostEstimate({
+  estimate,
+}: {
+  estimate: CloudSetupEstimate | null;
+}) {
+  const t = useTranslations("BillingPage");
+  const infraEstimate = estimate?.infra_estimate_mtd_usd;
+
+  return (
+    <section className="rounded-md border border-zinc-200/70 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="mb-3 flex items-center gap-2">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/5 text-primary dark:bg-primary/10">
+              <ServerCog className="h-4 w-4" />
+            </div>
+            <div>
+              <h3 className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+                {t("cloudBilling.estimate.title")}
+              </h3>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                {t("cloudBilling.estimate.subtitle")}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-dashed border-zinc-200 p-3 dark:border-zinc-800">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {t("cloudBilling.estimate.infraLabel")}
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+                  {infraEstimate === null || infraEstimate === undefined
+                    ? t("cloudBilling.estimate.telemetryPending")
+                    : formatUsd(infraEstimate)}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+                <Cpu className="h-4 w-4 text-primary" />
+                {t("cloudBilling.estimate.basedOnResources")}
+              </div>
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <InlineMetric
+                label={t("cloudBilling.estimate.cpu")}
+                value={formatHours(estimate?.cpu_core_hours_mtd)}
+              />
+              <InlineMetric
+                label={t("cloudBilling.estimate.memory")}
+                value={formatHours(estimate?.memory_gb_hours_mtd)}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-3 lg:w-72 lg:grid-cols-1">
+          <EstimateMetric
+            label={t("cloudBilling.estimate.agents")}
+            value={formatCount(estimate?.agent_count)}
+          />
+          <EstimateMetric
+            label={t("cloudBilling.estimate.connections")}
+            value={formatCount(estimate?.connection_count)}
+          />
+          <EstimateMetric
+            label={t("cloudBilling.estimate.taskRuns")}
+            value={formatCount(estimate?.task_runs_mtd)}
+          />
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-md bg-zinc-50 p-3 text-xs leading-5 text-zinc-600 dark:bg-zinc-950 dark:text-zinc-300">
+        <span className="font-medium text-zinc-800 dark:text-zinc-100">
+          {t("cloudBilling.agentUsage.label")}
+        </span>{" "}
+        {t("cloudBilling.agentUsage.description", {
+          spend: formatUsd(estimate?.agent_spend_mtd_usd),
+          projected: formatUsd(estimate?.agent_projected_eom_usd),
+        })}
+      </div>
+    </section>
+  );
+}
+
+function CloudBillingFeatureCard({
+  itemKey,
+}: {
+  itemKey: (typeof CLOUD_BILLING_FEATURES)[number];
+}) {
+  const t = useTranslations("BillingPage");
+  const icons: Record<(typeof CLOUD_BILLING_FEATURES)[number], UsageIcon> = {
+    paymentMethods: CreditCard,
+    paymentHistory: TableProperties,
+    publicAgents: Globe2,
+    guardrails: ShieldCheck,
+    managedInfra: ServerCog,
+  };
+  const Icon = icons[itemKey];
+
+  return (
+    <div className="rounded-md border border-zinc-200/70 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="mb-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary/5 text-primary dark:bg-primary/10">
+        <Icon className="h-4 w-4" />
+      </div>
+      <h3 className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+        {t(`cloudBilling.features.${itemKey}.title`)}
+      </h3>
+      <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
+        {t(`cloudBilling.features.${itemKey}.description`)}
+      </p>
+    </div>
+  );
+}
+
+function EstimateMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-zinc-200/70 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-950">
+      <p className="text-xs text-zinc-500 dark:text-zinc-400">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function InlineMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md bg-zinc-50 px-3 py-2 text-xs dark:bg-zinc-950">
+      <span className="text-zinc-500 dark:text-zinc-400">{label}</span>
+      <span className="font-medium text-zinc-800 dark:text-zinc-100">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function formatUsd(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  }).format(value);
+}
+
+function formatCount(value: number | null | undefined): string {
+  return value === null || value === undefined ? "-" : value.toLocaleString();
+}
+
+function formatHours(value: number | null | undefined): string {
+  return value === null || value === undefined ? "-" : value.toLocaleString();
+}
+
+function CloudMigrationPanel() {
+  const t = useTranslations("BillingPage");
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <section className="relative overflow-hidden rounded-md border border-zinc-200/70 bg-white p-5 shadow-[0_2px_8px_-4px_rgba(0,0,0,0.05)] dark:border-zinc-800 dark:bg-zinc-900">
+        <HatchBackground />
+        <div className="relative z-10 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
+              <Cloud className="h-3.5 w-3.5 text-primary" />
+              {t("cloudMigration.badge")}
+            </div>
+            <div>
+              <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+                {t("cloudMigration.title")}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-zinc-600 dark:text-zinc-300">
+                {t("cloudMigration.description")}
+              </p>
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-col gap-2 sm:flex-row lg:flex-col">
+            <Button onClick={() => window.open(CLOUD_URL, "_blank")}>
+              <Cloud className="h-4 w-4" />
+              {t("cloudMigration.openCloud")}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() =>
+                window.open(
+                  `mailto:${SALES_EMAIL}?subject=Migrate to Agentarea Cloud`,
+                  "_blank"
+                )
+              }
+            >
+              <Users className="h-4 w-4" />
+              {t("cloudMigration.contactSales")}
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {CLOUD_BENEFITS.map((key) => (
+          <CloudBenefitCard key={key} itemKey={key} />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function CloudBenefitCard({
+  itemKey,
+}: {
+  itemKey: (typeof CLOUD_BENEFITS)[number];
+}) {
+  const t = useTranslations("BillingPage");
+  const icons: Record<(typeof CLOUD_BENEFITS)[number], UsageIcon> = {
+    paymentMethods: CreditCard,
+    paymentHistory: TableProperties,
+    publicAgents: Globe2,
+    guardrails: ShieldCheck,
+  };
+  const Icon = icons[itemKey];
+
+  return (
+    <div className="rounded-md border border-zinc-200/70 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="mb-3 flex h-8 w-8 items-center justify-center rounded-full bg-primary/5 text-primary dark:bg-primary/10">
+        <Icon className="h-4 w-4" />
+      </div>
+      <h3 className="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+        {t(`cloudMigration.benefits.${itemKey}.title`)}
+      </h3>
+      <p className="mt-1 text-xs leading-5 text-zinc-500 dark:text-zinc-400">
+        {t(`cloudMigration.benefits.${itemKey}.description`)}
+      </p>
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/settings/billing/BillingContent.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/billing/BillingContent.tsx
@@ -1,8 +1,14 @@
-import { fetchBillingOverview } from "./actions";
+import { getBillingExperience } from "@/lib/feature-service";
+import { fetchBillingOverview, fetchCloudSetupEstimate } from "./actions";
 import BillingClient from "./BillingClient";
 
 export default async function BillingContent() {
   const { data, available, error } = await fetchBillingOverview();
+  const billingExperience = getBillingExperience();
+  const cloudEstimate =
+    billingExperience === "cloud" && !available && !error
+      ? await fetchCloudSetupEstimate()
+      : null;
 
   return (
     <BillingClient
@@ -10,6 +16,8 @@ export default async function BillingContent() {
       usage={data?.usage ?? []}
       available={available}
       error={error}
+      billingExperience={billingExperience}
+      cloudEstimate={cloudEstimate}
     />
   );
 }

--- a/agentarea-webapp/src/app/(main)/settings/billing/actions.ts
+++ b/agentarea-webapp/src/app/(main)/settings/billing/actions.ts
@@ -1,6 +1,12 @@
 "use server";
 
-import { getBillingOverview } from "@/lib/api";
+import {
+  getBillingOverview,
+  listAgents,
+  listMCPServerInstances,
+  listOpenAPIConnections,
+} from "@/lib/api";
+import { getDashboard } from "@/lib/api-dashboard";
 
 export type BillingPlanKey = "free" | "payg" | "enterprise";
 
@@ -41,6 +47,18 @@ export interface BillingOverviewResult {
   error: string | null;
 }
 
+export interface CloudSetupEstimate {
+  agent_count: number | null;
+  connection_count: number | null;
+  task_runs_mtd: number | null;
+  agent_spend_mtd_usd: number | null;
+  agent_projected_eom_usd: number | null;
+  cpu_core_hours_mtd: number | null;
+  memory_gb_hours_mtd: number | null;
+  infra_estimate_mtd_usd: number | null;
+  platform_fee_usd: number;
+}
+
 /**
  * Fetches billing state from the expected `/v1/billing/overview` endpoint.
  *
@@ -67,5 +85,57 @@ export async function fetchBillingOverview(): Promise<BillingOverviewResult> {
     data: data as unknown as BillingOverview,
     available: true,
     error: null,
+  };
+}
+
+function getCollectionCount(value: unknown): number | null {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+
+  if (value && typeof value === "object") {
+    const items = (value as { items?: unknown }).items;
+    if (Array.isArray(items)) {
+      return items.length;
+    }
+  }
+
+  return null;
+}
+
+export async function fetchCloudSetupEstimate(): Promise<CloudSetupEstimate> {
+  const [agentsResult, mcpInstancesResult, openApiResult, dashboard] =
+    await Promise.all([
+      listAgents().catch(() => ({ data: null })),
+      listMCPServerInstances().catch(() => ({ data: null })),
+      listOpenAPIConnections().catch(() => ({ data: null })),
+      getDashboard().catch(() => null),
+    ]);
+
+  const mcpConnections = getCollectionCount(mcpInstancesResult.data);
+  const openApiConnections = getCollectionCount(openApiResult.data);
+  const knownConnectionCounts = [mcpConnections, openApiConnections].filter(
+    (count): count is number => typeof count === "number"
+  );
+
+  const taskRuns =
+    dashboard?.daily_tasks.reduce(
+      (total, day) => total + day.completed + day.failed + day.input_required,
+      0
+    ) ?? null;
+
+  return {
+    agent_count: getCollectionCount(agentsResult.data),
+    connection_count:
+      knownConnectionCounts.length > 0
+        ? knownConnectionCounts.reduce((total, count) => total + count, 0)
+        : null,
+    task_runs_mtd: taskRuns,
+    agent_spend_mtd_usd: dashboard?.spend.mtd_usd ?? null,
+    agent_projected_eom_usd: dashboard?.spend.projected_eom_usd ?? null,
+    cpu_core_hours_mtd: null,
+    memory_gb_hours_mtd: null,
+    infra_estimate_mtd_usd: null,
+    platform_fee_usd: 0,
   };
 }

--- a/agentarea-webapp/src/app/(main)/triggers/components/taskParameters.ts
+++ b/agentarea-webapp/src/app/(main)/triggers/components/taskParameters.ts
@@ -1,0 +1,131 @@
+export type TaskParameterRef = {
+  id: string;
+  name?: string | null;
+  description?: string | null;
+};
+
+export type NormalizedTaskParameters = {
+  text: string;
+  files: string[];
+  skills: TaskParameterRef[];
+  mcps: TaskParameterRef[];
+  rest: Record<string, unknown>;
+};
+
+const STRUCTURED_KEYS = new Set([
+  "text",
+  "files",
+  "skills",
+  "mcps",
+  "mcp",
+  "mcp_servers",
+]);
+
+function normalizeRef(value: unknown): TaskParameterRef | null {
+  if (typeof value === "string" && value.trim()) {
+    return { id: value.trim(), name: value.trim() };
+  }
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  const id = record.id ?? record.instance_id ?? record.skill_id;
+  if (typeof id !== "string" || !id.trim()) return null;
+
+  return {
+    id: id.trim(),
+    name: typeof record.name === "string" ? record.name : null,
+    description:
+      typeof record.description === "string" ? record.description : null,
+  };
+}
+
+function normalizeRefs(value: unknown): TaskParameterRef[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(normalizeRef).filter(Boolean) as TaskParameterRef[];
+}
+
+function normalizeFiles(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((file) => {
+      if (typeof file === "string") return file.trim();
+      if (!file || typeof file !== "object") return "";
+      const record = file as Record<string, unknown>;
+      const path = record.path ?? record.name ?? record.url;
+      return typeof path === "string" ? path.trim() : "";
+    })
+    .filter(Boolean);
+}
+
+export function normalizeTaskParameters(
+  value: unknown
+): NormalizedTaskParameters {
+  const source =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  const rest = Object.fromEntries(
+    Object.entries(source).filter(([key]) => !STRUCTURED_KEYS.has(key))
+  );
+
+  return {
+    text: typeof source.text === "string" ? source.text : "",
+    files: normalizeFiles(source.files),
+    skills: normalizeRefs(source.skills),
+    mcps: normalizeRefs(source.mcps ?? source.mcp ?? source.mcp_servers),
+    rest,
+  };
+}
+
+export function composeTaskParameters({
+  text,
+  files,
+  skills,
+  mcps,
+  rest,
+}: NormalizedTaskParameters): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...rest };
+  const trimmedText = text.trim();
+
+  if (trimmedText) {
+    next.text = trimmedText;
+  } else {
+    delete next.text;
+  }
+
+  if (files.length > 0) {
+    next.files = files;
+  } else {
+    delete next.files;
+  }
+
+  if (skills.length > 0) {
+    next.skills = skills.map(({ id, name, description }) => ({
+      id,
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    }));
+  } else {
+    delete next.skills;
+  }
+
+  if (mcps.length > 0) {
+    next.mcps = mcps.map(({ id, name, description }) => ({
+      id,
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    }));
+  } else {
+    delete next.mcps;
+  }
+
+  return next;
+}
+
+export function splitLines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}

--- a/agentarea-webapp/src/app/(main)/triggers/create/CreateTriggerForm.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/create/CreateTriggerForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useActionState } from "react";
+import { useState, useEffect, useActionState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import {
@@ -21,6 +21,11 @@ import {
   Webhook,
   Circle,
   Info,
+  FileText,
+  Paperclip,
+  Server,
+  Sparkles,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -40,11 +45,21 @@ import FormLabel from "@/components/FormLabel/FormLabel";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import {
+  listMCPServerInstancesAction as listMCPServerInstances,
+  listSkillsAction as listSkills,
+} from "@/lib/server-actions";
+import {
   createTriggerAction,
   updateTriggerAction,
   type TriggerFormState,
 } from "./actions";
 import { CronScheduler } from "./CronScheduler";
+import {
+  composeTaskParameters,
+  normalizeTaskParameters,
+  splitLines,
+  type TaskParameterRef,
+} from "../components/taskParameters";
 
 interface CatalogEntry {
   id: string;
@@ -67,6 +82,8 @@ interface CreateTriggerFormProps {
 }
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
+type SelectableResource = TaskParameterRef;
 
 const TIMEZONES = [
   "UTC",
@@ -118,6 +135,27 @@ export function CreateTriggerForm({
   const [selectedEvents, setSelectedEvents] = useState<string[]>(
     initialData?.event_types || []
   );
+  const initialTaskParameters = useMemo(
+    () => normalizeTaskParameters(initialData?.task_parameters),
+    [initialData?.task_parameters]
+  );
+  const [taskText, setTaskText] = useState(initialTaskParameters.text);
+  const [taskFilesText, setTaskFilesText] = useState(
+    initialTaskParameters.files.join("\n")
+  );
+  const [taskSkills, setTaskSkills] = useState<TaskParameterRef[]>(
+    initialTaskParameters.skills
+  );
+  const [taskMcps, setTaskMcps] = useState<TaskParameterRef[]>(
+    initialTaskParameters.mcps
+  );
+  const [taskRestJson, setTaskRestJson] = useState(
+    Object.keys(initialTaskParameters.rest).length > 0
+      ? JSON.stringify(initialTaskParameters.rest, null, 2)
+      : ""
+  );
+  const [availableSkills, setAvailableSkills] = useState<SelectableResource[]>([]);
+  const [availableMcps, setAvailableMcps] = useState<SelectableResource[]>([]);
 
   // Fetch catalog from backend
   useEffect(() => {
@@ -133,6 +171,40 @@ export function CreateTriggerForm({
         }
       })
       .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchTaskResources() {
+      const [skillsResponse, mcpsResponse] = await Promise.all([
+        listSkills().catch(() => ({ data: [] })),
+        listMCPServerInstances().catch(() => ({ data: [] })),
+      ]);
+
+      if (cancelled) return;
+
+      setAvailableSkills(
+        (((skillsResponse as any).data as any[]) || []).map((skill) => ({
+          id: skill.id,
+          name: skill.name,
+          description: skill.description,
+        }))
+      );
+      setAvailableMcps(
+        (((mcpsResponse as any).data as any[]) || []).map((mcp) => ({
+          id: mcp.id,
+          name: mcp.name,
+          description: mcp.description,
+        }))
+      );
+    }
+
+    fetchTaskResources();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const selected = catalog.find((e) => e.id === selectedId);
@@ -163,6 +235,72 @@ export function CreateTriggerForm({
         : [...prev, method]
     );
   };
+
+  const addTaskResource = (
+    resourceId: string,
+    available: SelectableResource[],
+    selected: TaskParameterRef[],
+    onChange: (items: TaskParameterRef[]) => void
+  ) => {
+    const resource = available.find((item) => item.id === resourceId);
+    if (!resource || selected.some((item) => item.id === resource.id)) return;
+    onChange([...selected, resource]);
+  };
+
+  const removeTaskResource = (
+    resourceId: string,
+    selected: TaskParameterRef[],
+    onChange: (items: TaskParameterRef[]) => void
+  ) => {
+    onChange(selected.filter((item) => item.id !== resourceId));
+  };
+
+  const taskParametersValue = useMemo(() => {
+    let rest: Record<string, unknown> = {};
+    if (taskRestJson.trim()) {
+      try {
+        const parsed = JSON.parse(taskRestJson);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          rest = parsed;
+        } else {
+          return "__INVALID_TASK_PARAMETERS_JSON__";
+        }
+      } catch {
+        return "__INVALID_TASK_PARAMETERS_JSON__";
+      }
+    }
+
+    return JSON.stringify(
+      composeTaskParameters({
+        text: taskText,
+        files: splitLines(taskFilesText),
+        skills: taskSkills,
+        mcps: taskMcps,
+        rest,
+      })
+    );
+  }, [taskText, taskFilesText, taskSkills, taskMcps, taskRestJson]);
+
+  const renderSelectedResource = (
+    resource: TaskParameterRef,
+    onRemove: (id: string) => void
+  ) => (
+    <div
+      key={resource.id}
+      className="inline-flex max-w-full items-center gap-1 rounded-md border border-border/60 bg-muted/40 px-2 py-1 text-xs"
+    >
+      <span className="truncate">{resource.name || resource.id}</span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-4 w-4 shrink-0 text-muted-foreground hover:bg-transparent hover:text-destructive"
+        onClick={() => onRemove(resource.id)}
+      >
+        <X className="h-3 w-3" />
+      </Button>
+    </div>
+  );
 
   useEffect(() => {
     if (state.success) {
@@ -260,6 +398,11 @@ export function CreateTriggerForm({
         {selected?.data_extractor && (
           <input type="hidden" name="data_extractor" value={selected.data_extractor} />
         )}
+        <input
+          type="hidden"
+          name="task_parameters"
+          value={taskParametersValue}
+        />
 
         {/* Catalog Picker */}
         {!isEditing ? (
@@ -532,26 +675,122 @@ export function CreateTriggerForm({
         )}
 
         {/* Task Parameters */}
-        <div className="grid gap-2">
-          <FormLabel htmlFor="task_parameters" icon={Code2} optional>
+        <div className="space-y-4 rounded-lg border border-border/60 bg-muted/20 p-4">
+          <FormLabel icon={Code2} optional>
             {t("taskParameters")}
           </FormLabel>
-          <Textarea
-            id="task_parameters"
-            name="task_parameters"
-            placeholder={t("taskParametersPlaceholder")}
-            defaultValue={
-              initialData?.task_parameters
-                ? JSON.stringify(initialData.task_parameters, null, 2)
-                : ""
-            }
-            className="font-mono min-h-[100px]"
-          />
-          {state.errors?.task_parameters && (
-            <p className="text-sm text-destructive">
-              {state.errors.task_parameters[0]}
-            </p>
-          )}
+
+          <div className="grid gap-2">
+            <FormLabel htmlFor="task_text" icon={FileText} optional>
+              Task text
+            </FormLabel>
+            <Textarea
+              id="task_text"
+              value={taskText}
+              onChange={(event) => setTaskText(event.target.value)}
+              placeholder="Text to pass into each task created by this trigger"
+              className="min-h-[96px]"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <FormLabel htmlFor="task_files" icon={Paperclip} optional>
+              Additional files
+            </FormLabel>
+            <Textarea
+              id="task_files"
+              value={taskFilesText}
+              onChange={(event) => setTaskFilesText(event.target.value)}
+              placeholder="One file path or URL per line"
+              className="min-h-[72px] font-mono text-xs"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <FormLabel icon={Sparkles} optional>
+              Additional skills
+            </FormLabel>
+            <Select
+              value=""
+              onValueChange={(value) =>
+                addTaskResource(value, availableSkills, taskSkills, setTaskSkills)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Add a skill" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableSkills
+                  .filter((skill) => !taskSkills.some((item) => item.id === skill.id))
+                  .map((skill) => (
+                    <SelectItem key={skill.id} value={skill.id}>
+                      {skill.name || skill.id}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+            {taskSkills.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {taskSkills.map((skill) =>
+                  renderSelectedResource(skill, (id) =>
+                    removeTaskResource(id, taskSkills, setTaskSkills)
+                  )
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <FormLabel icon={Server} optional>
+              Additional MCP
+            </FormLabel>
+            <Select
+              value=""
+              onValueChange={(value) =>
+                addTaskResource(value, availableMcps, taskMcps, setTaskMcps)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Add an MCP server" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableMcps
+                  .filter((mcp) => !taskMcps.some((item) => item.id === mcp.id))
+                  .map((mcp) => (
+                    <SelectItem key={mcp.id} value={mcp.id}>
+                      {mcp.name || mcp.id}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+            {taskMcps.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {taskMcps.map((mcp) =>
+                  renderSelectedResource(mcp, (id) =>
+                    removeTaskResource(id, taskMcps, setTaskMcps)
+                  )
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <FormLabel htmlFor="task_parameters_rest" icon={Code2} optional>
+              Other JSON parameters
+            </FormLabel>
+            <Textarea
+              id="task_parameters_rest"
+              value={taskRestJson}
+              onChange={(event) => setTaskRestJson(event.target.value)}
+              placeholder={t("taskParametersPlaceholder")}
+              className="min-h-[96px] font-mono text-xs"
+            />
+            {state.errors?.task_parameters && (
+              <p className="text-sm text-destructive">
+                {state.errors.task_parameters[0]}
+              </p>
+            )}
+          </div>
         </div>
 
         {/* Failure Threshold */}

--- a/agentarea-webapp/src/app/(main)/triggers/create/actions.ts
+++ b/agentarea-webapp/src/app/(main)/triggers/create/actions.ts
@@ -20,6 +20,36 @@ export type TriggerFormState = {
   success?: boolean;
 };
 
+function parseTaskParameters(raw: string | null): {
+  data?: Record<string, any>;
+  error?: TriggerFormState;
+} {
+  if (!raw || !raw.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {
+        error: {
+          message: "Invalid JSON in task parameters",
+          errors: { task_parameters: ["Task parameters must be a JSON object"] },
+        },
+      };
+    }
+
+    return { data: parsed };
+  } catch {
+    return {
+      error: {
+        message: "Invalid JSON in task parameters",
+        errors: { task_parameters: ["Invalid JSON format"] },
+      },
+    };
+  }
+}
+
 function buildConfig(formData: FormData): Record<string, any> {
   const trigger_type = formData.get("trigger_type") as string;
   const data_extractor = formData.get("data_extractor") as string | null;
@@ -74,18 +104,9 @@ export async function createTriggerAction(
 
   const config = buildConfig(formData);
 
-  // Parse task parameters
-  let task_parameters: Record<string, any> | undefined;
-  if (task_parameters_raw && task_parameters_raw.trim()) {
-    try {
-      task_parameters = JSON.parse(task_parameters_raw);
-    } catch {
-      return {
-        message: "Invalid JSON in task parameters",
-        errors: { task_parameters: ["Invalid JSON format"] },
-      };
-    }
-  }
+  const parsedTaskParameters = parseTaskParameters(task_parameters_raw);
+  if (parsedTaskParameters.error) return parsedTaskParameters.error;
+  const task_parameters = parsedTaskParameters.data;
 
   // Parse failure threshold
   const failure_threshold = failure_threshold_raw
@@ -172,18 +193,9 @@ export async function updateTriggerAction(
   const task_parameters_raw = formData.get("task_parameters") as string;
   const failure_threshold_raw = formData.get("failure_threshold") as string;
 
-  // Parse task parameters
-  let task_parameters: Record<string, any> | undefined;
-  if (task_parameters_raw && task_parameters_raw.trim()) {
-    try {
-      task_parameters = JSON.parse(task_parameters_raw);
-    } catch {
-      return {
-        message: "Invalid JSON in task parameters",
-        errors: { task_parameters: ["Invalid JSON format"] },
-      };
-    }
-  }
+  const parsedTaskParameters = parseTaskParameters(task_parameters_raw);
+  if (parsedTaskParameters.error) return parsedTaskParameters.error;
+  const task_parameters = parsedTaskParameters.data;
 
   // Parse failure threshold
   const failure_threshold = failure_threshold_raw

--- a/agentarea-webapp/src/lib/feature-service.ts
+++ b/agentarea-webapp/src/lib/feature-service.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+export type BillingExperience = "oss" | "cloud";
+
+export type FeatureFlag = "cloudBilling";
+
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on", "enabled"]);
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value?.trim();
+}
+
+function isEnabledValue(value: string | undefined): boolean {
+  return value ? ENABLED_VALUES.has(value.toLowerCase()) : false;
+}
+
+function getDeploymentExperience(): BillingExperience {
+  const explicitExperience =
+    readEnv("AGENTAREA_BILLING_EXPERIENCE") ??
+    readEnv("NEXT_PUBLIC_AGENTAREA_BILLING_EXPERIENCE");
+
+  if (explicitExperience?.toLowerCase() === "cloud") {
+    return "cloud";
+  }
+
+  return "oss";
+}
+
+export function isFeatureEnabled(flag: FeatureFlag): boolean {
+  switch (flag) {
+    case "cloudBilling":
+      return (
+        getDeploymentExperience() === "cloud" ||
+        isEnabledValue(readEnv("AGENTAREA_CLOUD_BILLING")) ||
+        isEnabledValue(readEnv("NEXT_PUBLIC_AGENTAREA_CLOUD_BILLING"))
+      );
+  }
+}
+
+export function getBillingExperience(): BillingExperience {
+  return isFeatureEnabled("cloudBilling") ? "cloud" : "oss";
+}
+
+export const featureService = {
+  isEnabled: isFeatureEnabled,
+  getBillingExperience,
+};

--- a/data/catalog/mcp-servers.json
+++ b/data/catalog/mcp-servers.json
@@ -1,0 +1,87 @@
+{
+  "metadata": {
+    "source": "curated",
+    "generated_by": "agentarea curated command/stdio MCP catalog",
+    "total_count": 1
+  },
+  "servers": [
+    {
+      "server": {
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name": "ai.agentarea.catalog/telegram",
+        "title": "Telegram",
+        "description": "Telegram MCP server (Telethon) — list chats, read and search messages, download media, and (when enabled) send. Read-only by default.",
+        "version": "0.6.3",
+        "websiteUrl": "https://github.com/chigwell/telegram-mcp",
+        "repository": {
+          "url": "https://github.com/chigwell/telegram-mcp",
+          "source": "github"
+        },
+        "packages": [
+          {
+            "registryType": "pypi",
+            "identifier": "telegram-mcp",
+            "name": "telegram-mcp",
+            "version": "0.6.3",
+            "transport": {
+              "type": "stdio"
+            },
+            "environmentVariables": [
+              {
+                "name": "TELEGRAM_API_ID",
+                "description": "Telegram API ID from https://my.telegram.org/apps",
+                "required": true,
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "TELEGRAM_API_HASH",
+                "description": "Telegram API hash from https://my.telegram.org/apps",
+                "required": true,
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "TELEGRAM_SESSION_STRING",
+                "description": "Telethon StringSession produced once via the interactive auth flow (phone number + login code). Generated outside the platform, then pasted here.",
+                "required": true,
+                "isRequired": true,
+                "isSecret": true
+              },
+              {
+                "name": "TELEGRAM_EXPOSED_TOOLS",
+                "description": "Tool exposure mode. 'read-only' (default) disables sending, deleting, and other mutating tools. Set to 'all' to enable write access.",
+                "required": false,
+                "isRequired": false,
+                "isSecret": false,
+                "default": "read-only"
+              }
+            ]
+          }
+        ],
+        "icons": [
+          {
+            "src": "https://www.google.com/s2/favicons?domain=telegram.org&sz=128",
+            "mimeType": "image/png",
+            "sizes": ["128x128"]
+          }
+        ],
+        "metadata": {
+          "agentarea:source_type": "community",
+          "agentarea:source_url": "https://github.com/chigwell/telegram-mcp",
+          "agentarea:logo_domain": "telegram.org",
+          "agentarea:logo_source_url": "https://www.google.com/s2/favicons?domain=telegram.org&sz=128",
+          "agentarea:notes": "Python stdio server run via 'uvx telegram-mcp' inside agentarea/mcp-bridge:latest. Read-only by default via TELEGRAM_EXPOSED_TOOLS. Requires a pre-generated Telethon session string."
+        }
+      },
+      "_meta": {
+        "io.modelcontextprotocol.registry/official": {
+          "status": "active",
+          "isLatest": true,
+          "publishedAt": "2026-06-20T00:00:00Z",
+          "updatedAt": "2026-06-20T00:00:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/data/registry-sources.local.yaml
+++ b/data/registry-sources.local.yaml
@@ -8,6 +8,10 @@
 #   docker exec agentarea-backend /app/.venv/bin/agentarea-api reconcile \
 #       --config-file /tmp/rs.local.yaml
 
+- name: mcp-curated-catalog
+  source_url: /tmp/catalog/mcp-servers.json
+  description: Curated command/stdio MCP server catalog (local)
+
 - name: agents-catalog
   source_url: /tmp/catalog/agents.json
   description: Built-in agent catalog (local)

--- a/docs/agent-communication.md
+++ b/docs/agent-communication.md
@@ -1,5 +1,15 @@
 # Agent-to-Agent (A2A) Communication Guide
 
+> ⚠️ **OUTDATED (2026-06-20).** This guide describes the retired Google ADK /
+> `InMemoryTaskManager` / `AgentCommunicationService` model. The current design runs
+> A2A over Temporal tasks + the workflow event stream. See:
+> - **`docs/adr/2026-06-20-a2a-transport-correctness.md`** — how an A2A task produces and
+>   returns a result (authoritative).
+> - `docs/plans/2026-03-10-agent-delegation-remote-mcp.md` — delegation via `A2AAgentTool`.
+> - `docs/plans/2026-03-10-a2a-spec-compliance.md` — A2A v0.3.0 wire contract.
+>
+> The sections below are kept for historical context only.
+
 Welcome to the **AgentArea agent-to-agent communication** documentation.  
 This feature allows an _agent A_ to request work from _agent B_ by **creating a task for it** via the A2A-protocol API. Under the hood it is powered by:
 


### PR DESCRIPTION
## Summary

Rebuilt on top of latest `main`. The branch's earlier headline work (A2A v1.0.0 + push notifications, members page, policy editor rebuild, status indicator system) **already landed on main** via #242 / #243 / #245 / #248, so this PR now contains only the genuinely-new slice that is not yet upstream — applied cleanly without reverting main's newer versions of those subsystems.

**21 files, +2067 / −91.** Verified: webapp `tsc --noEmit` passes with 0 errors; JSON catalogs/i18n validated.

### Triggers & registry (backend + data)
- Trigger **task-text fallback**: when no message text is present, fall back to `trigger.task_parameters["text"]` (execution activities + `TriggerService`)
- Curated **MCP server catalog** (`data/catalog/mcp-servers.json`) + `registry-sources.local.yaml` source
- Registry service catalog test coverage

### Webapp features
- Triggers create flow: `taskParameters.ts` + expanded `CreateTriggerForm`
- Budgets: new `BudgetCapPanel` + `BudgetsData` wiring
- Billing & audit: expanded `actions.ts` + clients (3-way merged with main's billing changes)
- `feature-service.ts` feature flags
- EN/RU i18n additions

### Docs
- `docs/agent-communication.md` note

## What was intentionally dropped
The branch's parallel re-implementations of the status system, Context selector, policy editor, members page, and A2A were **superseded by main** and excluded to avoid regressing #243/#244/#245/#248. Pre-rebuild tip preserved at tag `backup/fix-members-page-pre-rebuild`.

## Test plan
- [x] `tsc --noEmit` (webapp) — 0 errors
- [ ] `make test` (platform) — trigger/registry units
- [ ] Manual: create trigger with task text, budgets cap panel, billing/audit pages
