### PR TITLE
Loading skeleton

### DIFF
--- a/agentarea-webapp/src/app/(main)/admin/api-keys/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/api-keys/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { TableSkeleton } from "@/components/Skeleton";
 import APIKeysContent from "./APIKeysContent";
 import CreateAPIKeyButton from "./components/CreateAPIKeyButton";
 
@@ -26,9 +26,17 @@ export default async function APIKeysPage() {
     >
       <Suspense
         fallback={
-          <div className="flex h-64 items-center justify-center">
-            <LoadingSpinner />
-          </div>
+          <TableSkeleton
+            rows={6}
+            columns={[
+              { header: t("table.name"), barClassName: "h-4 w-32" },
+              { header: t("table.tokenPrefix"), barClassName: "h-4 w-24" },
+              { header: t("table.status"), barClassName: "h-5 w-20 rounded-full" },
+              { header: t("table.created"), barClassName: "h-4 w-24" },
+              { header: t("table.expires"), barClassName: "h-4 w-24" },
+              { header: t("table.lastUsed"), barClassName: "h-4 w-24" },
+            ]}
+          />
         }
       >
         <APIKeysContent />

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProviderConfigsView.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProviderConfigsView.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import EmptyState from "@/components/EmptyState";
 import Table from "@/components/Table/Table";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 import ModelsList from "./ModelsList";
 import { ProviderConfigCard } from "./ProviderItem";
 import { ProviderConfig } from "./types";
@@ -87,7 +88,7 @@ export default function ProviderConfigsView({
 
   // Render grid view (default)
   return (
-    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+    <div className={CARD_GRID_DENSE}>
       {configs.map((config) => (
         <ProviderConfigCard key={config.id} config={config} />
       ))}

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProviderSpecView.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProviderSpecView.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import EmptyState from "@/components/EmptyState";
 import Table from "@/components/Table/Table";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 import ModelsList from "./ModelsList";
 import { ProviderSpecCard } from "./ProviderItem";
 import { ProviderSpec } from "./types";
@@ -92,7 +93,7 @@ export default function ProviderSpecView({
 
   // Render grid view (default)
   return (
-    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+    <div className={CARD_GRID_DENSE}>
       {specs.map((spec) => (
         <ProviderSpecCard key={spec.id} spec={spec} />
       ))}

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProvidersSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProvidersSkeleton.tsx
@@ -3,9 +3,7 @@ import {
   LinkedCardSkeleton,
   type SkeletonColumn,
 } from "@/components/Skeleton";
-
-const GRID_CLASS =
-  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 
 // ProviderConfigCard: icon + provider subtitle + a models/badge body row.
 function ProviderConfigCardSkeleton() {
@@ -42,7 +40,7 @@ export default function ProvidersSkeleton({
           viewMode={viewMode}
           columns={configColumns}
           rows={5}
-          gridClassName={GRID_CLASS}
+          gridClassName={CARD_GRID_DENSE}
           count={5}
           Card={ProviderConfigCardSkeleton}
         />
@@ -55,7 +53,7 @@ export default function ProvidersSkeleton({
           viewMode={viewMode}
           columns={specColumns}
           rows={5}
-          gridClassName={GRID_CLASS}
+          gridClassName={CARD_GRID_DENSE}
           count={10}
           Card={ProviderSpecCardSkeleton}
         />

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProvidersSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/components/ProvidersSkeleton.tsx
@@ -1,0 +1,65 @@
+import {
+  CollectionSkeleton,
+  LinkedCardSkeleton,
+  type SkeletonColumn,
+} from "@/components/Skeleton";
+
+const GRID_CLASS =
+  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+
+// ProviderConfigCard: icon + provider subtitle + a models/badge body row.
+function ProviderConfigCardSkeleton() {
+  return <LinkedCardSkeleton icon subtitle lines={1} />;
+}
+
+// ProviderSpecCard: compact — icon + title only (py-3).
+function ProviderSpecCardSkeleton() {
+  return <LinkedCardSkeleton icon className="py-3" />;
+}
+
+interface ProvidersSkeletonProps {
+  viewMode?: string;
+  configsLabel: string;
+  specsLabel: string;
+  configColumns: SkeletonColumn[];
+  specColumns: SkeletonColumn[];
+}
+
+export default function ProvidersSkeleton({
+  viewMode,
+  configsLabel,
+  specsLabel,
+  configColumns,
+  specColumns,
+}: ProvidersSkeletonProps) {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h4 className="mb-3 text-xs uppercase text-muted-foreground/80">
+          {configsLabel}
+        </h4>
+        <CollectionSkeleton
+          viewMode={viewMode}
+          columns={configColumns}
+          rows={5}
+          gridClassName={GRID_CLASS}
+          count={5}
+          Card={ProviderConfigCardSkeleton}
+        />
+      </div>
+      <div>
+        <h4 className="mb-3 text-xs uppercase text-muted-foreground/80">
+          {specsLabel}
+        </h4>
+        <CollectionSkeleton
+          viewMode={viewMode}
+          columns={specColumns}
+          rows={5}
+          gridClassName={GRID_CLASS}
+          count={10}
+          Card={ProviderSpecCardSkeleton}
+        />
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/create/[provider_spec_id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/create/[provider_spec_id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import ProviderConfigFormWrapper from "../components/ProviderConfigFormWrapper";
 import { Button } from "@/components/ui/button";
 
@@ -35,14 +35,7 @@ export default async function CreateProviderConfigWithSpecPage({
         ),
       }}
     >
-      <Suspense
-        key={provider_spec_id}
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+      <Suspense key={provider_spec_id} fallback={<FormSkeleton />}>
         <ProviderConfigFormWrapper
           preselectedProviderId={provider_spec_id}
           isEdit={false}

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/create/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/create/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import ProviderConfigFormWrapper from "./components/ProviderConfigFormWrapper";
 import { Button } from "@/components/ui/button";
 import { getProviderSpec } from "@/lib/api";
@@ -60,11 +60,7 @@ export default async function CreateProviderConfigPage({
     >
       <Suspense
         key={preselectedProviderId || "create"}
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
+        fallback={<FormSkeleton />}
       >
         <ProviderConfigFormWrapper
           preselectedProviderId={preselectedProviderId}

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/edit/[providerConfigId]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/edit/[providerConfigId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import { Button } from "@/components/ui/button";
 import { getProviderConfig } from "@/lib/api";
 import { notFoundOnApi404 } from "@/lib/server-resource";
@@ -52,14 +52,7 @@ export default async function EditProviderConfigPage({
         ),
       }}
     >
-      <Suspense
-        key={providerConfigId}
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+      <Suspense key={providerConfigId} fallback={<FormSkeleton />}>
         <ProviderConfigFormWrapper
           preselectedProviderId={providerConfigId}
           isEdit={true}

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/page.tsx
@@ -5,11 +5,11 @@ import { cookies } from "next/headers";
 import Link from "next/link";
 import { Settings } from "lucide-react";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import { Button } from "@/components/ui/button";
 import ProviderHeaderTabs from "./components/ProviderHeaderTabs";
 import ProvidersData from "./components/ProvidersData";
+import ProvidersSkeleton from "./components/ProvidersSkeleton";
 
 export const metadata: Metadata = {
   title: "Provider Configs",
@@ -36,6 +36,17 @@ export default async function ProviderConfigsPage({
     typeof resolvedSearchParams.tab === "string"
       ? resolvedSearchParams.tab
       : cookieTab || "grid";
+
+  const configColumns = [
+    { header: t("table.name"), barClassName: "h-4 w-32" },
+    { header: t("table.provider"), barClassName: "h-4 w-24" },
+    { header: t("table.models"), barClassName: "h-5 w-28 rounded-full" },
+  ];
+  const specColumns = [
+    { header: t("table.name"), barClassName: "h-4 w-32" },
+    { header: t("table.description"), cellClassName: "max-w-[300px]", barClassName: "h-3 w-48" },
+    { header: t("table.models"), barClassName: "h-5 w-28 rounded-full" },
+  ];
 
   return (
     <ContentBlock
@@ -68,9 +79,13 @@ export default async function ProviderConfigsPage({
       <Suspense
         key={searchQuery}
         fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
+          <ProvidersSkeleton
+            viewMode={tab}
+            configsLabel={t("providerConfigsSection")}
+            specsLabel={t("providerSpecsSection")}
+            configColumns={configColumns}
+            specColumns={specColumns}
+          />
         }
       >
         <ProvidersData searchQuery={searchQuery} viewMode={tab} />

--- a/agentarea-webapp/src/app/(main)/agents/[id]/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/loading.tsx
@@ -1,10 +1,9 @@
-import React from "react";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { DetailSkeleton } from "@/components/Skeleton";
 
 export default function Loading() {
   return (
-    <div className="flex h-64 items-center justify-center">
-      <LoadingSpinner />
+    <div className="main-content">
+      <DetailSkeleton />
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/agents/[id]/new-task/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/new-task/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import { getAgent, listModelInstances } from "@/lib/api";
 import { requireApiData } from "@/lib/server-resource";
 import AgentNewTask from "./components/AgentNewTask";
@@ -33,13 +33,7 @@ export default async function AgentNewTaskPage({ params }: Props) {
     : undefined;
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex h-32 items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }
-    >
+    <Suspense fallback={<FormSkeleton className="p-4" />}>
       <AgentNewTask agent={{ ...agent, model_info } as any} />
     </Suspense>
   );

--- a/agentarea-webapp/src/app/(main)/agents/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { DetailSkeleton } from "@/components/Skeleton";
 import { AgentOverview } from "./components/AgentOverview";
 
 interface Props {
@@ -10,13 +10,7 @@ export default async function AgentDetailPage({ params }: Props) {
   const { id } = await params;
   return (
     <div className="main-content">
-      <Suspense
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+      <Suspense fallback={<DetailSkeleton />}>
         <AgentOverview agentId={id} />
       </Suspense>
     </div>

--- a/agentarea-webapp/src/app/(main)/agents/[id]/settings/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/settings/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import AgentEditContent from "./AgentEditContent";
 
 export const metadata: Metadata = {
@@ -19,13 +19,7 @@ export default async function AgentSettingsPage({
   const resolvedParams = await params;
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex h-32 items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }
-    >
+    <Suspense fallback={<FormSkeleton className="p-4" />}>
       <AgentEditContent agentId={resolvedParams.id} />
     </Suspense>
   );

--- a/agentarea-webapp/src/app/(main)/agents/[id]/tasks/components/AgentTasksSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/tasks/components/AgentTasksSkeleton.tsx
@@ -1,0 +1,15 @@
+import { LinkedCardSkeleton } from "@/components/Skeleton";
+
+// Mirrors AgentTasksList: a grid of TaskItem cards (status badge + date row).
+export default function AgentTasksSkeleton() {
+  return (
+    <div
+      className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3"
+      aria-hidden="true"
+    >
+      {Array.from({ length: 9 }).map((_, i) => (
+        <LinkedCardSkeleton key={i} topRight lines={1} />
+      ))}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/agents/[id]/tasks/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/tasks/loading.tsx
@@ -1,0 +1,5 @@
+import AgentTasksSkeleton from "./components/AgentTasksSkeleton";
+
+export default function Loading() {
+  return <AgentTasksSkeleton />;
+}

--- a/agentarea-webapp/src/app/(main)/agents/[id]/tasks/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/tasks/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { getAgent, listAgentTasks, type Agent } from "@/lib/api";
 import AgentTasksList from "./components/AgentTasksList";
+import AgentTasksSkeleton from "./components/AgentTasksSkeleton";
 import { TaskWithStatus } from "./types";
 
 export const metadata: Metadata = {
@@ -33,13 +33,7 @@ export default async function AgentTasksPage({ params }: Props) {
   }
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex h-32 items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }
-    >
+    <Suspense fallback={<AgentTasksSkeleton />}>
       <AgentTasksList agentId={realId} initialTasks={initialTasks} />
     </Suspense>
   );

--- a/agentarea-webapp/src/app/(main)/agents/[id]/wallet/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/wallet/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import WalletFormContent from "./WalletFormContent";
 
 export const metadata: Metadata = {
@@ -19,13 +19,7 @@ export default async function AgentWalletPage({
   const resolvedParams = await params;
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex h-32 items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }
-    >
+    <Suspense fallback={<FormSkeleton className="px-4 py-5" />}>
       <div className="h-full space-y-8 px-4 py-5 overflow-auto">
         <WalletFormContent agentId={resolvedParams.id} />
       </div>

--- a/agentarea-webapp/src/app/(main)/agents/components/AgentCardSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/components/AgentCardSkeleton.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+/**
+ * Loading placeholder for `AgentCard`. Mirrors its exact structure — avatar +
+ * title row, model badge, and the bordered footer with tool chips — so the grid
+ * doesn't shift when real data replaces the skeleton.
+ */
+export default function AgentCardSkeleton() {
+  return (
+    <Card
+      className={cn(
+        "relative flex h-full flex-col justify-between overflow-hidden p-0",
+        "border border-zinc-200 dark:border-zinc-800",
+        "bg-white dark:bg-zinc-900"
+      )}
+      aria-hidden="true"
+    >
+      <div className="relative z-10 flex h-full flex-col justify-between">
+        <div className="flex flex-col gap-2 px-[16px] py-[16px] md:px-[20px] lg:px-[24px]">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 pt-0.5">
+              <div className="flex items-center gap-2">
+                {/* avatar — AgentAvatar size="sm" is h-6 w-6 rounded-md */}
+                <Skeleton className="h-6 w-6 shrink-0 rounded-md" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {/* model badge */}
+                <Skeleton className="h-5 w-24 rounded-full" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            "relative overflow-hidden border-t",
+            "border-zinc-200/60 dark:border-zinc-700/60",
+            "pl-[16px] pr-[8px] py-[10px] md:pl-[20px] md:pr-[10px] lg:pl-[24px] lg:pr-[10px]"
+          )}
+        >
+          <div className="relative z-10 flex items-center justify-between">
+            {/* tool chips — overlapping h-6 w-6 circles */}
+            <div className="flex -space-x-1.5">
+              <Skeleton className="h-6 w-6 rounded-full" />
+              <Skeleton className="h-6 w-6 rounded-full" />
+              <Skeleton className="h-6 w-6 rounded-full" />
+            </div>
+            <Skeleton className="h-4 w-4 rounded-sm" />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/agents/components/AgentsList.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/components/AgentsList.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import ModelBadge from "@/components/ui/model-badge";
 import { Agent, agentPath } from "@/types";
 import { AgentToolIcon } from "@/utils/agentToolIcons";
+import { AGENT_COLUMNS, AGENTS_GRID_CLASS } from "./agentColumns";
 import { AgentToolIcons } from "./AgentToolIcons";
 import AgentCard from "./AgentCard";
 
@@ -26,74 +27,63 @@ export default function AgentsList({
   const t = useTranslations("AgentsPage");
   const router = useRouter();
 
-  // Define table columns for agents
-  const agentColumns = [
-    {
-      accessor: "name",
-      header: t("name") || "Name",
-      render: (value: string, item: Agent) => (
+  // Cell renderers keyed by accessor. The column order, labels, and widths come
+  // from the shared `AGENT_COLUMNS` meta (also used by the table skeleton).
+  const renderers: Record<
+    string,
+    (value: any, item: AgentWithToolIcons) => React.ReactNode
+  > = {
+    name: (value: string, item: Agent) => (
+      <div className="flex items-center gap-2">
+        <AgentAvatar agent={item} size="xs" />
+        <span className="truncate font-medium">{value}</span>
+      </div>
+    ),
+    description: (value: string) => (
+      <span className="block truncate text-xs text-muted-foreground">
+        {value || "-"}
+      </span>
+    ),
+    model_info: (value: any) => (
+      <ModelBadge
+        providerName={value?.provider_name}
+        iconUrl={value?.provider_icon_url}
+        modelDisplayName={value?.model_display_name}
+        configName={value?.config_name}
+      />
+    ),
+    active_task_count: (value: number) =>
+      value > 0 ? (
+        <Badge variant="blue" className="text-xs">
+          {value}
+        </Badge>
+      ) : (
+        <span className="text-xs text-muted-foreground">—</span>
+      ),
+    tools_config: (_value: any, item: AgentWithToolIcons) => {
+      const toolIcons = item.tool_icons ?? [];
+
+      if (toolIcons.length === 0) {
+        return <span className="text-xs text-muted-foreground">-</span>;
+      }
+
+      return (
         <div className="flex items-center gap-2">
-          <AgentAvatar agent={item} size="xs" />
-          <span className="truncate font-medium">{value}</span>
+          <AgentToolIcons maxDisplay={3} tools={toolIcons} />
+          <span className="text-xs text-muted-foreground">
+            {toolIcons.length}
+          </span>
         </div>
-      ),
+      );
     },
-    {
-      accessor: "description",
-      header: t("description") || "Description",
-      cellClassName: "max-w-[300px]",
-      render: (value: string) => (
-        <span className="block truncate text-xs text-muted-foreground">
-          {value || "-"}
-        </span>
-      ),
-    },
-    {
-      accessor: "model_info",
-      header: t("model") || "Model",
-      render: (value: any) => (
-        <ModelBadge
-          providerName={value?.provider_name}
-          iconUrl={value?.provider_icon_url}
-          modelDisplayName={value?.model_display_name}
-          configName={value?.config_name}
-        />
-      ),
-    },
-    {
-      accessor: "active_task_count",
-      header: t("activeTasks") || "Active Tasks",
-      render: (value: number) => (
-        value > 0 ? (
-          <Badge variant="blue" className="text-xs">
-            {value}
-          </Badge>
-        ) : (
-          <span className="text-xs text-muted-foreground">—</span>
-        )
-      ),
-    },
-    {
-      accessor: "tools_config",
-      header: t("tools") || "Tools",
-      render: (value: any, item: AgentWithToolIcons) => {
-        const toolIcons = item.tool_icons ?? [];
+  };
 
-        if (toolIcons.length === 0) {
-          return <span className="text-xs text-muted-foreground">-</span>;
-        }
-
-        return (
-          <div className="flex items-center gap-2">
-            <AgentToolIcons maxDisplay={3} tools={toolIcons} />
-            <span className="text-xs text-muted-foreground">
-              {toolIcons.length}
-            </span>
-          </div>
-        );
-      },
-    },
-  ];
+  const agentColumns = AGENT_COLUMNS.map((column) => ({
+    accessor: column.accessor,
+    header: t(column.labelKey),
+    cellClassName: column.cellClassName,
+    render: renderers[column.accessor],
+  }));
 
   // Render table view
   if (viewMode === "table") {
@@ -111,7 +101,7 @@ export default function AgentsList({
   // Render grid view (default). The agents list is "Yours only" — catalog
   // (built-in) agents are discovered via Explore, not mixed into the working set.
   return (
-    <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+    <div className={AGENTS_GRID_CLASS}>
       {initialAgents.map((agent) => (
         <AgentCard key={agent.id} agent={agent} />
       ))}

--- a/agentarea-webapp/src/app/(main)/agents/components/AgentsSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/components/AgentsSkeleton.tsx
@@ -1,0 +1,30 @@
+import { CollectionSkeleton, type SkeletonColumn } from "@/components/Skeleton";
+import { AGENTS_GRID_CLASS } from "./agentColumns";
+import AgentCardSkeleton from "./AgentCardSkeleton";
+
+interface AgentsSkeletonProps {
+  /** Selected view, known server-side (URL/cookie) before content suspends. */
+  viewMode?: string;
+  /** Resolved table columns (header labels need translations from the page). */
+  columns: SkeletonColumn[];
+}
+
+/**
+ * Loading placeholder for the agents list — switches between the grid of
+ * `AgentCardSkeleton`s and a `TableSkeleton`, matching the selected view.
+ */
+export default function AgentsSkeleton({
+  viewMode,
+  columns,
+}: AgentsSkeletonProps) {
+  return (
+    <CollectionSkeleton
+      viewMode={viewMode}
+      columns={columns}
+      rows={8}
+      gridClassName={AGENTS_GRID_CLASS}
+      count={10}
+      Card={AgentCardSkeleton}
+    />
+  );
+}

--- a/agentarea-webapp/src/app/(main)/agents/components/agentColumns.ts
+++ b/agentarea-webapp/src/app/(main)/agents/components/agentColumns.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared layout metadata for the agents list. Both the real `Table` (in
+ * `AgentsList`) and the loading `TableSkeleton` (in `AgentsSkeleton`) derive
+ * from this, so the header labels, order, and cell widths can never drift apart.
+ *
+ * Only layout-relevant fields live here — the actual cell `render` functions
+ * stay in `AgentsList`, keyed by `accessor`.
+ */
+export type AgentColumnMeta = {
+  accessor: string;
+  /** Translation key in the `AgentsPage` namespace. */
+  labelKey: string;
+  cellClassName?: string;
+  /** Width/shape of the skeleton bar for this column while loading. */
+  barClassName?: string;
+};
+
+export const AGENT_COLUMNS: AgentColumnMeta[] = [
+  { accessor: "name", labelKey: "name", barClassName: "h-4 w-32" },
+  {
+    accessor: "description",
+    labelKey: "description",
+    cellClassName: "max-w-[300px]",
+    barClassName: "h-3 w-48",
+  },
+  { accessor: "model_info", labelKey: "model", barClassName: "h-5 w-24 rounded-full" },
+  { accessor: "active_task_count", labelKey: "activeTasks", barClassName: "h-4 w-6" },
+  { accessor: "tools_config", labelKey: "tools", barClassName: "h-6 w-16" },
+];
+
+/** Grid classes shared by the real agents grid and its skeleton. */
+export const AGENTS_GRID_CLASS =
+  "grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";

--- a/agentarea-webapp/src/app/(main)/agents/components/agentColumns.ts
+++ b/agentarea-webapp/src/app/(main)/agents/components/agentColumns.ts
@@ -29,5 +29,4 @@ export const AGENT_COLUMNS: AgentColumnMeta[] = [
 ];
 
 /** Grid classes shared by the real agents grid and its skeleton. */
-export const AGENTS_GRID_CLASS =
-  "grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";
+export { CARD_GRID_WIDE as AGENTS_GRID_CLASS } from "@/lib/collectionGrids";

--- a/agentarea-webapp/src/app/(main)/agents/create/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import AgentPageWrapper from "../shared/AgentPageWrapper";
 import { ChatProvider } from "../shared/ChatContext";
 import CreateAgentContent from "./CreateAgentContent";
@@ -24,13 +24,7 @@ export default async function CreateAgentPage() {
         useContentBlock={true}
         controls={<CreateAgentHeaderControls label={t("createAgent")} />}
       >
-        <Suspense
-          fallback={
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          }
-        >
+        <Suspense fallback={<FormSkeleton className="p-4" />}>
           <CreateAgentContent />
         </Suspense>
       </AgentPageWrapper>

--- a/agentarea-webapp/src/app/(main)/agents/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/page.tsx
@@ -4,10 +4,11 @@ import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import Link from "next/link";
 import { Plus } from "lucide-react";
+import { AGENT_COLUMNS } from "@/app/(main)/agents/components/agentColumns";
 import AgentsContent from "@/app/(main)/agents/components/AgentsContent";
 import AgentsHeaderTabs from "@/app/(main)/agents/components/AgentsHeaderTabs";
+import AgentsSkeleton from "@/app/(main)/agents/components/AgentsSkeleton";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import { Button } from "@/components/ui/button";
 
@@ -37,6 +38,14 @@ export default async function AgentsBrowsePage({
       ? resolvedSearchParams.tab
       : cookieTab || "grid";
 
+  // Resolve table header labels here (the page has the translations); the
+  // skeleton stays a sync component so it never re-suspends as a fallback.
+  const skeletonColumns = AGENT_COLUMNS.map((column) => ({
+    header: t(column.labelKey),
+    cellClassName: column.cellClassName,
+    barClassName: column.barClassName,
+  }));
+
   return (
     <ContentBlock
       header={{
@@ -64,11 +73,7 @@ export default async function AgentsBrowsePage({
     >
       <Suspense
         key={`${searchQuery}-${tab}`}
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
+        fallback={<AgentsSkeleton viewMode={tab} columns={skeletonColumns} />}
       >
         <AgentsContent searchQuery={searchQuery} viewMode={tab} />
       </Suspense>

--- a/agentarea-webapp/src/app/(main)/budgets/components/BudgetsSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/budgets/components/BudgetsSkeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Mirrors BudgetsData: a SpendCard + a summary list on top, a cap panel below.
+export default function BudgetsSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-[980px] space-y-6" aria-hidden="true">
+      <div className="grid gap-x-10 gap-y-6 lg:grid-cols-5 lg:divide-x lg:divide-border/50">
+        <div className="lg:col-span-3 lg:pr-10">
+          <header className="flex items-baseline justify-between">
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-3 w-24" />
+          </header>
+          <div className="mt-2 flex items-baseline gap-3">
+            <Skeleton className="h-7 w-28" />
+            <Skeleton className="h-4 w-12 rounded-full" />
+          </div>
+          <Skeleton className="mt-3 h-24 w-full rounded" />
+        </div>
+
+        <section className="lg:col-span-2 lg:pl-10">
+          <Skeleton className="h-4 w-20" />
+          <dl className="mt-4 space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-baseline justify-between gap-4 border-b border-border/50 pb-3 last:border-0"
+              >
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+            ))}
+          </dl>
+        </section>
+      </div>
+
+      <div className="border-t border-border/50 pt-6">
+        <Skeleton className="h-28 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/budgets/page.tsx
+++ b/agentarea-webapp/src/app/(main)/budgets/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { BudgetsData } from "./components/BudgetsData";
+import BudgetsSkeleton from "./components/BudgetsSkeleton";
 
 export const metadata: Metadata = {
   title: "Budgets",
@@ -17,13 +17,7 @@ export default async function BudgetsPage() {
       }}
     >
       <div className="main-content">
-        <Suspense
-          fallback={
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          }
-        >
+        <Suspense fallback={<BudgetsSkeleton />}>
           <BudgetsData />
         </Suspense>
       </div>

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import Link from "next/link";
 import {
   AlertTriangle,
@@ -117,13 +124,21 @@ export default function CatalogGallery({
 }: CatalogGalleryProps) {
   // Catalog UI state lives in the URL (nuqs) so views are shareable/back-able.
   // `type` uses shallow:false so switching tabs re-runs the Server Component
-  // (explore/page.tsx) and re-fetches the first page server-side. Combined with
-  // `key={type}` on this component, every type view starts from fresh SSR data —
-  // there is no client fetch on mount and no stale-response race across types.
+  // (explore/page.tsx) and re-fetches the first page server-side — every type
+  // view starts from fresh SSR data, with no client fetch on mount and no
+  // stale-response race across types.
+  //
+  // The round-trip runs inside a transition: `isPending` lets us skeleton ONLY
+  // the content/facets while the persistent chrome (type tabs, search, view
+  // toggle, "Category" label) stays mounted. This component is NOT remounted on
+  // type change (no `key`) — instead an effect below re-seeds state from the new
+  // SSR props, so the chrome never flashes.
+  const [isPending, startTransition] = useTransition();
   const [type, setType] = useQueryState(
     "type",
     parseAsStringLiteral(TYPE_KEYS).withDefault(initialType).withOptions({
       shallow: false,
+      startTransition,
     })
   );
   // Seeded from the server-rendered first page (no initial client fetch / flash).
@@ -142,6 +157,20 @@ export default function CatalogGallery({
   );
   const [itemId, setItemId] = useQueryState("item", parseAsString);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Re-seed from fresh SSR data when the type's server round-trip lands. Because
+  // the component is no longer remounted on type change, this is what swaps in
+  // the new type's first page — while `isPending` skeletons the content. The
+  // ref guards the initial mount (already seeded via useState initializers).
+  const seededType = useRef(initialType);
+  useEffect(() => {
+    if (seededType.current === initialType) return;
+    seededType.current = initialType;
+    setEntries(initialEntries);
+    setOffset(initialEntries.length);
+    setHasMore(initialHasMore);
+    setError(initialError);
+  }, [initialType, initialEntries, initialHasMore, initialError]);
 
   const load = useCallback(
     async (t: CatalogType, off: number, append: boolean) => {
@@ -211,6 +240,10 @@ export default function CatalogGallery({
   // like browsing a marketplace rather than a full-page takeover.
   const active = itemId ? (entries.find((e) => e.id === itemId) ?? null) : null;
 
+  // "Busy" = first-page client load OR an in-flight type switch (SSR round-trip).
+  // Either way we skeleton the content/facets but keep the chrome mounted.
+  const busy = loading || isPending;
+
   return (
     <div className="space-y-4">
       {/* Type tabs — the primary axis */}
@@ -243,7 +276,7 @@ export default function CatalogGallery({
         {/* Facet sidebar — always reserved (fixed width) so the layout doesn't
             shift when categories arrive. Shows a skeleton while loading. */}
         <aside className="hidden w-52 shrink-0 lg:block">
-          {loading ? (
+          {busy ? (
             <FacetSkeleton />
           ) : categories.length > 0 ? (
             <FacetGroup
@@ -283,12 +316,12 @@ export default function CatalogGallery({
               {error}
             </div>
           )}
-          {loading && <GridSkeleton />}
-          {!loading && filtered.length === 0 && !error && (
+          {busy && <ContentSkeleton view={view} />}
+          {!busy && filtered.length === 0 && !error && (
             <EmptyState title="Nothing here" detail="Try another type, clear filters, or search." />
           )}
 
-          {!loading && filtered.length > 0 && (
+          {!busy && filtered.length > 0 && (
             <>
               {view === "grid" ? (
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
@@ -1109,12 +1142,59 @@ function SkillFacts({ entry }: { entry: CatalogEntry }) {
 
 // ── Misc ──
 
-function GridSkeleton() {
+// Content placeholder that matches the selected view — grid of card-shaped
+// skeletons or table rows — so switching type never shifts the layout.
+function ContentSkeleton({ view }: { view: ViewMode }) {
+  if (view === "table") return <CatalogTableSkeleton />;
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="h-48 animate-pulse rounded-lg border border-border/60 bg-muted/40" />
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <CatalogCardSkeleton key={i} />
       ))}
+    </div>
+  );
+}
+
+// Mirrors CatalogCard: h-24 logo header + padded title/description body.
+function CatalogCardSkeleton() {
+  return (
+    <div
+      className="flex flex-col overflow-hidden rounded-lg border border-border/60 bg-white dark:border-zinc-700/60 dark:bg-zinc-900"
+      aria-hidden="true"
+    >
+      <div className="flex h-24 items-center justify-center border-b border-border/40 bg-[radial-gradient(circle,theme(colors.zinc.200)_1px,transparent_1px)] [background-size:12px_12px] dark:bg-[radial-gradient(circle,theme(colors.zinc.800)_1px,transparent_1px)]">
+        <div className="h-10 w-10 animate-pulse rounded-lg bg-muted" />
+      </div>
+      <div className="flex flex-1 flex-col gap-1.5 p-4">
+        <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+        <div className="h-3 w-full animate-pulse rounded bg-muted/60" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-muted/60" />
+      </div>
+    </div>
+  );
+}
+
+// Mirrors CatalogTable rows: icon + title + (md) description.
+function CatalogTableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/60" aria-hidden="true">
+      <table className="w-full text-sm">
+        <tbody>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <tr key={i} className="border-b border-border/40 last:border-0">
+              <td className="w-10 py-2 pl-3 pr-0">
+                <div className="h-6 w-6 animate-pulse rounded bg-muted" />
+              </td>
+              <td className="py-2 pl-2 pr-3">
+                <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+              </td>
+              <td className="hidden py-2 pr-4 md:table-cell">
+                <div className="h-3 w-64 animate-pulse rounded bg-muted/60" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/connections/page.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/page.tsx
@@ -3,11 +3,13 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import { AddConnectionDropdown } from "../mcp-servers/components/AddConnectionDropdown";
 import MCPHeaderTabs from "../mcp-servers/components/MCPHeaderTabs";
 import MCPServersContent from "../mcp-servers/components/MCPServersContent";
+import MCPSkeleton, {
+  mcpSkeletonColumns,
+} from "../mcp-servers/components/MCPSkeleton";
 
 export const metadata: Metadata = {
   title: "Connections",
@@ -48,8 +50,12 @@ export default async function ConnectionsPage({
       <Suspense
         key={`${searchQuery}-${tab}`}
         fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
+          <div id="my-connections">
+            <MCPSkeleton
+              viewMode={tab}
+              columns={mcpSkeletonColumns(t)}
+              headerLabel={t("myConnections")}
+            />
           </div>
         }
       >

--- a/agentarea-webapp/src/app/(main)/dashboard/components/DashboardSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/dashboard/components/DashboardSkeleton.tsx
@@ -1,0 +1,111 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Section titles are static, so we keep them real and skeleton only the
+// right-aligned metadata + body — mirroring DashboardData's two-row layout.
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <header className="flex items-baseline justify-between">
+      <h3 className="text-[13px] font-medium text-foreground">{title}</h3>
+      <Skeleton className="h-3 w-20" />
+    </header>
+  );
+}
+
+function SpendSkeleton() {
+  return (
+    <section>
+      <SectionHeader title="Spend" />
+      <div className="mt-2 flex items-baseline gap-3">
+        <Skeleton className="h-7 w-28" />
+        <Skeleton className="h-4 w-12 rounded-full" />
+        <div className="ml-auto flex flex-col items-end gap-1">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      </div>
+      <Skeleton className="mt-3 h-24 w-full rounded" />
+    </section>
+  );
+}
+
+function ActivitySkeleton() {
+  return (
+    <section>
+      <SectionHeader title="Activity" />
+      <div className="mt-3 grid grid-cols-3 gap-6">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i}>
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="mt-1 h-6 w-12" />
+            <Skeleton className="mt-1.5 h-6 w-full" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AgentRowsSkeleton() {
+  return (
+    <section>
+      <SectionHeader title="Agents" />
+      <ul className="-mx-2 mt-2 divide-y divide-border/50">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <li key={i}>
+            <div className="flex items-center gap-3 px-2 py-2.5">
+              <Skeleton className="h-6 w-6 shrink-0 rounded-md" />
+              <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+              <div className="hidden shrink-0 gap-5 sm:flex">
+                <Skeleton className="h-6 w-8" />
+                <Skeleton className="h-6 w-8" />
+                <Skeleton className="h-6 w-10" />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function BlockersSkeleton() {
+  return (
+    <section>
+      <SectionHeader title="Blockers" />
+      <div className="mt-3 space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full rounded" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function DashboardSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <div className="grid gap-x-10 gap-y-6 lg:grid-cols-5 lg:divide-x lg:divide-border/50">
+        <div className="lg:col-span-3 lg:pr-10">
+          <SpendSkeleton />
+        </div>
+        <div className="lg:col-span-2 lg:pl-10">
+          <ActivitySkeleton />
+        </div>
+      </div>
+
+      <div className="my-6 border-t border-border/50" />
+
+      <div className="grid gap-x-10 gap-y-6 lg:grid-cols-3 lg:divide-x lg:divide-border/50">
+        <div className="lg:col-span-2 lg:pr-10">
+          <AgentRowsSkeleton />
+        </div>
+        <div className="lg:col-span-1 lg:pl-10">
+          <BlockersSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/dashboard/page.tsx
+++ b/agentarea-webapp/src/app/(main)/dashboard/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { DashboardData } from "./components/DashboardData";
+import DashboardSkeleton from "./components/DashboardSkeleton";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -16,13 +16,7 @@ export default async function DashboardPage() {
       }}
     >
       <div className="main-content">
-        <Suspense
-          fallback={
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          }
-        >
+        <Suspense fallback={<DashboardSkeleton />}>
           <DashboardData />
         </Suspense>
       </div>

--- a/agentarea-webapp/src/app/(main)/explore/page.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/page.tsx
@@ -42,7 +42,6 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
       }}
     >
       <CatalogGallery
-        key={type}
         initialType={type}
         initialEntries={entries}
         initialHasMore={hasMore}

--- a/agentarea-webapp/src/app/(main)/files/page.tsx
+++ b/agentarea-webapp/src/app/(main)/files/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import ContentBlock from "@/components/ContentBlock";
 import { FileBrowser, type BrowsedFile } from "@/components/files/file-browser";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   listWorkspaceFilesAction,
   downloadWorkspaceFileAction,
@@ -45,27 +45,46 @@ export default function WorkspaceFilesPage() {
     return (data as any)?.events ?? [];
   }, []);
 
-  if (loading) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <LoadingSpinner />
-      </div>
-    );
-  }
-
   return (
     <ContentBlock
       header={{ breadcrumb: [{ label: "Files" }] }}
       className="p-0 overflow-hidden"
     >
-      <FileBrowser
-        files={files}
-        directories={directories}
-        fetchUrl={fetchUrl}
-        fetchHistory={fetchHistory}
-        emptyMessage="No files in this workspace yet."
-        className="h-full"
-      />
+      {loading ? (
+        <FileBrowserSkeleton />
+      ) : (
+        <FileBrowser
+          files={files}
+          directories={directories}
+          fetchUrl={fetchUrl}
+          fetchHistory={fetchHistory}
+          emptyMessage="No files in this workspace yet."
+          className="h-full"
+        />
+      )}
     </ContentBlock>
+  );
+}
+
+// Mirrors FileBrowser's two-panel layout: a file-tree column + an empty editor.
+function FileBrowserSkeleton() {
+  return (
+    <div className="flex h-full" aria-hidden="true">
+      <div className="w-[28%] shrink-0 space-y-1.5 border-r border-border p-3">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-2"
+            style={{ paddingLeft: `${(i % 3) * 14}px` }}
+          >
+            <Skeleton className="h-3.5 w-3.5 shrink-0 rounded-sm" />
+            <Skeleton className="h-3.5" style={{ width: `${50 + ((i * 13) % 40)}%` }} />
+          </div>
+        ))}
+      </div>
+      <div className="flex-1 p-4">
+        <Skeleton className="h-5 w-48" />
+      </div>
+    </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/inbox/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/inbox/loading.tsx
@@ -1,0 +1,39 @@
+import ContentBlock from "@/components/ContentBlock/ContentBlock";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Shown while the inbox page fetches on the server. Keeps the real "Inbox"
+// breadcrumb; the toolbar counts and task list are skeletoned (they need data).
+export default function InboxLoading() {
+  return (
+    <ContentBlock
+      header={{ breadcrumb: [{ label: "Inbox" }] }}
+      subheader={
+        <div className="flex items-center gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-20 rounded-md" />
+          ))}
+        </div>
+      }
+      className="flex min-h-0 flex-1 flex-col overflow-hidden p-0"
+    >
+      <div className="min-h-0 flex-1 overflow-hidden" aria-hidden="true">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-start gap-3 border-b border-zinc-200 px-4 py-2.5 dark:border-zinc-700"
+          >
+            <Skeleton className="mt-1 h-4 w-4 shrink-0 rounded-full" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <Skeleton className="h-4 w-2/3" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+            <Skeleton className="h-3 w-[62px] shrink-0" />
+          </div>
+        ))}
+      </div>
+    </ContentBlock>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/mcp-servers/add-docker-server/page.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/add-docker-server/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import AddDockerServerForm from "./AddDockerServerForm";
 import AddDockerServerHeaderControls from "./AddDockerServerHeaderControls";
 
@@ -23,13 +23,7 @@ export default async function AddMCPServerPage() {
         controls: <AddDockerServerHeaderControls />,
       }}
     >
-        <Suspense
-          fallback={
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          }
-        >
+        <Suspense fallback={<FormSkeleton />}>
           <AddDockerServerForm />
         </Suspense>
     </ContentBlock>

--- a/agentarea-webapp/src/app/(main)/mcp-servers/add/page.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/add/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import { AddMCPServerForm } from "./form";
 import AddMCPServerHeaderControls from "./header-controls";
 
@@ -23,13 +23,7 @@ export default async function AddMCPServerPage() {
         controls: <AddMCPServerHeaderControls />,
       }}
     >
-      <Suspense
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+      <Suspense fallback={<FormSkeleton />}>
         <AddMCPServerForm />
       </Suspense>
     </ContentBlock>

--- a/agentarea-webapp/src/app/(main)/mcp-servers/components/MCPServersContent.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/components/MCPServersContent.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import EmptyState from "@/components/EmptyState";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { listMCPServerInstances, listMCPServers, listOpenAPIConnections } from "@/lib/api";
+import MCPSkeleton, { mcpSkeletonColumns } from "./MCPSkeleton";
 import { MyMCPsSection } from "./MyMCPsSection";
 import { MCPInstance, MCPServer, OpenAPIConnection } from "../types";
 
@@ -38,14 +38,11 @@ export default async function MCPServersContent({
     <div id="my-connections">
       <Suspense
         fallback={
-          <div className="py-1">
-            <h4 className="mb-3 text-xs uppercase text-muted-foreground/80">
-              {t("myConnections")}
-            </h4>
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          </div>
+          <MCPSkeleton
+            viewMode={viewMode}
+            columns={mcpSkeletonColumns(t)}
+            headerLabel={t("myConnections")}
+          />
         }
       >
         <MyConnectionsSectionServer

--- a/agentarea-webapp/src/app/(main)/mcp-servers/components/MCPSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/components/MCPSkeleton.tsx
@@ -3,9 +3,7 @@ import {
   LinkedCardSkeleton,
   type SkeletonColumn,
 } from "@/components/Skeleton";
-
-const GRID_CLASS =
-  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 
 // MCPInstanceCard / OpenAPIConnectionCard: icon + status/type subtitle, no body.
 function MCPCardSkeleton() {
@@ -45,7 +43,7 @@ export default function MCPSkeleton({
         viewMode={viewMode}
         columns={columns}
         rows={8}
-        gridClassName={GRID_CLASS}
+        gridClassName={CARD_GRID_DENSE}
         count={10}
         Card={MCPCardSkeleton}
       />

--- a/agentarea-webapp/src/app/(main)/mcp-servers/components/MCPSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/components/MCPSkeleton.tsx
@@ -1,0 +1,54 @@
+import {
+  CollectionSkeleton,
+  LinkedCardSkeleton,
+  type SkeletonColumn,
+} from "@/components/Skeleton";
+
+const GRID_CLASS =
+  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+
+// MCPInstanceCard / OpenAPIConnectionCard: icon + status/type subtitle, no body.
+function MCPCardSkeleton() {
+  return <LinkedCardSkeleton icon subtitle />;
+}
+
+/** Skeleton columns matching the unified connections table (Type + 5 cols). */
+export function mcpSkeletonColumns(t: (key: string) => string): SkeletonColumn[] {
+  return [
+    { header: "Type", barClassName: "h-5 w-16 rounded-full" },
+    { header: t("table.name"), barClassName: "h-4 w-40" },
+    { header: t("table.description"), barClassName: "h-3 w-48" },
+    { header: t("table.endpoint"), barClassName: "h-3 w-32" },
+    { header: "Tools", barClassName: "h-4 w-8" },
+    { header: t("table.status"), barClassName: "h-5 w-20 rounded-full" },
+  ];
+}
+
+interface MCPSkeletonProps {
+  viewMode?: string;
+  columns: SkeletonColumn[];
+  /** "My connections" section heading — kept visible while content loads. */
+  headerLabel: string;
+}
+
+export default function MCPSkeleton({
+  viewMode,
+  columns,
+  headerLabel,
+}: MCPSkeletonProps) {
+  return (
+    <div className="py-1">
+      <h4 className="mb-3 text-xs uppercase text-muted-foreground/80">
+        {headerLabel}
+      </h4>
+      <CollectionSkeleton
+        viewMode={viewMode}
+        columns={columns}
+        rows={8}
+        gridClassName={GRID_CLASS}
+        count={10}
+        Card={MCPCardSkeleton}
+      />
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/mcp-servers/components/MyMCPsSection.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/components/MyMCPsSection.tsx
@@ -8,6 +8,7 @@ import EmptyState from "@/components/EmptyState";
 import Table from "@/components/Table/Table";
 import { Badge } from "@/components/ui/badge";
 import { StatusIndicator } from "@/components/ui/status-indicator";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 import {
   getMcpHealthStatusPresentation,
   getOpenApiConnectionDisplayStatus,
@@ -372,7 +373,7 @@ export function MyMCPsSection({
 
   // Render grid view (default)
   return (
-    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+    <div className={CARD_GRID_DENSE}>
       {mcpInstances.map((instance) => {
         const serverSpec = mcpServers.find(
           (server) => server.id === instance.server_spec_id

--- a/agentarea-webapp/src/app/(main)/mcp-servers/openapi/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/openapi/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Pencil, RefreshCw, Trash2 } from "lucide-react";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { DetailSkeleton } from "@/components/Skeleton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { StatusIndicator } from "@/components/ui/status-indicator";
@@ -144,11 +144,7 @@ export default function OpenAPIConnectionDetailPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex h-32 items-center justify-center">
-        <LoadingSpinner />
-      </div>
-    );
+    return <DetailSkeleton className="p-6" />;
   }
 
   if (error && !connection) {

--- a/agentarea-webapp/src/app/(main)/mcp-servers/page.tsx
+++ b/agentarea-webapp/src/app/(main)/mcp-servers/page.tsx
@@ -3,10 +3,10 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import MCPHeaderTabs from "./components/MCPHeaderTabs";
 import MCPServersContent from "./components/MCPServersContent";
+import MCPSkeleton, { mcpSkeletonColumns } from "./components/MCPSkeleton";
 import { AddConnectionDropdown } from "./components/AddConnectionDropdown";
 
 export const metadata: Metadata = {
@@ -49,8 +49,12 @@ export default async function MCPServersPage({
       <Suspense
         key={`${searchQuery}-${tab}`}
         fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
+          <div id="my-connections">
+            <MCPSkeleton
+              viewMode={tab}
+              columns={mcpSkeletonColumns(t)}
+              headerLabel={t("myConnections")}
+            />
           </div>
         }
       >

--- a/agentarea-webapp/src/app/(main)/members/MembersData.tsx
+++ b/agentarea-webapp/src/app/(main)/members/MembersData.tsx
@@ -1,0 +1,75 @@
+import {
+  listWorkspaceInvitations,
+  listWorkspaceMembers,
+  type WorkspaceInvitation,
+  type WorkspaceMember,
+} from "@/lib/api";
+import { getAuthContext } from "@/lib/getAuthContext";
+import MembersClient from "./MembersClient";
+
+function ensureCurrentUserMember(
+  members: WorkspaceMember[],
+  currentUser: {
+    workspaceId: string | null;
+    userId: string | null;
+    email: string | null;
+    name: string | null;
+    username: string | null;
+  }
+): WorkspaceMember[] {
+  if (!currentUser.workspaceId || !currentUser.userId) return members;
+  if (members.some((member) => member.user_id === currentUser.userId)) {
+    return members;
+  }
+
+  return [
+    {
+      id: currentUser.userId,
+      workspace_id: currentUser.workspaceId,
+      user_id: currentUser.userId,
+      email: currentUser.email,
+      display_name:
+        currentUser.name || currentUser.email || currentUser.username || null,
+      joined_at: new Date().toISOString(),
+      invitation_id: null,
+    },
+    ...members,
+  ];
+}
+
+// The data-fetching half of the members page, isolated so the page can wrap it
+// in <Suspense> and show MembersSkeleton while it loads.
+export default async function MembersData() {
+  const { workspaceId, userId, email, name, username } = await getAuthContext();
+
+  let members: WorkspaceMember[] = [];
+  let invitations: WorkspaceInvitation[] = [];
+
+  if (workspaceId) {
+    const [membersRes, invitationsRes] = await Promise.all([
+      listWorkspaceMembers(workspaceId),
+      listWorkspaceInvitations(workspaceId),
+    ]);
+    members = membersRes.data ?? [];
+    invitations = invitationsRes.data ?? [];
+  }
+
+  members = ensureCurrentUserMember(members, {
+    workspaceId,
+    userId,
+    email,
+    name,
+    username,
+  });
+
+  return (
+    <MembersClient
+      members={members}
+      invitations={invitations}
+      currentUserId={userId}
+      currentUserEmail={email}
+      currentUserName={name}
+      currentUsername={username}
+    />
+  );
+}

--- a/agentarea-webapp/src/app/(main)/members/MembersSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/members/MembersSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// One section: a title/description header + a bordered table of placeholder rows.
+function SectionSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1.5">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3 w-64" />
+      </div>
+      <div className="overflow-hidden rounded-md border bg-white dark:bg-zinc-900">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between gap-4 border-b px-3 py-3 last:border-0"
+          >
+            <div className="flex min-w-0 flex-col gap-1.5">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-7 w-16 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function MembersSkeleton() {
+  return (
+    <div className="space-y-8" aria-hidden="true">
+      <SectionSkeleton rows={5} />
+      <SectionSkeleton rows={2} />
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/members/page.tsx
+++ b/agentarea-webapp/src/app/(main)/members/page.tsx
@@ -1,72 +1,16 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock";
-import {
-  listWorkspaceInvitations,
-  listWorkspaceMembers,
-  type WorkspaceInvitation,
-  type WorkspaceMember,
-} from "@/lib/api";
-import { getAuthContext } from "@/lib/getAuthContext";
-import MembersClient from "./MembersClient";
+import MembersData from "./MembersData";
+import MembersSkeleton from "./MembersSkeleton";
 
 export const metadata: Metadata = {
   title: "Members",
 };
 
-function ensureCurrentUserMember(
-  members: WorkspaceMember[],
-  currentUser: {
-    workspaceId: string | null;
-    userId: string | null;
-    email: string | null;
-    name: string | null;
-    username: string | null;
-  }
-): WorkspaceMember[] {
-  if (!currentUser.workspaceId || !currentUser.userId) return members;
-  if (members.some((member) => member.user_id === currentUser.userId)) {
-    return members;
-  }
-
-  return [
-    {
-      id: currentUser.userId,
-      workspace_id: currentUser.workspaceId,
-      user_id: currentUser.userId,
-      email: currentUser.email,
-      display_name:
-        currentUser.name || currentUser.email || currentUser.username || null,
-      joined_at: new Date().toISOString(),
-      invitation_id: null,
-    },
-    ...members,
-  ];
-}
-
 export default async function MembersPage() {
   const t = await getTranslations("MembersPage");
-  const { workspaceId, userId, email, name, username } = await getAuthContext();
-
-  let members: WorkspaceMember[] = [];
-  let invitations: WorkspaceInvitation[] = [];
-
-  if (workspaceId) {
-    const [membersRes, invitationsRes] = await Promise.all([
-      listWorkspaceMembers(workspaceId),
-      listWorkspaceInvitations(workspaceId),
-    ]);
-    members = membersRes.data ?? [];
-    invitations = invitationsRes.data ?? [];
-  }
-
-  members = ensureCurrentUserMember(members, {
-    workspaceId,
-    userId,
-    email,
-    name,
-    username,
-  });
 
   return (
     <ContentBlock
@@ -76,14 +20,9 @@ export default async function MembersPage() {
       }}
     >
       <div className="main-content">
-        <MembersClient
-          members={members}
-          invitations={invitations}
-          currentUserId={userId}
-          currentUserEmail={email}
-          currentUserName={name}
-          currentUsername={username}
-        />
+        <Suspense fallback={<MembersSkeleton />}>
+          <MembersData />
+        </Suspense>
       </div>
     </ContentBlock>
   );

--- a/agentarea-webapp/src/app/(main)/network/NetworkClient.tsx
+++ b/agentarea-webapp/src/app/(main)/network/NetworkClient.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { RefreshCw } from "lucide-react";
 import { AnimatedTabs } from "@/components/ui/animated-tabs";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import NetworkLegend from "./components/NetworkLegend";
 import NetworkMetricsPanel from "./components/NetworkMetricsPanel";
 import NodeDetailDrawer from "./components/NodeDetailDrawer";
@@ -74,11 +75,7 @@ export default function NetworkClient() {
   };
 
   if (loading && !topology) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <RefreshCw className="h-5 w-5 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <NetworkGraphSkeleton />;
   }
 
   if (!topology || topology.nodes.length === 0) {
@@ -133,6 +130,33 @@ export default function NetworkClient() {
           onClose={() => handleSelect(null)}
         />
       )}
+    </div>
+  );
+}
+
+// Placeholder for the topology canvas — scattered node bubbles while the graph
+// data loads. The header tabs stay mounted above (page subheader).
+function NetworkGraphSkeleton() {
+  const nodes = [
+    { top: "30%", left: "22%" },
+    { top: "18%", left: "55%" },
+    { top: "52%", left: "38%" },
+    { top: "42%", left: "72%" },
+    { top: "72%", left: "58%" },
+    { top: "62%", left: "20%" },
+  ];
+  return (
+    <div className="relative h-full w-full" aria-hidden="true">
+      {nodes.map((n, i) => (
+        <div
+          key={i}
+          className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2"
+          style={{ top: n.top, left: n.left }}
+        >
+          <Skeleton className="h-12 w-12 rounded-full" />
+          <Skeleton className="h-2.5 w-14" />
+        </div>
+      ))}
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesSkeleton.tsx
@@ -1,0 +1,35 @@
+import { TableSkeleton } from "@/components/Skeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Matches PoliciesList: Policy · Value · Category · Effect · Status.
+const COLUMNS = [
+  { header: "Policy", barClassName: "h-4 w-40" },
+  { header: "Value", barClassName: "h-4 w-24" },
+  { header: "Category", barClassName: "h-4 w-20" },
+  { header: "Effect", barClassName: "h-4 w-16" },
+  { header: "Status", barClassName: "h-5 w-20 rounded-full" },
+];
+
+// The Access view is a query-builder + interactive graph; approximate it with a
+// narrow control column and a large canvas block rather than a faithful graph.
+function AccessSkeleton() {
+  return (
+    <div className="flex gap-6">
+      <div className="hidden w-64 shrink-0 flex-col gap-3 lg:flex">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-[60vh] flex-1 rounded-lg" />
+    </div>
+  );
+}
+
+interface PoliciesSkeletonProps {
+  view: "access" | "policies";
+}
+
+export default function PoliciesSkeleton({ view }: PoliciesSkeletonProps) {
+  if (view === "access") return <AccessSkeleton />;
+  return <TableSkeleton columns={COLUMNS} rows={8} />;
+}

--- a/agentarea-webapp/src/app/(main)/policies/page.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import AccessControlData from "./components/access/AccessControlData";
 import AccessControlHeaderControls from "./components/access/AccessControlHeaderControls";
 import { PoliciesData } from "./components/PoliciesData";
 import PoliciesHeaderControls from "./components/PoliciesHeaderControls";
+import PoliciesSkeleton from "./components/PoliciesSkeleton";
 import { PoliciesViewTabs } from "./components/PoliciesViewTabs";
 
 export const metadata: Metadata = {
@@ -34,13 +34,7 @@ export default async function PoliciesPage({
       subheader={<PoliciesViewTabs current={view} />}
     >
       <div className="main-content">
-        <Suspense
-          fallback={
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          }
-        >
+        <Suspense fallback={<PoliciesSkeleton view={view} />}>
           {view === "access" ? <AccessControlData /> : <PoliciesData />}
         </Suspense>
       </div>

--- a/agentarea-webapp/src/app/(main)/projects/[id]/files/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/files/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { Upload, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/hooks/use-toast";
 import { FileBrowser, type BrowsedFile } from "@/components/files/file-browser";
 import {
@@ -90,8 +90,22 @@ export default function ProjectFilesPage() {
 
   if (loading) {
     return (
-      <div className="flex h-64 items-center justify-center">
-        <LoadingSpinner />
+      <div className="flex h-[calc(100vh-8rem)] flex-col" aria-hidden="true">
+        <div className="flex items-center justify-between border-b px-4 py-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-7 w-28 rounded-md" />
+        </div>
+        <div className="flex-1 space-y-2 p-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Skeleton className="h-4 w-4 rounded-sm" />
+              <Skeleton
+                className="h-4"
+                style={{ width: `${40 + ((i * 11) % 40)}%` }}
+              />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/agentarea-webapp/src/app/(main)/projects/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { DetailSkeleton } from "@/components/Skeleton";
 import { AssociationSection } from "./components/AssociationSection";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -56,11 +56,7 @@ export default function ProjectOverviewPage() {
   }, [projectId]);
 
   if (loading) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <LoadingSpinner />
-      </div>
-    );
+    return <DetailSkeleton />;
   }
 
   if (!project) return null;

--- a/agentarea-webapp/src/app/(main)/projects/[id]/settings/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/settings/page.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import FormLabel from "@/components/FormLabel/FormLabel";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { FormSkeleton } from "@/components/Skeleton";
 import { useToast } from "@/hooks/use-toast";
 import { getProjectAction, updateProjectAction } from "@/lib/server-actions";
 
@@ -71,11 +71,7 @@ export default function ProjectSettingsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <LoadingSpinner />
-      </div>
-    );
+    return <FormSkeleton className="p-6 lg:max-w-xl" fields={3} />;
   }
 
   return (

--- a/agentarea-webapp/src/app/(main)/projects/components/ProjectsSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/components/ProjectsSkeleton.tsx
@@ -1,0 +1,46 @@
+import { CardGridSkeleton } from "@/components/Skeleton";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+const GRID_CLASS =
+  "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 p-4";
+
+// Mirrors ProjectCard: title + 2-line description, bordered footer with 3 stat
+// chips and the hover-link arrow.
+function ProjectCardSkeleton() {
+  return (
+    <Card
+      className={cn(
+        "relative flex h-full flex-col justify-between overflow-hidden p-0",
+        "border border-zinc-200 dark:border-zinc-800",
+        "bg-white dark:bg-zinc-900"
+      )}
+      aria-hidden="true"
+    >
+      <div className="relative z-10 flex h-full flex-col justify-between">
+        <div className="flex flex-col gap-2 px-[16px] py-[16px] md:px-[20px] lg:px-[24px]">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-2/3" />
+        </div>
+        <div className="border-t border-zinc-200/60 py-[10px] pl-[16px] pr-[8px] md:pl-[20px] md:pr-[10px] lg:pl-[24px] lg:pr-[10px] dark:border-zinc-700/60">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-3.5 w-8" />
+              <Skeleton className="h-3.5 w-8" />
+              <Skeleton className="h-3.5 w-8" />
+            </div>
+            <Skeleton className="h-4 w-4 rounded-sm" />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export default function ProjectsSkeleton() {
+  return (
+    <CardGridSkeleton count={8} className={GRID_CLASS} Card={ProjectCardSkeleton} />
+  );
+}

--- a/agentarea-webapp/src/app/(main)/projects/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/page.tsx
@@ -3,10 +3,10 @@ import { Suspense } from "react";
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import { Button } from "@/components/ui/button";
 import ProjectsContent from "./components/ProjectsContent";
+import ProjectsSkeleton from "./components/ProjectsSkeleton";
 
 export const metadata: Metadata = {
   title: "Projects",
@@ -41,14 +41,7 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
         <SearchInput urlParamName="search" urlPath="/projects" />
       }
     >
-      <Suspense
-        key={searchQuery}
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+      <Suspense key={searchQuery} fallback={<ProjectsSkeleton />}>
         <ProjectsContent searchQuery={searchQuery} />
       </Suspense>
     </ContentBlock>

--- a/agentarea-webapp/src/app/(main)/secrets/components/SecretsSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/secrets/components/SecretsSkeleton.tsx
@@ -1,0 +1,17 @@
+import { TableSkeleton } from "@/components/Skeleton";
+
+// Matches SecretsTable: Connection name · Auth type · Status · Created.
+const COLUMNS = [
+  { header: "Connection name", barClassName: "h-4 w-40" },
+  { header: "Auth type", barClassName: "h-4 w-20" },
+  { header: "Status", barClassName: "h-5 w-20 rounded-full" },
+  { header: "Created", barClassName: "h-4 w-24" },
+];
+
+export default function SecretsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <TableSkeleton columns={COLUMNS} rows={8} />
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/secrets/page.tsx
+++ b/agentarea-webapp/src/app/(main)/secrets/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { SecretsData } from "./components/SecretsData";
+import SecretsSkeleton from "./components/SecretsSkeleton";
 
 export const metadata: Metadata = {
   title: "Secrets",
@@ -16,13 +16,7 @@ export default async function SecretsPage() {
       }}
     >
       <div className="main-content">
-        <Suspense
-          fallback={
-            <div className="flex h-32 items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          }
-        >
+        <Suspense fallback={<SecretsSkeleton />}>
           <SecretsData />
         </Suspense>
       </div>

--- a/agentarea-webapp/src/app/(main)/settings/audit/page.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/audit/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { TableSkeleton } from "@/components/Skeleton";
 import AuditLogContent from "./AuditLogContent";
 
 export const metadata: Metadata = {
@@ -24,9 +24,17 @@ export default async function AuditLogPage() {
     >
       <Suspense
         fallback={
-          <div className="flex h-64 items-center justify-center">
-            <LoadingSpinner />
-          </div>
+          <TableSkeleton
+            rows={10}
+            columns={[
+              { header: "", barClassName: "h-4 w-4" },
+              { header: t("table.action"), barClassName: "h-4 w-28" },
+              { header: t("table.resource"), barClassName: "h-4 w-32" },
+              { header: t("table.actor"), barClassName: "h-4 w-24" },
+              { header: t("table.ip"), barClassName: "h-4 w-20" },
+              { header: t("table.when"), barClassName: "h-4 w-24" },
+            ]}
+          />
         }
       >
         <AuditLogContent />

--- a/agentarea-webapp/src/app/(main)/settings/billing/BillingSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/billing/BillingSkeleton.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Approximates BillingClient: a subscription summary card + a usage list.
+export default function BillingSkeleton() {
+  return (
+    <div className="space-y-6" aria-hidden="true">
+      <Skeleton className="h-32 w-full rounded-lg" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-32" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/settings/billing/page.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/billing/page.tsx
@@ -2,8 +2,8 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import BillingContent from "./BillingContent";
+import BillingSkeleton from "./BillingSkeleton";
 
 export const metadata: Metadata = {
   title: "Billing",
@@ -23,13 +23,7 @@ export default async function BillingPage() {
         description: t("description"),
       }}
     >
-      <Suspense
-        fallback={
-          <div className="flex h-64 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
-      >
+      <Suspense fallback={<BillingSkeleton />}>
         <BillingContent />
       </Suspense>
     </ContentBlock>

--- a/agentarea-webapp/src/app/(main)/skills/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/[id]/page.tsx
@@ -18,6 +18,7 @@ import { Streamdown } from "streamdown";
 import ContentBlock from "@/components/ContentBlock";
 import DeleteButton from "@/components/DeleteButton";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { DetailSkeleton } from "@/components/Skeleton";
 import SkillPanel from "@/components/SkillPanel/SkillPanel";
 import Section from "@/components/TaskInfoPanel/components/Section";
 import TaskInfoPanelDock from "@/components/TaskInfoPanel/TaskInfoPanelDock";
@@ -350,9 +351,7 @@ export default function SkillDetailPage() {
           ],
         }}
       >
-        <div className="flex h-64 items-center justify-center">
-          <LoadingSpinner />
-        </div>
+        <DetailSkeleton />
       </ContentBlock>
     );
   }

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsContentSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsContentSkeleton.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Mirrors SkillsCard: tile + name, two-line description, source/scope footer.
+function SkillCardSkeleton() {
+  return (
+    <div className="rounded-[10px] border border-zinc-200 bg-background p-3.5 dark:border-zinc-800">
+      <div className="mb-[9px] flex items-center gap-[9px]">
+        <Skeleton className="h-[30px] w-[30px] rounded-[8px]" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+      <div className="mb-3 space-y-1.5">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-4/5" />
+      </div>
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-[22px] w-20 rounded-full" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  );
+}
+
+// Mirrors SkillRow (InteractiveListRow): tile + name + description + badges.
+function SkillRowSkeleton() {
+  return (
+    <div className="flex items-center gap-3 border-b border-zinc-200 px-4 py-2.5 dark:border-zinc-700">
+      <Skeleton className="h-[22px] w-[22px] shrink-0 rounded-[6px]" />
+      <Skeleton className="h-3.5 w-40 shrink-0" />
+      <Skeleton className="h-3 flex-1" />
+      <Skeleton className="hidden h-[22px] w-20 shrink-0 rounded-full sm:block" />
+      <Skeleton className="hidden h-3 w-12 shrink-0 sm:block" />
+    </div>
+  );
+}
+
+export default function SkillsContentSkeleton({ view }: { view: "list" | "grid" }) {
+  if (view === "grid") {
+    return (
+      <div
+        className="grid gap-3 p-4"
+        style={{ gridTemplateColumns: "repeat(auto-fill, minmax(264px, 1fr))" }}
+        aria-hidden="true"
+      >
+        {Array.from({ length: 12 }).map((_, i) => (
+          <SkillCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div aria-hidden="true">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <SkillRowSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/skills/components/SkillsView.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/SkillsView.tsx
@@ -18,7 +18,6 @@ import {
 import CatalogSuggestions from "@/components/CatalogSuggestions";
 import EmptyState from "@/components/EmptyState";
 import HeaderTabs from "@/components/HeaderTabs";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import {
   Popover,
   PopoverContent,
@@ -38,6 +37,7 @@ import { setCookie } from "@/utils/cookies";
 import { getValidTimestamp } from "@/utils/dateUtils";
 import SkillRow from "./SkillRow";
 import SkillsCard from "./SkillsCard";
+import SkillsContentSkeleton from "./SkillsContentSkeleton";
 import {
   SCOPE_META,
   SCOPE_ORDER,
@@ -438,9 +438,7 @@ export default function SkillsView({ initial }: { initial: InitialState }) {
       {/* ---------------- body ---------------- */}
       <div className="min-h-0 flex-1 overflow-auto">
         {isLoading ? (
-          <div className="flex h-64 items-center justify-center">
-            <LoadingSpinner />
-          </div>
+          <SkillsContentSkeleton view={view} />
         ) : error ? (
           <div className="flex h-64 items-center justify-center text-destructive">
             {t("error.loadSkills")}

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/artifacts/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/artifacts/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Download, FileText } from "lucide-react";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useTaskContext } from "../TaskContext";
 
 export default function TaskArtifactsPage() {
@@ -10,8 +10,10 @@ export default function TaskArtifactsPage() {
 
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <LoadingSpinner />
+      <div className="space-y-2 p-4" aria-hidden="true">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-16 w-full rounded-lg" />
+        ))}
       </div>
     );
   }

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/events/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/events/page.tsx
@@ -11,7 +11,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useTaskEvents } from "@/hooks/useTaskEvents";
 import type { DisplayEvent, EventLevel } from "@/types/events";
 import { useTaskContext } from "../TaskContext";
@@ -111,8 +111,17 @@ export default function TaskEventsPage() {
 
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <LoadingSpinner />
+      <div className="main-content space-y-2 p-4" aria-hidden="true">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 border-b border-zinc-100 py-2.5 dark:border-zinc-800"
+          >
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        ))}
       </div>
     );
   }

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/page.tsx
@@ -11,6 +11,7 @@ import type { MessageComponentType } from "@/components/Chat/types";
 import { processEventsToMessages } from "@/components/Chat/utils/eventProcessor";
 import EmptyState from "@/components/EmptyState";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import TaskInfoPanel from "@/components/TaskInfoPanel/TaskInfoPanel";
 import TaskInfoPanelDock from "@/components/TaskInfoPanel/TaskInfoPanelDock";
 import { buildActivitySummary } from "@/components/TaskInfoPanel/buildActivitySummary";
@@ -234,11 +235,20 @@ export default function TaskDetailsPage() {
     setChatInput(e.target.value);
   };
 
-  // Show loading state
+  // Show loading state — chat-shaped placeholder (alternating message bubbles).
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <LoadingSpinner />
+      <div className="mx-auto w-full max-w-3xl space-y-4 p-4" aria-hidden="true">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className={`flex ${i % 2 ? "justify-end" : "justify-start"}`}
+          >
+            <Skeleton
+              className={`h-16 rounded-lg ${i % 2 ? "w-1/2" : "w-2/3"}`}
+            />
+          </div>
+        ))}
       </div>
     );
   }

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/task-logs/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/task-logs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FileText } from "lucide-react";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useTaskContext } from "../TaskContext";
 
 export default function TaskLogsPage() {
@@ -16,8 +16,14 @@ export default function TaskLogsPage() {
 
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <LoadingSpinner />
+      <div className="space-y-1.5 p-4" aria-hidden="true">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <Skeleton
+            key={i}
+            className="h-3"
+            style={{ width: `${60 + ((i * 7) % 35)}%` }}
+          />
+        ))}
       </div>
     );
   }

--- a/agentarea-webapp/src/app/(main)/tasks/components/TasksList.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/components/TasksList.tsx
@@ -7,6 +7,7 @@ import { AgentAvatar } from "@/components/AgentAvatar";
 import Table from "@/components/Table/Table";
 import { TaskItem } from "@/components/TaskItem";
 import { TaskWithAgent } from "@/lib/api";
+import { CARD_GRID_WIDE } from "@/lib/collectionGrids";
 import { getTaskStatusPresentation } from "@/lib/status";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 
@@ -141,7 +142,7 @@ export default function TasksList({
 
   // Render grid view (default)
   return (
-    <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+    <div className={CARD_GRID_WIDE}>
       {initialTasks.map((task) => (
         <TaskItem key={task.id} task={task} />
       ))}

--- a/agentarea-webapp/src/app/(main)/tasks/components/TasksSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/components/TasksSkeleton.tsx
@@ -3,9 +3,7 @@ import {
   LinkedCardSkeleton,
   type SkeletonColumn,
 } from "@/components/Skeleton";
-
-const GRID_CLASS =
-  "grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";
+import { CARD_GRID_WIDE } from "@/lib/collectionGrids";
 
 // TaskItem: status badge top-right, body = agent row + date/time row.
 function TaskCardSkeleton() {
@@ -23,7 +21,7 @@ export default function TasksSkeleton({ viewMode, columns }: TasksSkeletonProps)
       viewMode={viewMode}
       columns={columns}
       rows={8}
-      gridClassName={GRID_CLASS}
+      gridClassName={CARD_GRID_WIDE}
       count={10}
       Card={TaskCardSkeleton}
     />

--- a/agentarea-webapp/src/app/(main)/tasks/components/TasksSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/components/TasksSkeleton.tsx
@@ -1,0 +1,31 @@
+import {
+  CollectionSkeleton,
+  LinkedCardSkeleton,
+  type SkeletonColumn,
+} from "@/components/Skeleton";
+
+const GRID_CLASS =
+  "grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";
+
+// TaskItem: status badge top-right, body = agent row + date/time row.
+function TaskCardSkeleton() {
+  return <LinkedCardSkeleton topRight lines={2} />;
+}
+
+interface TasksSkeletonProps {
+  viewMode?: string;
+  columns: SkeletonColumn[];
+}
+
+export default function TasksSkeleton({ viewMode, columns }: TasksSkeletonProps) {
+  return (
+    <CollectionSkeleton
+      viewMode={viewMode}
+      columns={columns}
+      rows={8}
+      gridClassName={GRID_CLASS}
+      count={10}
+      Card={TaskCardSkeleton}
+    />
+  );
+}

--- a/agentarea-webapp/src/app/(main)/tasks/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/page.tsx
@@ -3,10 +3,10 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import { TasksData } from "./components/TasksData";
 import TasksHeaderTabs from "./components/TasksHeaderTabs";
+import TasksSkeleton from "./components/TasksSkeleton";
 
 export const metadata: Metadata = {
   title: "Tasks",
@@ -32,6 +32,14 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
       ? resolvedSearchParams.tab
       : cookieTab || "grid";
 
+  const skeletonColumns = [
+    { header: t("description"), barClassName: "h-4 w-48" },
+    { header: t("agent"), barClassName: "h-4 w-28" },
+    { header: t("statusLabel"), barClassName: "h-5 w-20 rounded-full" },
+    { header: t("cost"), barClassName: "h-4 w-12" },
+    { header: t("created"), barClassName: "h-8 w-24" },
+  ];
+
   return (
     <ContentBlock
       header={{
@@ -46,11 +54,7 @@ export default async function TasksPage({ searchParams }: TasksPageProps) {
     >
       <Suspense
         key={`${searchQuery}-${tab}`}
-        fallback={
-          <div className="flex h-32 items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        }
+        fallback={<TasksSkeleton viewMode={tab} columns={skeletonColumns} />}
       >
         <TasksData searchQuery={searchQuery} viewMode={tab} />
       </Suspense>

--- a/agentarea-webapp/src/app/(main)/triggers/[id]/executions/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/[id]/executions/loading.tsx
@@ -1,0 +1,20 @@
+import { TableSkeleton } from "@/components/Skeleton";
+
+// Matches ExecutionsTable: Execution ID · Status · Executed · Duration · Task · Error.
+export default function Loading() {
+  return (
+    <div className="p-6">
+      <TableSkeleton
+        rows={10}
+        columns={[
+          { header: "Execution ID", barClassName: "h-4 w-32" },
+          { header: "Status", barClassName: "h-5 w-20 rounded-full" },
+          { header: "Executed", barClassName: "h-4 w-24" },
+          { header: "Duration", barClassName: "h-4 w-16" },
+          { header: "Task", barClassName: "h-4 w-24" },
+          { header: "Error", barClassName: "h-4 w-28" },
+        ]}
+      />
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/triggers/[id]/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { DetailSkeleton } from "@/components/Skeleton";
+
+export default function Loading() {
+  return <DetailSkeleton />;
+}

--- a/agentarea-webapp/src/app/(main)/triggers/[id]/metrics/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/[id]/metrics/loading.tsx
@@ -1,0 +1,23 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Mirrors the 3 stat cards on the trigger metrics page.
+export default function Loading() {
+  return (
+    <div className="p-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3" aria-hidden="true">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-4 rounded-sm" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-7 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/triggers/components/TriggersList.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/components/TriggersList.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import EmptyState from "@/components/EmptyState";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 import TriggerCard from "./TriggerCard";
 import TriggersTable from "./TriggersTable";
 
@@ -45,7 +46,7 @@ export default function TriggersList({
   return (
     <>
       {viewMode === "grid" ? (
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        <div className={CARD_GRID_DENSE}>
           {triggers.map((trigger) => (
             <TriggerCard key={trigger.id} trigger={trigger} catalog={catalog} />
           ))}

--- a/agentarea-webapp/src/app/(main)/triggers/components/TriggersSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/components/TriggersSkeleton.tsx
@@ -1,0 +1,50 @@
+import { LinkedCardSkeleton } from "@/components/Skeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const GRID_CLASS =
+  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+
+// TriggerCard: icon + (type badge / status) subtitle + optional agent row.
+function TriggerCardSkeleton() {
+  return <LinkedCardSkeleton icon subtitle lines={1} />;
+}
+
+// Mirrors a TriggersTable row: icon · name · schedule · type · agent · next · status.
+function TriggersTableSkeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div className="-mx-4 -mt-5 border-t border-zinc-100 dark:border-zinc-800" aria-hidden="true">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-3 border-b border-zinc-100 px-4 py-2.5 dark:border-zinc-800"
+        >
+          <Skeleton className="h-7 w-7 shrink-0 rounded-md" />
+          <Skeleton className="h-4 flex-[1.7]" />
+          <Skeleton className="hidden h-3 flex-[1.4] md:block" />
+          <Skeleton className="hidden h-5 w-20 shrink-0 rounded-full sm:block" />
+          <div className="hidden flex-[1.2] items-center gap-2 md:flex">
+            <Skeleton className="h-5 w-5 shrink-0 rounded-md" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <Skeleton className="hidden h-3 w-[72px] shrink-0 lg:block" />
+          <Skeleton className="h-5 w-[92px] shrink-0 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface TriggersSkeletonProps {
+  viewMode?: "grid" | "table";
+}
+
+export default function TriggersSkeleton({ viewMode = "table" }: TriggersSkeletonProps) {
+  if (viewMode === "table") return <TriggersTableSkeleton />;
+  return (
+    <div className={GRID_CLASS} aria-hidden="true">
+      {Array.from({ length: 10 }).map((_, i) => (
+        <TriggerCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/triggers/components/TriggersSkeleton.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/components/TriggersSkeleton.tsx
@@ -1,8 +1,6 @@
 import { LinkedCardSkeleton } from "@/components/Skeleton";
 import { Skeleton } from "@/components/ui/skeleton";
-
-const GRID_CLASS =
-  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";
+import { CARD_GRID_DENSE } from "@/lib/collectionGrids";
 
 // TriggerCard: icon + (type badge / status) subtitle + optional agent row.
 function TriggerCardSkeleton() {
@@ -41,7 +39,7 @@ interface TriggersSkeletonProps {
 export default function TriggersSkeleton({ viewMode = "table" }: TriggersSkeletonProps) {
   if (viewMode === "table") return <TriggersTableSkeleton />;
   return (
-    <div className={GRID_CLASS} aria-hidden="true">
+    <div className={CARD_GRID_DENSE} aria-hidden="true">
       {Array.from({ length: 10 }).map((_, i) => (
         <TriggerCardSkeleton key={i} />
       ))}

--- a/agentarea-webapp/src/app/(main)/triggers/page.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/page.tsx
@@ -2,10 +2,10 @@ import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
 import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock";
-import { LoadingSpinner } from "@/components/LoadingSpinner";
 import SearchInput from "@/components/SearchInput";
 import TriggersContent from "./components/TriggersContent";
 import TriggersHeaderTabs from "./components/TriggersHeaderTabs";
+import TriggersSkeleton from "./components/TriggersSkeleton";
 import TriggersTypeFilterSection from "./components/TriggersTypeFilterSection";
 import CreateTriggerButton from "./components/CreateTriggerButton";
 
@@ -61,11 +61,10 @@ export default async function TriggersPage({
         </>
       }
     >
-      <Suspense key={`${viewMode}-${searchQuery}-${typeFilter}`} fallback={
-        <div className="flex h-64 items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }>
+      <Suspense
+        key={`${viewMode}-${searchQuery}-${typeFilter}`}
+        fallback={<TriggersSkeleton viewMode={viewMode} />}
+      >
         <TriggersContent
           viewMode={viewMode}
           searchQuery={searchQuery}

--- a/agentarea-webapp/src/app/(main)/workplace/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/workplace/loading.tsx
@@ -1,0 +1,29 @@
+import ContentBlock from "@/components/ContentBlock/ContentBlock";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Shown while the workplace page fetches agents/projects/policies on the server.
+// Keeps the "Workplace" header; the chat composer + suggestion chips are
+// skeletoned in the centered position WorkplaceChat occupies.
+export default function WorkplaceLoading() {
+  return (
+    <ContentBlock
+      header={{ breadcrumb: [{ label: "Workplace", href: "/workplace" }] }}
+      className="p-0"
+    >
+      <div className="relative h-full w-full overflow-hidden" aria-hidden="true">
+        <div className="absolute inset-0 bg-[url('/lines.png')] bg-[size:450px_450px] bg-center bg-repeat opacity-20 dark:bg-[url('/lines-dark.png')]" />
+        <div className="relative z-[1] flex h-full items-center justify-center p-4">
+          <div className="w-full max-w-2xl space-y-4">
+            <Skeleton className="mx-auto h-6 w-56" />
+            <Skeleton className="h-28 w-full rounded-xl" />
+            <div className="flex flex-wrap justify-center gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-32 rounded-full" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </ContentBlock>
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/CardGridSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/CardGridSkeleton.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+
+interface CardGridSkeletonProps {
+  /** How many placeholder cards to render. */
+  count?: number;
+  /**
+   * The exact grid classes the real list uses, so the placeholder grid has the
+   * same columns/gaps/breakpoints as the loaded content.
+   */
+  className?: string;
+  /** Per-domain card skeleton, rendered directly as a grid child. */
+  Card: React.ComponentType;
+}
+
+/**
+ * Loading placeholder for a card grid. Reuses the real grid classes and renders
+ * `count` copies of the supplied per-domain card skeleton.
+ */
+export default function CardGridSkeleton({
+  count = 10,
+  className,
+  Card,
+}: CardGridSkeletonProps) {
+  return (
+    <div className={cn(className)} aria-hidden="true">
+      {Array.from({ length: count }).map((_, index) => (
+        <Card key={index} />
+      ))}
+    </div>
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/CollectionSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/CollectionSkeleton.tsx
@@ -1,0 +1,40 @@
+import CardGridSkeleton from "./CardGridSkeleton";
+import TableSkeleton, { type SkeletonColumn } from "./TableSkeleton";
+
+interface CollectionSkeletonProps {
+  /**
+   * The currently selected view (`"grid"` | `"table"`). It is known server-side
+   * — read from the URL/cookie before the content suspends — so the placeholder
+   * matches the view the user will actually see.
+   */
+  viewMode?: string;
+  // --- table view ---
+  columns: SkeletonColumn[];
+  rows?: number;
+  // --- grid view ---
+  gridClassName: string;
+  count?: number;
+  Card: React.ComponentType;
+}
+
+/**
+ * Single entry point for list-page loading placeholders. Switches between a
+ * card-grid skeleton and a table skeleton based on `viewMode`, so the
+ * placeholder always matches the user's selected view.
+ */
+export default function CollectionSkeleton({
+  viewMode = "grid",
+  columns,
+  rows,
+  gridClassName,
+  count,
+  Card,
+}: CollectionSkeletonProps) {
+  if (viewMode === "table") {
+    return <TableSkeleton columns={columns} rows={rows} />;
+  }
+
+  return (
+    <CardGridSkeleton count={count} className={gridClassName} Card={Card} />
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/DetailSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/DetailSkeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface DetailSkeletonProps {
+  /** Number of info blocks in the two-column grid. */
+  blocks?: number;
+  className?: string;
+}
+
+/**
+ * Generic loading placeholder for detail/overview pages: an identity header
+ * (icon + title + subtitle) followed by a two-column grid of info blocks. Used
+ * as the content skeleton under a detail page's persistent header/tabs chrome.
+ */
+export default function DetailSkeleton({
+  blocks = 4,
+  className,
+}: DetailSkeletonProps) {
+  return (
+    <div className={cn("space-y-6", className)} aria-hidden="true">
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-lg" />
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {Array.from({ length: blocks }).map((_, i) => (
+          <div key={i} className="space-y-2 rounded-lg border border-border p-4">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/FormSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/FormSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface FormSkeletonProps {
+  /** Number of label + input field rows. */
+  fields?: number;
+  className?: string;
+}
+
+/**
+ * Loading placeholder for forms that fetch data before rendering (edit forms,
+ * create-from-spec). Mirrors a stack of "label + input" rows and a trailing
+ * action button — used in place of a spinner while the form's data loads.
+ */
+export default function FormSkeleton({
+  fields = 5,
+  className,
+}: FormSkeletonProps) {
+  return (
+    <div className={cn("max-w-2xl space-y-6", className)} aria-hidden="true">
+      {Array.from({ length: fields }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+      ))}
+      <div className="flex justify-end gap-2 pt-2">
+        <Skeleton className="h-9 w-24 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/LinkedCardSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/LinkedCardSkeleton.tsx
@@ -1,0 +1,76 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface LinkedCardSkeletonProps {
+  /** Show the leading 40px icon box (TriggerCard, MCPCard, ProviderConfigCard). */
+  icon?: boolean;
+  /** Show a subtitle row of small chips under the title (badge + status). */
+  subtitle?: boolean;
+  /** Show a top-right badge placeholder (TaskItem status). */
+  topRight?: boolean;
+  /** Number of body content lines rendered in the `mt-auto` area. */
+  lines?: number;
+  className?: string;
+}
+
+/**
+ * Loading placeholder for `LinkedCard`. Mirrors its padding, icon box, title /
+ * subtitle layout, body area, and the trailing hover-link arrow, so any grid of
+ * LinkedCards (tasks, triggers, connections, provider configs) keeps its shape
+ * while loading. Toggle the parts each card uses via props.
+ */
+export default function LinkedCardSkeleton({
+  icon = false,
+  subtitle = false,
+  topRight = false,
+  lines = 0,
+  className,
+}: LinkedCardSkeletonProps) {
+  return (
+    <Card
+      className={cn(
+        "group relative flex h-full cursor-default flex-col justify-between px-4 py-4",
+        "border border-zinc-200 dark:border-zinc-800",
+        "bg-white dark:bg-zinc-900",
+        className
+      )}
+      aria-hidden="true"
+    >
+      <div className="z-10 flex h-full flex-col">
+        <div className={cn("mb-2 flex gap-3", subtitle ? "items-start" : "items-center")}>
+          {icon && (
+            <Skeleton className="h-10 w-10 flex-shrink-0 rounded-lg" />
+          )}
+
+          <div className="min-w-0 flex-1">
+            <div className={cn("flex justify-between gap-3", subtitle ? "items-start" : "items-center")}>
+              <div className={cn("min-w-0 flex-1", subtitle && "pt-0.5")}>
+                <Skeleton className={cn("h-4 w-3/4", subtitle && "mb-2")} />
+                {subtitle && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Skeleton className="h-4 w-16 rounded-full" />
+                    <Skeleton className="h-4 w-12 rounded-full" />
+                  </div>
+                )}
+              </div>
+              {topRight && <Skeleton className="h-4 w-16 flex-shrink-0 rounded-full" />}
+            </div>
+          </div>
+        </div>
+
+        {lines > 0 && (
+          <div className="mt-auto flex flex-col gap-2 py-2">
+            {Array.from({ length: lines }).map((_, i) => (
+              <Skeleton key={i} className="h-3 w-2/5" />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="-mb-2 -mr-2 -mt-4 flex justify-end">
+        <Skeleton className="h-4 w-4 rounded-sm" />
+      </div>
+    </Card>
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/LinkedCardSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/LinkedCardSkeleton.tsx
@@ -30,7 +30,7 @@ export default function LinkedCardSkeleton({
   return (
     <Card
       className={cn(
-        "group relative flex h-full cursor-default flex-col justify-between px-4 py-4",
+        "relative flex h-full cursor-default flex-col justify-between px-4 py-4",
         "border border-zinc-200 dark:border-zinc-800",
         "bg-white dark:bg-zinc-900",
         className

--- a/agentarea-webapp/src/components/Skeleton/TableSkeleton.tsx
+++ b/agentarea-webapp/src/components/Skeleton/TableSkeleton.tsx
@@ -1,0 +1,90 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  TableBody,
+  TableCell,
+  Table as TableComponent,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+/**
+ * A column descriptor for the table skeleton. It mirrors the meaningful bits of
+ * the real `Table` column (header label + cell width) so the skeleton lines up
+ * with the actual table once data arrives. `render`/`accessor` are irrelevant
+ * here — only layout matters.
+ */
+export type SkeletonColumn = {
+  /** Real, static header label (no data needed) — keeps the header faithful. */
+  header?: React.ReactNode;
+  headerClassName?: string;
+  cellClassName?: string;
+  /** Width/shape of the shimmering bar inside each body cell. */
+  barClassName?: string;
+};
+
+interface TableSkeletonProps {
+  columns: SkeletonColumn[];
+  rows?: number;
+}
+
+// Same diagonal hatch the real `Table` header uses, so the two are visually
+// identical while loading.
+const HEADER_HATCH = `repeating-linear-gradient(
+  -45deg,
+  color-mix(in srgb, currentColor 4%, transparent),
+  color-mix(in srgb, currentColor 4%, transparent) 1px,
+  transparent 1px,
+  transparent 10px
+)`;
+
+/**
+ * Loading placeholder for the shared `Table` component. Renders the real
+ * (static) header row plus `rows` shimmering body rows that match the real
+ * table's padding/borders.
+ */
+export default function TableSkeleton({ columns, rows = 8 }: TableSkeletonProps) {
+  return (
+    <TableComponent>
+      <TableHeader
+        className="relative"
+        style={{ backgroundImage: HEADER_HATCH }}
+      >
+        <TableRow className="pointer-events-none hover:bg-transparent">
+          {columns.map((column, index) => (
+            <TableHead
+              key={index}
+              className={cn(
+                "h-auto py-[4px] text-[11px] font-medium uppercase text-zinc-400 first:pl-[20px] last:pr-[20px] dark:text-zinc-400",
+                column.headerClassName
+              )}
+            >
+              {column.header}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: rows }).map((_, rowIndex) => (
+          <TableRow
+            key={rowIndex}
+            className="border-b border-zinc-100 hover:bg-transparent dark:border-zinc-800"
+          >
+            {columns.map((column, colIndex) => (
+              <TableCell
+                key={colIndex}
+                className={cn(
+                  "py-[10px] first:pl-[20px] last:pr-[20px]",
+                  column.cellClassName
+                )}
+              >
+                <Skeleton className={cn("h-4 w-24", column.barClassName)} />
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </TableComponent>
+  );
+}

--- a/agentarea-webapp/src/components/Skeleton/index.ts
+++ b/agentarea-webapp/src/components/Skeleton/index.ts
@@ -1,0 +1,6 @@
+export { default as TableSkeleton, type SkeletonColumn } from "./TableSkeleton";
+export { default as CardGridSkeleton } from "./CardGridSkeleton";
+export { default as CollectionSkeleton } from "./CollectionSkeleton";
+export { default as LinkedCardSkeleton } from "./LinkedCardSkeleton";
+export { default as DetailSkeleton } from "./DetailSkeleton";
+export { default as FormSkeleton } from "./FormSkeleton";

--- a/agentarea-webapp/src/components/ui/model-badge.tsx
+++ b/agentarea-webapp/src/components/ui/model-badge.tsx
@@ -65,15 +65,19 @@ export default function ModelBadge({
       title={`Model: ${getModelName()}${providerName ? ` (${providerName})` : ""}`}
     >
       {renderIcon()}
-      <span
-        className={cn(
-          "font-medium text-gray-700",
-          isSm ? "text-[10px]" : "text-xs"
-        )}
-      >
-        {getModelName()}
-      </span>
-      {providerName && !isSm && (
+      {isLoading ? (
+        <Skeleton className={cn("rounded", isSm ? "h-2.5 w-12" : "h-3 w-16")} />
+      ) : (
+        <span
+          className={cn(
+            "font-medium text-gray-700",
+            isSm ? "text-[10px]" : "text-xs"
+          )}
+        >
+          {getModelName()}
+        </span>
+      )}
+      {providerName && !isLoading && !isSm && (
         <span className="text-xs text-gray-500">({providerName})</span>
       )}
     </div>

--- a/agentarea-webapp/src/lib/collectionGrids.ts
+++ b/agentarea-webapp/src/lib/collectionGrids.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared card-grid density classes for list pages. Both a page's real card grid
+ * and its loading skeleton import from here, so the two can never drift apart.
+ */
+
+// agents, tasks — 5 columns at 2xl, no `sm` breakpoint.
+export const CARD_GRID_WIDE =
+  "grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5";
+
+// triggers, connections (MCP), provider-configs — 5 columns at xl, denser `sm`.
+export const CARD_GRID_DENSE =
+  "grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5";


### PR DESCRIPTION
Replaces the inconsistent loading states across the app (frozen previous screen, ad‑hoc spinners, inline "Loading…" text) with a single, view‑aware skeleton system. While data loads, the page chrome (header, sub‑header, search, tabs, view toggle) stays instant and only the content area renders a skeleton that matches the real layout — and the selected view (cards/table), which is known server‑side.

<img width="1470" height="805" alt="Снимок экрана 2026-06-29 в 12 25 26" src="https://github.com/user-attachments/assets/73b02902-2714-4050-9ccb-608b1f55a286" />
<img width="1470" height="797" alt="Снимок экрана 2026-06-29 в 12 25 18" src="https://github.com/user-attachments/assets/c4e63750-98f0-4158-9d82-eed9c7a40ddb" />
