### PR TITLE
fix(alembic): unbreak CI after head merge (ruff + non-merge tip)

### DIFF
--- a/agentarea-platform/apps/api/alembic/versions/20260624_0001_merge_heads.py
+++ b/agentarea-platform/apps/api/alembic/versions/20260624_0001_merge_heads.py
@@ -20,7 +20,12 @@ from collections.abc import Sequence
 
 # revision identifiers, used by Alembic.
 revision: str = "20260624_0001_merge_heads"
-down_revision: str | None = ("010_add_a2ui_enabled", "20260618_1200_reg_item_installs", "gg2_add_wallet_fk_cascades", "jj1_docker_url_nullable")
+down_revision: str | None = (
+    "010_add_a2ui_enabled",
+    "20260618_1200_reg_item_installs",
+    "gg2_add_wallet_fk_cascades",
+    "jj1_docker_url_nullable",
+)
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/agentarea-platform/apps/api/alembic/versions/20260624_0002_post_merge.py
+++ b/agentarea-platform/apps/api/alembic/versions/20260624_0002_post_merge.py
@@ -1,0 +1,32 @@
+"""linear no-op after the 4-head merge (keeps a non-merge tip)
+
+The merge migration ``20260624_0001_merge_heads`` reunites four divergent heads,
+but a merge node cannot be the tip: ``alembic downgrade -1`` from a merge raises
+"Ambiguous walk" (it cannot pick which branch to walk down), which breaks the
+CI migrations-gate downgrade/upgrade roundtrip. This trivial linear revision
+sits on top of the merge so the single head is an ordinary (non-merge) node and
+the roundtrip is unambiguous. No schema change.
+
+Revision ID: 20260624_0002_post_merge
+Revises: 20260624_0001_merge_heads
+Create Date: 2026-06-24 00:01:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "20260624_0002_post_merge"
+down_revision: str | None = "20260624_0001_merge_heads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """No-op: linear tip above the merge."""
+    pass
+
+
+def downgrade() -> None:
+    """No-op."""
+    pass


### PR DESCRIPTION
PR #255 turned main red: platform-lint (ruff format on the merge file) + migrations-gate roundtrip (`alembic downgrade -1` from a merge node = "Ambiguous walk").

Fix: ruff-format the merge file + add a trivial linear no-op `20260624_0002_post_merge` on top so the single head is a non-merge node and the roundtrip is unambiguous. No schema change.

**Verified locally** (postgres:15): one head, fresh `upgrade head` OK, `downgrade -1`+`upgrade head` roundtrip OK, ruff clean.