### PR TITLE
fix(auth): explicit ACCESS_CONTROL_BACKEND wins over permissions extension

### DIFF
--- a/agentarea-platform/AGENTS.md
+++ b/agentarea-platform/AGENTS.md
@@ -50,8 +50,18 @@ agentarea-platform/
 - **Audit decorator**: Prefer `@audited(action, resource_type, resource_id_param=...)` on service mutation methods
 - **Money type**: All monetary values (costs, budgets, balances) use `Money` from `agentarea_common.money`. `Money` is `Decimal` with Pydantic str serialization — use it for model fields, arithmetic, and function args. Use `to_money()` to construct, `serialize_money()` for raw dicts/events. Never use `float` for money.
 
+## EXTENSION POINTS (OSS ↔ enterprise)
+
+Enterprise features plug in via `agentarea.extensions` entry points (see `libs/common/agentarea_common/extensions/`). Before adding a new extension point, classify it — this prevents the "installed plugin silently overrides explicit config" class of bug:
+
+- **Selector** (exactly ONE implementation is active — e.g. the `PermissionService` backend). The active impl is chosen by **explicit config** (`ACCESS_CONTROL_BACKEND`), and explicit config MUST win over a merely-installed extension. The extension is a **fallback**, used only when the operator picked no concrete backend. "Installed ⇒ active" is forbidden for selectors. Always **log the resolved impl**, and warn when an extension is shadowed by explicit config. (This mirrors Spring `@ConditionalOnMissingBean` / Django `AUTHENTICATION_BACKENDS` / Vault mounts — selection is config-driven, never classpath-driven.)
+- **Additive** (layers on without replacing — e.g. `entitlement_guard`, middleware, hooks). Here "installed ⇒ active" is correct; nothing is contradicted.
+
+The `permissions` selector wiring lives in `apps/api/.../main.py` and `apps/worker/.../main.py` — keep both in sync.
+
 ## ANTI-PATTERNS (THIS DIR)
 
+- Never let an installed extension override an EXPLICIT selector config (e.g. a `permissions` extension must not shadow `ACCESS_CONTROL_BACKEND`); explicit config wins, extension is fallback. See EXTENSION POINTS above.
 - Never skip `UserContext` in repository constructors
 - Never use `metadata` as field name (use `event_metadata`)
 - Never create service without DI registration

--- a/agentarea-platform/apps/api/agentarea_api/main.py
+++ b/agentarea-platform/apps/api/agentarea_api/main.py
@@ -80,19 +80,40 @@ async def initialize_services():
             )
             register_singleton(KetoClient, keto_client)
 
+        # PermissionService is a SELECTOR extension point: exactly one impl is
+        # active, and an EXPLICIT ACCESS_CONTROL_BACKEND must win over a merely
+        # installed "permissions" extension. (Previously the extension was checked
+        # first and silently overrode the configured backend -- e.g. an installed
+        # keto extension shadowed ACCESS_CONTROL_BACKEND=openfga so OpenFGA never
+        # enforced.) The extension is a FALLBACK, used only when the operator did
+        # not select a concrete backend. See AGENTS.md "Extension points".
+        backend = settings.access_control.ACCESS_CONTROL_BACKEND
         perm_factory = ExtensionRegistry.get_factory("permissions")
-        if perm_factory:
-            register_factory(PermissionService, perm_factory)
-        elif openfga_client is not None:
+        if openfga_client is not None:
             from agentarea_common.auth.openfga_permission import OpenFGAPermissionService
 
             register_singleton(PermissionService, OpenFGAPermissionService(openfga_client))
+            perm_impl = "OpenFGAPermissionService"
         elif keto_client is not None:
             from agentarea_common.auth.keto_permission import KetoPermissionService
 
             register_singleton(PermissionService, KetoPermissionService(keto_client))
+            perm_impl = "KetoPermissionService"
+        elif perm_factory:
+            register_factory(PermissionService, perm_factory)
+            perm_impl = "extension:permissions"
         else:
             register_singleton(PermissionService, WorkspaceScopedPermissionService())
