### PR TITLE
feat(chart): seed system registries via reconcile Job (replaces operator)

### DIFF
--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -393,6 +393,13 @@ The following table lists configurable parameters of the chart and their default
 | rustfs.livenessProbe.timeoutSeconds | int | `5` |  |
 | rustfs.livenessProbe.failureThreshold | int | `6` |  |
 | jobs.dbMigration.enabled | bool | `true` |  |
+| registryReconcile.enabled | bool | `true` |  |
+| registryReconcile.registries[0].name | string | `"system-llm-providers"` |  |
+| registryReconcile.registries[0].source_url | string | `"https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-providers.json"` |  |
+| registryReconcile.registries[1].name | string | `"system-llm-models"` |  |
+| registryReconcile.registries[1].source_url | string | `"https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-models.json"` |  |
+| registryReconcile.registries[2].name | string | `"system-mcp-servers"` |  |
+| registryReconcile.registries[2].source_url | string | `"https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/mcp-servers.json"` |  |
 | keto.enabled | bool | `false` |  |
 | keto.replicaCount | int | `1` |  |
 | keto.image.repository | string | `"oryd/keto"` |  |

--- a/charts/agentarea/templates/jobs/registry-reconcile.yaml
+++ b/charts/agentarea/templates/jobs/registry-reconcile.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.registryReconcile.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agentarea.fullname" . }}-registry-reconcile
+  labels:
+    {{- include "agentarea.labels" . | nindent 4 }}
+    app.kubernetes.io/component: registry-reconcile
+    {{- with .Values.global.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    # Standard resource (not a Helm hook) that waits for the database, mirroring
+    # the db-migration Job. ttlSecondsAfterFinished clears it so a later upgrade
+    # recreates and re-runs it (reconcile is idempotent).
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "agentarea.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: registry-reconcile
+        {{- with .Values.global.extraSelectorLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "agentarea.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- with .Values.global.security.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- include "agentarea.imagePullSecrets" . | nindent 6 }}
+      initContainers:
+        # Wait for the database (registries/items live in the platform DB).
+        - name: wait-for-db
+          image: {{ .Values.global.jobs.kube.images.busybox }}
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "agentarea.database.host" . }} {{ .Values.global.database.port }}; do
+                echo "Waiting for database..."
+                sleep 2
+              done
+              echo "Database is ready!"
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+      containers:
+        - name: reconcile
+          image: "{{ .Values.global.image.registry }}{{ if .Values.global.image.registry }}/{{ end }}{{ .Values.backend.image.repository }}:{{ default .Chart.AppVersion .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- with .Values.global.security.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          workingDir: /app/apps/api
+          command:
+            - agentarea-api
+            - reconcile
+          envFrom:
+            - configMapRef:
+                name: {{ include "agentarea.fullname" . }}-env-databasejobs
+          env:
+            # Database credentials
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.secrets.postgresql }}
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.secrets.postgresql }}
+                  key: password
+            # Registry definitions consumed by `agentarea-api reconcile`
+            # (JSON array; bound to the --registries-config option via envvar).
+            - name: REGISTRIES_CONFIG
+              value: {{ .Values.registryReconcile.registries | toJson | quote }}
+          {{- if or .Values.global.jobs.kube.resources .Values.backend.resources }}
+          resources:
+            {{- if .Values.global.jobs.kube.resources }}
+            {{- toYaml .Values.global.jobs.kube.resources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  backoffLimit: 3
+{{- end }}

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -768,6 +768,25 @@ jobs:
   dbMigration:
     enabled: true
 
+# Registry reconcile (replaces the standalone agentarea-operator).
+# A post-migration Job runs `agentarea-api reconcile`, which ensures each
+# registry exists and syncs it via the platform RegistryService (the same code
+# path the API and CLI use). Idempotent: re-runs on every install/upgrade.
+# Disable to bring your own catalog or start empty.
+registryReconcile:
+  enabled: true
+  # Each entry needs `name` + `source_url`; the catalog type is auto-detected
+  # from the fetched payload. Skills are intentionally NOT seeded by default
+  # (the public skill catalog is ~123k entries across 25 shards); add skill
+  # shards explicitly if you want them.
+  registries:
+    - name: system-llm-providers
+      source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-providers.json
+    - name: system-llm-models
+      source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-models.json
+    - name: system-mcp-servers
+      source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/mcp-servers.json
+
 # Ory Kratos Identity Server
 # Ory Keto (ReBAC) — powers Govern -> Policies -> Access (the relationship graph).
 # Disabled by default; enable to turn on real relationship-based access checks.


### PR DESCRIPTION
## What
Adds an optional post-migration **Job** that runs `agentarea-api reconcile` to seed the system registries (LLM providers, models, MCP servers) on install/upgrade.

## Why
Out-of-the-box catalog seeding regressed when the in-chart operator templates were removed (the chart now ships empty registries → no models → unusable first run). This restores it **without** a CRD/controller or direct DB writes — reconcile goes through the platform `RegistryService` (same path as the API/CLI).

## Details
- `registryReconcile.enabled` (default `true`) + `registries` list — providers/models/mcp-servers. **Skills intentionally opt-in** (~123k entries across 25 shards).
- Job modeled on `db-migration`: wait-for-db init, backend image, `REGISTRIES_CONFIG` env, idempotent (re-runs each install/upgrade, `ttlSecondsAfterFinished`).
- README regenerated via helm-docs (CI doc gate).

## Verified
- `helm lint` clean; template renders; `REGISTRIES_CONFIG` serializes to valid JSON; `enabled=false` toggles off.
- appVersion `0.0.12` == VERSION (release gate).

## Follow-ups (not in this PR)
- Cut chart release (workflow_dispatch / `v*` tag) → publishes new chart version.
- Bump `k8s-apps` wrapper dependency → ArgoCD deploys (RU Timeweb + EN DO).
- Decommission standalone operator + CRD + RegistrySync CRs.