### PR TITLE
fix(mcp-manager): publish production image, not the dev stage (CrashLoopBackOff)

### DIFF
--- a/agentarea-mcp-manager/Dockerfile
+++ b/agentarea-mcp-manager/Dockerfile
@@ -19,7 +19,33 @@ ARG TARGETOS
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -installsuffix cgo -o bin/mcp-manager ./cmd/mcp-manager \
     && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -installsuffix cgo -o bin/sandbox-runner ./cmd/sandbox-runner
 
-# ---- Production stage (default build target) ----
+# ---- Development stage (hot reload via Air) ----
+# Same docker-CLI runtime model as production, plus the Go toolchain + Air so a
+# bind-mounted source tree rebuilds on change. Opt-in only: build with
+# `--target dev` (docker-compose.dev.yaml does this). It is deliberately NOT the
+# last stage so a plain `docker build` / CI build without --target never ships
+# this image (it has no compiled binary and crash-loops in a pod).
+FROM golang:1.25-alpine AS dev
+
+RUN apk add --no-cache git ca-certificates docker-cli dumb-init \
+    && rm -rf /var/cache/apk/*
+
+RUN go install github.com/air-verse/air@latest
+
+WORKDIR /app
+
+# Pre-cache dependencies so the first reload is fast
+COPY go.mod go.sum ./
+RUN go mod download
+
+EXPOSE 8000 80
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["sh", "-c", "if [ -f /app/.air.toml ] && command -v air >/dev/null 2>&1; then exec air -c /app/.air.toml; else exec /app/start-dev.sh; fi"]
+
+# ---- Production stage ----
+# MUST be the LAST stage: buildx builds the final stage when no --target is
+# given, so this is what CI publishes by default.
 # Slim runtime: ships only the docker CLI so the manager can drive containers
 # through the mounted Docker socket. No podman/buildah/skopeo, no privileged mode.
 FROM alpine:3.20 AS production
@@ -43,24 +69,3 @@ EXPOSE 8000 80
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/app/mcp-manager"]
-
-# ---- Development stage (hot reload via Air) ----
-# Same docker-CLI runtime model as production, plus the Go toolchain + Air so a
-# bind-mounted source tree rebuilds on change. Build with `--target dev`.
-FROM golang:1.25-alpine AS dev
-
-RUN apk add --no-cache git ca-certificates docker-cli dumb-init \
-    && rm -rf /var/cache/apk/*
-
-RUN go install github.com/air-verse/air@latest
-
-WORKDIR /app
-
-# Pre-cache dependencies so the first reload is fast
-COPY go.mod go.sum ./
-RUN go mod download
-
-EXPOSE 8000 80
-
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["sh", "-c", "if [ -f /app/.air.toml ] && command -v air >/dev/null 2>&1; then exec air -c /app/.air.toml; else exec /app/start-dev.sh; fi"]


### PR DESCRIPTION
## Problem

`agentarea/agentarea-mcp-manager:0.0.12-*` CrashLoopBackOffs on Kubernetes (observed on the Timeweb cluster). The published image is the **`dev` (Air hot-reload) stage**, not the production runtime.

### Root cause

The 0.0.12 Dockerfile restructure (#231) made the file multi-stage, ordered `builder → production → dev`, with **`dev` last** and a misleading `# default build target` comment on `production`.

buildx builds the **final stage** when no `--target` is given. Neither the reusable `docker-build-push.yml` (`docker/build-push-action@v6` step has no `target:`) nor the `docker-agentarea-mcp-manager` job in `ci.yml` passes one — so CI published the `dev` stage.

The `dev` stage copies only `go.mod`/`go.sum` — **no compiled `/app/mcp-manager` binary, no `.air.toml`, no `start-dev.sh`** (those come from the compose bind-mount). Its CMD falls through to `exec /app/start-dev.sh`, which does not exist in the image → container exits non-zero → **CrashLoopBackOff**.

This is version-specific: 0.0.10 had a single runtime stage (the runtime *was* the last stage), so its image was correct.

## Fix

Reorder so **`production` is the last stage** (idiomatic "release stage last"), and replace the misleading comment with one stating the dev stage is intentionally not last.

- `dev` stays opt-in via `--target dev`, which `docker-compose.dev.yaml` already specifies — local hot reload is unaffected.
- A plain `docker build` and the existing CI build (no `--target`) now produce the production image.

## Verification

- `docker build --target production` builds the slim runtime image with the compiled binary.
- `docker-compose.dev.yaml` continues to build the `dev` target for live reload.

## Not in this PR (separate signals for the team)

- `image-updater` bumped mcp-manager to the broken build — worth a guard.
- The git/registry override points at the Timeweb Zot registry which has no mcp-manager image (→ ImagePullBackOff when it can't fall back to docker.io).