+            perm_impl = "WorkspaceScopedPermissionService"
+
+        if perm_factory and perm_impl != "extension:permissions":
+            logger.warning(
+                "Ignoring registered 'permissions' extension: ACCESS_CONTROL_BACKEND=%s "
+                "selects %s explicitly. An extension cannot override an explicit backend.",
+                backend,
+                perm_impl,
+            )
+        logger.info("PermissionService=%s (ACCESS_CONTROL_BACKEND=%s)", perm_impl, backend)
 
         authz_factory = ExtensionRegistry.get_factory("authorization")
         if authz_factory:

--- a/agentarea-platform/apps/worker/agentarea_worker/main.py
+++ b/agentarea-platform/apps/worker/agentarea_worker/main.py
@@ -178,19 +178,40 @@ class AgentAreaWorker:
             )
             register_singleton(KetoClient, keto_client)
 
+        # PermissionService is a SELECTOR extension point: exactly one impl is
+        # active, and an EXPLICIT ACCESS_CONTROL_BACKEND must win over a merely
+        # installed "permissions" extension. (Previously the extension was checked
+        # first and silently overrode the configured backend -- e.g. an installed
+        # keto extension shadowed ACCESS_CONTROL_BACKEND=openfga so OpenFGA never
+        # enforced.) The extension is a FALLBACK, used only when the operator did
+        # not select a concrete backend. See AGENTS.md "Extension points".
+        backend = settings.access_control.ACCESS_CONTROL_BACKEND
         perm_factory = ExtensionRegistry.get_factory("permissions")
-        if perm_factory:
-            register_factory(PermissionService, perm_factory)
-        elif openfga_client is not None:
+        if openfga_client is not None:
             from agentarea_common.auth.openfga_permission import OpenFGAPermissionService
 
             register_singleton(PermissionService, OpenFGAPermissionService(openfga_client))
+            perm_impl = "OpenFGAPermissionService"
         elif keto_client is not None:
             from agentarea_common.auth.keto_permission import KetoPermissionService
 
             register_singleton(PermissionService, KetoPermissionService(keto_client))
+            perm_impl = "KetoPermissionService"
+        elif perm_factory:
+            register_factory(PermissionService, perm_factory)
+            perm_impl = "extension:permissions"
         else:
             register_singleton(PermissionService, WorkspaceScopedPermissionService())
+            perm_impl = "WorkspaceScopedPermissionService"
+
+        if perm_factory and perm_impl != "extension:permissions":
+            logger.warning(
+                "Ignoring registered 'permissions' extension: ACCESS_CONTROL_BACKEND=%s "
+                "selects %s explicitly. An extension cannot override an explicit backend.",
+                backend,
+                perm_impl,
+            )
+        logger.info("PermissionService=%s (ACCESS_CONTROL_BACKEND=%s)", perm_impl, backend)
 
         authz_factory = ExtensionRegistry.get_factory("authorization")
         if authz_factory:

--- a/agentarea-platform/libs/common/tests/test_extension_wiring.py
+++ b/agentarea-platform/libs/common/tests/test_extension_wiring.py
@@ -17,8 +17,18 @@ def clean():
     get_container().clear()
 
 
-def wire_di(deployment_mode: str = "oss"):
-    """Simulate the startup wiring logic."""
+def wire_di(
+    deployment_mode: str = "oss",
+    backend: str = "disabled",
+    openfga_impl: PermissionService | None = None,
+    keto_impl: PermissionService | None = None,
+):
+    """Simulate the startup wiring logic (mirrors apps/api + apps/worker main.py).
+
+    PermissionService is a SELECTOR: an explicit ACCESS_CONTROL_BACKEND wins over a
+    merely-installed "permissions" extension; the extension is only a fallback used
+    when no concrete backend is selected.
+    """
     from agentarea_common.extensions import discover_extensions
 
     discover_extensions()
@@ -29,9 +39,13 @@ def wire_di(deployment_mode: str = "oss"):
     mode = DeploymentMode(deployment_mode)
     container.register_singleton(FeatureService, FeatureService(mode=mode))
 
