### PR TITLE
Connections page - restore saved view mde

### DIFF
--- a/agentarea-webapp/src/app/(main)/connections/page.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/page.tsx
@@ -21,7 +21,7 @@ export default async function ConnectionsPage({
   const t = await getTranslations("MCPServersPage");
   const resolvedSearchParams = await searchParams;
   const cookieStore = await cookies();
-  const cookieTab = cookieStore.get("tab_mcp-servers")?.value;
+  const cookieTab = cookieStore.get("tab_connections")?.value;
   const tab =
     typeof resolvedSearchParams.tab === "string"
       ? resolvedSearchParams.tab


### PR DESCRIPTION
The connections page saved the view toggle under `tab_connections` but read back `tab_mcp-servers` (leftover from being copied off the mcp-servers page), so a user's grid/table choice was lost on every return to the page. Fixed by reading the correct cookie key. 

Audited the six other pages with view toggles — all keys are consistent, this was the only mismatch.