-    # Permission service — enterprise factory overrides OSS default
+    # Permission service — explicit backend is authoritative; extension is fallback.
     perm_factory = ExtensionRegistry.get_factory("permissions")
-    if perm_factory:
+    if backend == "openfga" and openfga_impl is not None:
+        container.register_singleton(PermissionService, openfga_impl)
+    elif backend == "keto" and keto_impl is not None:
+        container.register_singleton(PermissionService, keto_impl)
+    elif perm_factory:
         container.register_factory(PermissionService, perm_factory)
     else:
         container.register_singleton(PermissionService, WorkspaceScopedPermissionService())
@@ -53,6 +67,8 @@ def test_oss_wiring_registers_feature_service():
 
 @pytest.mark.flow(MainFlow.EXTENSION_CONTRACT)
 def test_enterprise_factory_overrides_default():
+    """With no explicit backend selected, a permissions extension is the fallback."""
+
     class FakePermissionService(PermissionService):
         async def check(self, user_id, permission, resource_type, resource_id):
             return False
@@ -63,3 +79,29 @@ def test_enterprise_factory_overrides_default():
     container = get_container()
     perm = container.get(PermissionService)
     assert isinstance(perm, FakePermissionService)
+
+
+@pytest.mark.flow(MainFlow.EXTENSION_CONTRACT)
+def test_explicit_backend_shadows_extension():
+    """An EXPLICIT ACCESS_CONTROL_BACKEND must win over an installed extension.
+
+    Regression guard: a registered "permissions" extension used to be checked
+    first and silently overrode the configured backend (an installed keto
+    extension shadowed ACCESS_CONTROL_BACKEND=openfga, so OpenFGA never enforced).
+    """
+
+    class FakeExtensionPermissionService(PermissionService):
+        async def check(self, user_id, permission, resource_type, resource_id):
+            return False
+
+    class FakeOpenFGAPermissionService(PermissionService):
+        async def check(self, user_id, permission, resource_type, resource_id):
+            return True
+
+    ExtensionRegistry.register("permissions", FakeExtensionPermissionService)
+    wire_di("enterprise", backend="openfga", openfga_impl=FakeOpenFGAPermissionService())
+
+    container = get_container()
+    perm = container.get(PermissionService)
+    assert isinstance(perm, FakeOpenFGAPermissionService)
+    assert not isinstance(perm, FakeExtensionPermissionService)


### PR DESCRIPTION
## Problem
`PermissionService` is a **selector** extension point (exactly one impl active). The startup wiring checked the `permissions` extension factory **before** the configured backend, so a merely-installed extension silently overrode `ACCESS_CONTROL_BACKEND`.

In prod this bit us: an enterprise keto `permissions` extension shadowed `ACCESS_CONTROL_BACKEND=openfga`, so the OpenFGA store/model were bootstrapped but enforcement still ran through keto — OpenFGA never actually enforced. It cost a full image rebuild to diagnose.

## Fix
- Reorder: an **explicit** backend (`openfga`/`keto`) is authoritative; the extension is a **fallback**, used only when no concrete backend is selected.
- **Log** the resolved `PermissionService` impl on startup, and **warn** loudly when an installed extension is shadowed by explicit config.
- Applied identically in `apps/api` and `apps/worker` (kept in sync).

This matches industry norms — Spring `@ConditionalOnMissingBean`, Django `AUTHENTICATION_BACKENDS`, Vault mounts, Keycloak `default-provider`: selection is config-driven, never “installed ⇒ active”.

## Tests / docs
- New regression test `test_explicit_backend_shadows_extension` (extension present + `backend=openfga` ⇒ OpenFGA wins). All 4 wiring tests pass.
- Documents the **selector vs additive** extension rule in `agentarea-platform/AGENTS.md` (additive points like `entitlement_guard` correctly stay “installed ⇒ active”).

## Compatibility
No behavior change when no explicit backend is set (extension still wins as the fallback), so existing enterprise wiring that relies on an extension without setting `ACCESS_CONTROL_BACKEND` is unaffected.