### PR TITLE
Use components at explore

### DIFF
--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -1282,6 +1282,43 @@ function ContentSkeleton({ view }: { view: ViewMode }) {
   );
 }
 
+// Route-level skeleton for explore/loading.tsx. Mirrors the in-component `busy`
+// layout (facet rail + search + content grid) so a hard refresh — where the SSR
+// page is still awaiting its first fetch and React hasn't mounted the gallery
+// yet — shows the same chrome-preserving skeleton instead of the generic
+// full-screen spinner. Reads `type`/`view` from the URL so it matches the
+// destination view exactly.
+export function CatalogGallerySkeleton() {
+  const [type] = useQueryState(
+    "type",
+    parseAsStringLiteral(TYPE_KEYS).withDefault("bundles")
+  );
+  const [view] = useQueryState(
+    "view",
+    parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
+  );
+  const label = TYPES.find((t) => t.key === type)?.label.toLowerCase() ?? "";
+  return (
+    <div className="flex gap-6">
+      <aside className="hidden w-52 shrink-0 lg:block">
+        <FacetSkeleton />
+      </aside>
+      <div className="min-w-0 flex-1 space-y-4">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            disabled
+            placeholder={`Search ${label}…`}
+            aria-hidden
+            className="pl-9"
+          />
+        </div>
+        <ContentSkeleton view={view} />
+      </div>
+    </div>
+  );
+}
+
 // Mirrors CatalogCard: h-24 logo header + padded title/description body.
 function CatalogCardSkeleton() {
   return (

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -209,6 +209,10 @@ export default function CatalogGallery({
     parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
   );
   const [itemId, setItemId] = useQueryState("item", parseAsString);
+  // Deep-link fallback for ?item= that points outside the loaded page(s).
+  const [deepItem, setDeepItem] = useState<CatalogEntry | null>(null);
+  const [deepLoading, setDeepLoading] = useState(false);
+  const [deepError, setDeepError] = useState<string | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   const load = useCallback(
@@ -274,10 +278,45 @@ export default function CatalogGallery({
     return () => io.disconnect();
   }, [hasMore, more, loading, type, offset, load]);
 
-  // Selected item (from ?item=) resolved against what's loaded. When set, the
-  // main column shows the detail in place — tabs + facets stay, so it feels
-  // like browsing a marketplace rather than a full-page takeover.
-  const active = itemId ? (entries.find((e) => e.id === itemId) ?? null) : null;
+  // Deep-link fallback: if ?item= points at an entry that isn't in the loaded
+  // page(s) (e.g. a shared link to something deep in the catalog), fetch that
+  // one item by id so the detail still opens instead of silently falling back
+  // to the grid.
+  useEffect(() => {
+    if (!itemId) {
+      setDeepItem(null);
+      setDeepError(null);
+      setDeepLoading(false);
+      return;
+    }
+    if (entries.some((e) => e.id === itemId)) return; // already in the list
+    if (deepItem?.id === itemId) return; // already fetched
+    let alive = true;
+    setDeepLoading(true);
+    setDeepError(null);
+    getJSON<RegistryItem>(`v1/registries/catalog/items/${itemId}`)
+      .then((it) => {
+        if (!alive) return;
+        setDeepItem(normalize(type, it));
+        setDeepLoading(false);
+      })
+      .catch((e) => {
+        if (!alive) return;
+        setDeepError(e instanceof Error ? e.message : "Failed to load");
+        setDeepLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [itemId, entries, type, deepItem?.id]);
+
+  // Selected item (from ?item=) — resolved against the loaded page first, then
+  // the deep-link fallback. When set, the main column shows the detail in place
+  // — tabs + facets stay, so it feels like browsing a marketplace rather than a
+  // full-page takeover.
+  const active =
+    (itemId ? (entries.find((e) => e.id === itemId) ?? null) : null) ??
+    (deepItem?.id === itemId ? deepItem : null);
   // Drives the empty-state copy + "Clear filters" affordance.
   const hasFilters = query.trim() !== "" || category !== ALL;
 
@@ -309,6 +348,23 @@ export default function CatalogGallery({
         <div className="min-w-0 flex-1 space-y-4">
           {active ? (
             <DetailView entry={active} onBack={() => void setItemId(null)} />
+          ) : itemId ? (
+            <DeepItemStatus onBack={() => void setItemId(null)}>
+              {deepLoading ? (
+                <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading…
+                </span>
+              ) : (
+                <EmptyState
+                  title="Item not found"
+                  detail={
+                    deepError ??
+                    "This item may have been removed or isn't available."
+                  }
+                />
+              )}
+            </DeepItemStatus>
           ) : (
           <>
           <div className="relative">
@@ -1162,6 +1218,29 @@ function EmptyState({
           Clear filters
         </Button>
       )}
+    </div>
+  );
+}
+
+// Back-button shell for the deep-link states (loading / not-found), so an
+// ?item= link that isn't in the loaded page still shows chrome to return.
+function DeepItemStatus({
+  onBack,
+  children,
+}: {
+  onBack: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-6">
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to catalog
+      </button>
+      {children}
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -236,6 +236,9 @@ export default function CatalogGallery({
             void setItemId(null);
           }}
           layoutId="catalog-type-control"
+          // Primary page-level navigation → solid dark pill, distinct from the
+          // inbox's quieter "subtle" secondary filter.
+          variant="solid"
         />
       </div>
 

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/popover";
 import { StartAgentButton } from "@/components/ui/start-agent-button";
 import { CountSegmentedControl } from "@/components/ui/count-segmented-control";
+import { HoverLink } from "@/components/ui/hover-link";
 import HeaderTabs from "@/components/HeaderTabs";
 import EmptyState from "@/components/EmptyState";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
@@ -519,7 +520,7 @@ export default function CatalogGallery({
           {!busy && filtered.length > 0 && (
             <>
               {view === "grid" ? (
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
                   {filtered.map((e) => (
                     <CatalogCard key={e.id} entry={e} onOpen={() => void setItemId(e.id)} />
                   ))}
@@ -733,7 +734,7 @@ function CatalogCard({ entry, onOpen }: { entry: CatalogEntry; onOpen: () => voi
       onClick={onOpen}
       className="group flex flex-col overflow-hidden rounded-lg border border-border/60 bg-white text-left transition-shadow hover:shadow-md dark:border-zinc-700/60 dark:bg-zinc-900"
     >
-      <div className="relative flex h-24 items-center justify-center gap-1.5 border-b border-border/40 bg-[radial-gradient(circle,theme(colors.zinc.200)_1px,transparent_1px)] [background-size:12px_12px] dark:bg-[radial-gradient(circle,theme(colors.zinc.800)_1px,transparent_1px)]">
+      <div className="relative flex h-20 items-center justify-center gap-1.5 border-b border-border/40 bg-[radial-gradient(circle,theme(colors.zinc.200)_1px,transparent_1px)] [background-size:12px_12px] dark:bg-[radial-gradient(circle,theme(colors.zinc.800)_1px,transparent_1px)]">
         {entry.verified ? (
           <span className="absolute left-2 top-2">
             <Badge variant="blue" size="sm" className="gap-1">
@@ -766,14 +767,12 @@ function CatalogCard({ entry, onOpen }: { entry: CatalogEntry; onOpen: () => voi
             <TypeIcon className="h-4 w-4 text-zinc-400" />
           </span>
         )}
-        <span className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100">
-          <Badge variant="default" size="sm">
-            View
-          </Badge>
+        <span className="absolute right-2 top-2">
+          <HoverLink text="View" />
         </span>
       </div>
 
-      <div className="flex flex-1 flex-col gap-1.5 p-4">
+      <div className="flex flex-1 flex-col gap-1 p-3">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-semibold">{entry.title}</span>
           {entry.category && (
@@ -782,10 +781,14 @@ function CatalogCard({ entry, onOpen }: { entry: CatalogEntry; onOpen: () => voi
             </Badge>
           )}
         </div>
-        <p className="line-clamp-2 text-xs text-muted-foreground">{entry.description}</p>
+        <p className="table-description line-clamp-2">{entry.description}</p>
         {entry.meta.length > 0 && (
-          <div className="mt-auto truncate pt-2 text-[11px] text-muted-foreground">
-            {entry.meta.join(" · ")}
+          <div className="mt-auto flex flex-wrap gap-1 pt-1.5">
+            {entry.meta.map((m) => (
+              <Badge key={m} variant="secondary" size="sm" className="font-normal">
+                {m}
+              </Badge>
+            ))}
           </div>
         )}
       </div>
@@ -1325,8 +1328,8 @@ function SkillFacts({ entry }: { entry: CatalogEntry }) {
 function ContentSkeleton({ view }: { view: ViewMode }) {
   if (view === "table") return <CatalogTableSkeleton />;
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-      {Array.from({ length: 8 }).map((_, i) => (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+      {Array.from({ length: 10 }).map((_, i) => (
         <CatalogCardSkeleton key={i} />
       ))}
     </div>
@@ -1383,17 +1386,17 @@ export function CatalogGallerySkeleton({
   );
 }
 
-// Mirrors CatalogCard: h-24 logo header + padded title/description body.
+// Mirrors CatalogCard: h-20 logo header + padded title/description body.
 function CatalogCardSkeleton() {
   return (
     <div
       className="flex flex-col overflow-hidden rounded-lg border border-border/60 bg-white dark:border-zinc-700/60 dark:bg-zinc-900"
       aria-hidden="true"
     >
-      <div className="flex h-24 items-center justify-center border-b border-border/40 bg-[radial-gradient(circle,theme(colors.zinc.200)_1px,transparent_1px)] [background-size:12px_12px] dark:bg-[radial-gradient(circle,theme(colors.zinc.800)_1px,transparent_1px)]">
+      <div className="flex h-20 items-center justify-center border-b border-border/40 bg-[radial-gradient(circle,theme(colors.zinc.200)_1px,transparent_1px)] [background-size:12px_12px] dark:bg-[radial-gradient(circle,theme(colors.zinc.800)_1px,transparent_1px)]">
         <div className="h-10 w-10 animate-pulse rounded-lg bg-muted" />
       </div>
-      <div className="flex flex-1 flex-col gap-1.5 p-4">
+      <div className="flex flex-1 flex-col gap-1 p-3">
         <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
         <div className="h-3 w-full animate-pulse rounded bg-muted/60" />
         <div className="h-3 w-2/3 animate-pulse rounded bg-muted/60" />

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React, {
+  createContext,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -110,21 +112,52 @@ const TYPE_ICON: Record<CatalogType, LucideIcon> = {
   mcp_servers: Plug,
 };
 
+// ── Shared "type switch in flight" signal ──
+// The type tabs live in the ContentBlock subheader while the gallery lives in
+// the content area, so the transition that wraps the SSR round-trip is owned
+// here and consumed by both: the tabs trigger it, the gallery skeletons its
+// content on `isPending` for the whole round-trip. This keeps the persistent
+// chrome mounted and — crucially — avoids any flash of the previous type's data
+// mid-switch (React holds the old tree during a transition, so a type-vs-seed
+// comparison would briefly read stale; `isPending` doesn't).
+type ExplorePending = {
+  isPending: boolean;
+  startTransition: React.TransitionStartFunction;
+};
+const ExplorePendingContext = createContext<ExplorePending | null>(null);
+
+export function ExplorePendingProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [isPending, startTransition] = useTransition();
+  return (
+    <ExplorePendingContext.Provider value={{ isPending, startTransition }}>
+      {children}
+    </ExplorePendingContext.Provider>
+  );
+}
+
+function useExplorePending() {
+  return useContext(ExplorePendingContext);
+}
+
 // ── Type switcher (lives in the ContentBlock subheader) ──
 // Lifted out of the gallery into the standard bordered subheader band — same
 // pattern as the agents / connections pages — so it no longer sits inside the
 // scrollable, padded content area. Shares the `type` URL state with the gallery
 // below (same nuqs key), so selecting a tab drives both in lock-step.
 export function ExploreTypeTabs({ initialType }: { initialType: CatalogType }) {
-  // shallow:false re-runs the explore Server Component; wrap it in a transition
-  // so the switch is non-blocking (no Suspense blank) — the gallery skeletons
-  // its content via `busy` while the new SSR page streams in.
-  const [, startTransition] = useTransition();
+  // shallow:false re-runs the explore Server Component. The transition is owned
+  // by ExplorePendingProvider (shared with the gallery) so its `isPending`
+  // drives the gallery's content skeleton for the whole round-trip.
+  const pending = useExplorePending();
   const [type, setType] = useQueryState(
     "type",
     parseAsStringLiteral(TYPE_KEYS).withDefault(initialType).withOptions({
       shallow: false,
-      startTransition,
+      startTransition: pending?.startTransition,
     })
   );
   const [, setCategory] = useQueryState("category", parseAsString.withDefault(ALL));
@@ -211,6 +244,9 @@ export default function CatalogGallery({
       shallow: false,
     })
   );
+  // Shared transition state (the subheader tabs own the setter) — drives the
+  // content skeleton while a type switch is in flight.
+  const explorePending = useExplorePending();
   // Seeded from the server-rendered first page (no initial client fetch / flash).
   const [entries, setEntries] = useState<CatalogEntry[]>(initialEntries);
   const [offset, setOffset] = useState(initialEntries.length);
@@ -236,19 +272,17 @@ export default function CatalogGallery({
 
   // Re-seed from fresh SSR data when the type's server round-trip lands. Because
   // the component is no longer remounted on type change, this is what swaps in
-  // the new type's first page — and flipping `seededType` back to the live type
-  // is what clears `busy` (which skeletons the content meanwhile). Tracked in
-  // state (not a ref) so the comparison below is render-safe; the guard skips
-  // the initial mount, already seeded via the useState initializers above.
-  const [seededType, setSeededType] = useState(initialType);
+  // the new type's first page when the transition commits. The ref guards the
+  // initial mount (already seeded via the useState initializers above).
+  const seededType = useRef(initialType);
   useEffect(() => {
-    if (seededType === initialType) return;
-    setSeededType(initialType);
+    if (seededType.current === initialType) return;
+    seededType.current = initialType;
     setEntries(initialEntries);
     setOffset(initialEntries.length);
     setHasMore(initialHasMore);
     setError(initialError);
-  }, [initialType, initialEntries, initialHasMore, initialError, seededType]);
+  }, [initialType, initialEntries, initialHasMore, initialError]);
 
   const load = useCallback(
     async (t: CatalogType, off: number, append: boolean) => {
@@ -355,12 +389,10 @@ export default function CatalogGallery({
   // Drives the empty-state copy + "Clear filters" affordance.
   const hasFilters = query.trim() !== "" || category !== ALL;
 
-  // "Busy" = first-page client load OR an in-flight type switch. The switch is
-  // detected by comparing the live URL `type` (updated optimistically by the
-  // subheader tabs) against the type whose SSR data is currently seeded — while
-  // they differ the new first page hasn't landed yet. Either way we skeleton the
-  // content/facets but keep the persistent chrome mounted.
-  const busy = loading || type !== seededType;
+  // "Busy" = first-page client load OR an in-flight type switch (the shared
+  // transition from ExplorePendingProvider, triggered by the subheader tabs).
+  // Either way we skeleton the content/facets but keep the chrome mounted.
+  const busy = loading || (explorePending?.isPending ?? false);
 
   return (
     <div className="flex gap-6">

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -10,12 +10,14 @@ import {
   CheckCircle2,
   ChevronLeft,
   Clock,
+  Compass,
   Loader2,
   Plug,
   Puzzle,
   Search,
   ShieldCheck,
   Star,
+  Telescope,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -36,6 +38,7 @@ import {
 import { StartAgentButton } from "@/components/ui/start-agent-button";
 import { CountSegmentedControl } from "@/components/ui/count-segmented-control";
 import HeaderTabs from "@/components/HeaderTabs";
+import EmptyState from "@/components/EmptyState";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { cn } from "@/lib/utils";
 import {
@@ -358,10 +361,11 @@ export default function CatalogGallery({
               ) : (
                 <EmptyState
                   title="Item not found"
-                  detail={
+                  description={
                     deepError ??
                     "This item may have been removed or isn't available."
                   }
+                  iconsType="404"
                 />
               )}
             </DeepItemStatus>
@@ -388,16 +392,20 @@ export default function CatalogGallery({
           {!loading && filtered.length === 0 && !error && (
             <EmptyState
               title={hasFilters ? "No matches" : "Nothing here"}
-              detail={
+              description={
                 hasFilters
                   ? "Nothing matches your search and filters."
                   : "Nothing to show for this type yet."
               }
-              onClear={
+              icons={hasFilters ? [Telescope, Compass, Search] : undefined}
+              action={
                 hasFilters
-                  ? () => {
-                      void setQuery("");
-                      void setCategory(ALL);
+                  ? {
+                      label: "Clear filters",
+                      onClick: () => {
+                        void setQuery("");
+                        void setCategory(ALL);
+                      },
                     }
                   : undefined
               }
@@ -1196,28 +1204,6 @@ function GridSkeleton() {
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="h-48 animate-pulse rounded-lg border border-border/60 bg-muted/40" />
       ))}
-    </div>
-  );
-}
-
-function EmptyState({
-  title,
-  detail,
-  onClear,
-}: {
-  title: string;
-  detail: string;
-  onClear?: () => void;
-}) {
-  return (
-    <div className="rounded-lg border border-dashed border-border/60 px-6 py-12 text-center">
-      <p className="text-sm font-medium">{title}</p>
-      <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
-      {onClear && (
-        <Button variant="outline" size="sm" className="mt-4" onClick={onClear}>
-          Clear filters
-        </Button>
-      )}
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -101,6 +101,47 @@ const TYPE_ICON: Record<CatalogType, LucideIcon> = {
   mcp_servers: Plug,
 };
 
+// ── Type switcher (lives in the ContentBlock subheader) ──
+// Lifted out of the gallery into the standard bordered subheader band — same
+// pattern as the agents / connections pages — so it no longer sits inside the
+// scrollable, padded content area. Shares the `type` URL state with the gallery
+// below (same nuqs key), so selecting a tab drives both in lock-step.
+export function ExploreTypeTabs({ initialType }: { initialType: CatalogType }) {
+  const [type, setType] = useQueryState(
+    "type",
+    parseAsStringLiteral(TYPE_KEYS).withDefault(initialType).withOptions({
+      shallow: false,
+    })
+  );
+  const [, setCategory] = useQueryState("category", parseAsString.withDefault(ALL));
+  const [, setItemId] = useQueryState("item", parseAsString);
+
+  return (
+    <CountSegmentedControl
+      items={TYPES.map((t) => {
+        const Icon = t.icon;
+        return {
+          value: t.key,
+          label: (
+            <span className="flex items-center gap-1.5">
+              <Icon className="h-4 w-4" />
+              {t.label}
+            </span>
+          ),
+        };
+      })}
+      value={type}
+      onChange={(next) => {
+        void setType(next);
+        void setCategory(ALL);
+        void setItemId(null);
+      }}
+      variant="solid"
+      layoutId="catalog-type-control"
+    />
+  );
+}
+
 // ── Component ──
 
 type CatalogGalleryProps = {
@@ -121,7 +162,9 @@ export default function CatalogGallery({
   // (explore/page.tsx) and re-fetches the first page server-side. Combined with
   // `key={type}` on this component, every type view starts from fresh SSR data —
   // there is no client fetch on mount and no stale-response race across types.
-  const [type, setType] = useQueryState(
+  // `type` is read-only here — the switcher lives in the subheader
+  // (ExploreTypeTabs) and drives this same nuqs key.
+  const [type] = useQueryState(
     "type",
     parseAsStringLiteral(TYPE_KEYS).withDefault(initialType).withOptions({
       shallow: false,
@@ -214,34 +257,6 @@ export default function CatalogGallery({
 
   return (
     <div className="space-y-4">
-      {/* Type tabs — the primary axis. Reuses the inbox segmented control. */}
-      <div className="border-b border-border/60 pb-3">
-        <CountSegmentedControl
-          items={TYPES.map((t) => {
-            const Icon = t.icon;
-            return {
-              value: t.key,
-              label: (
-                <span className="flex items-center gap-1.5">
-                  <Icon className="h-4 w-4" />
-                  {t.label}
-                </span>
-              ),
-            };
-          })}
-          value={type}
-          onChange={(next) => {
-            void setType(next);
-            void setCategory(ALL);
-            void setItemId(null);
-          }}
-          layoutId="catalog-type-control"
-          // Primary page-level navigation → solid dark pill, distinct from the
-          // inbox's quieter "subtle" secondary filter.
-          variant="solid"
-        />
-      </div>
-
       <div className="flex gap-6">
         {/* Facet sidebar — always reserved (fixed width) so the layout doesn't
             shift when categories arrive. Shows a skeleton while loading. */}

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -278,27 +278,32 @@ export default function CatalogGallery({
   // main column shows the detail in place — tabs + facets stay, so it feels
   // like browsing a marketplace rather than a full-page takeover.
   const active = itemId ? (entries.find((e) => e.id === itemId) ?? null) : null;
+  // Drives the empty-state copy + "Clear filters" affordance.
+  const hasFilters = query.trim() !== "" || category !== ALL;
 
   return (
-    <div className="space-y-4">
-      <div className="flex gap-6">
-        {/* Facet sidebar — always reserved (fixed width) so the layout doesn't
-            shift when categories arrive. Shows a skeleton while loading. */}
-        <aside className="hidden w-52 shrink-0 lg:block">
-          {loading ? (
-            <FacetSkeleton />
-          ) : categories.length > 0 ? (
-            <FacetGroup
-              label="Category"
-              options={categories}
-              selected={category}
-              onSelect={(v) => {
-                void setCategory(v);
-                void setItemId(null);
-              }}
-            />
-          ) : null}
-        </aside>
+    <div className="flex gap-6">
+        {/* Facet sidebar — reserved (fixed width) while loading or when the type
+            has categories, so the layout doesn't shift as they arrive. Omitted
+            entirely for category-less types so the grid isn't left with an empty
+            left gutter. */}
+        {(loading || categories.length > 0) && (
+          <aside className="hidden w-52 shrink-0 lg:block">
+            {loading ? (
+              <FacetSkeleton />
+            ) : (
+              <FacetGroup
+                label="Category"
+                options={categories}
+                selected={category}
+                onSelect={(v) => {
+                  void setCategory(v);
+                  void setItemId(null);
+                }}
+              />
+            )}
+          </aside>
+        )}
 
         {/* Main */}
         <div className="min-w-0 flex-1 space-y-4">
@@ -312,6 +317,7 @@ export default function CatalogGallery({
               value={query}
               onChange={(e) => void setQuery(e.target.value)}
               placeholder={`Search ${TYPES.find((t) => t.key === type)?.label.toLowerCase()}…`}
+              aria-label={`Search ${TYPES.find((t) => t.key === type)?.label.toLowerCase()}`}
               className="pl-9"
             />
           </div>
@@ -324,7 +330,22 @@ export default function CatalogGallery({
           )}
           {loading && <GridSkeleton />}
           {!loading && filtered.length === 0 && !error && (
-            <EmptyState title="Nothing here" detail="Try another type, clear filters, or search." />
+            <EmptyState
+              title={hasFilters ? "No matches" : "Nothing here"}
+              detail={
+                hasFilters
+                  ? "Nothing matches your search and filters."
+                  : "Nothing to show for this type yet."
+              }
+              onClear={
+                hasFilters
+                  ? () => {
+                      void setQuery("");
+                      void setCategory(ALL);
+                    }
+                  : undefined
+              }
+            />
           )}
 
           {!loading && filtered.length > 0 && (
@@ -358,7 +379,6 @@ export default function CatalogGallery({
           )}
         </div>
       </div>
-    </div>
   );
 }
 
@@ -1124,11 +1144,24 @@ function GridSkeleton() {
   );
 }
 
-function EmptyState({ title, detail }: { title: string; detail: string }) {
+function EmptyState({
+  title,
+  detail,
+  onClear,
+}: {
+  title: string;
+  detail: string;
+  onClear?: () => void;
+}) {
   return (
     <div className="rounded-lg border border-dashed border-border/60 px-6 py-12 text-center">
       <p className="text-sm font-medium">{title}</p>
       <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+      {onClear && (
+        <Button variant="outline" size="sm" className="mt-4" onClick={onClear}>
+          Clear filters
+        </Button>
+      )}
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -36,6 +36,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { StartAgentButton } from "@/components/ui/start-agent-button";
+import { CountSegmentedControl } from "@/components/ui/count-segmented-control";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { cn } from "@/lib/utils";
 import {
@@ -213,30 +214,29 @@ export default function CatalogGallery({
 
   return (
     <div className="space-y-4">
-      {/* Type tabs — the primary axis */}
-      <div className="flex flex-wrap gap-2 border-b border-border/60 pb-3">
-        {TYPES.map((t) => {
-          const Icon = t.icon;
-          return (
-            <button
-              key={t.key}
-              onClick={() => {
-                void setType(t.key);
-                void setCategory(ALL);
-                void setItemId(null);
-              }}
-              className={cn(
-                "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-                type === t.key
-                  ? "bg-foreground text-background"
-                  : "text-muted-foreground hover:bg-muted"
-              )}
-            >
-              <Icon className="h-4 w-4" />
-              {t.label}
-            </button>
-          );
-        })}
+      {/* Type tabs — the primary axis. Reuses the inbox segmented control. */}
+      <div className="border-b border-border/60 pb-3">
+        <CountSegmentedControl
+          items={TYPES.map((t) => {
+            const Icon = t.icon;
+            return {
+              value: t.key,
+              label: (
+                <span className="flex items-center gap-1.5">
+                  <Icon className="h-4 w-4" />
+                  {t.label}
+                </span>
+              ),
+            };
+          })}
+          value={type}
+          onChange={(next) => {
+            void setType(next);
+            void setCategory(ALL);
+            void setItemId(null);
+          }}
+          layoutId="catalog-type-control"
+        />
       </div>
 
       <div className="flex gap-6">

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -10,11 +10,9 @@ import {
   CheckCircle2,
   ChevronLeft,
   Clock,
-  LayoutGrid,
   Loader2,
   Plug,
   Puzzle,
-  Rows3,
   Search,
   ShieldCheck,
   Star,
@@ -37,6 +35,7 @@ import {
 } from "@/components/ui/popover";
 import { StartAgentButton } from "@/components/ui/start-agent-button";
 import { CountSegmentedControl } from "@/components/ui/count-segmented-control";
+import HeaderTabs from "@/components/HeaderTabs";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { cn } from "@/lib/utils";
 import {
@@ -142,6 +141,29 @@ export function ExploreTypeTabs({ initialType }: { initialType: CatalogType }) {
   );
 }
 
+// Grid/table switcher for the subheader (right side, paired with the type
+// tabs). Reuses the shared HeaderTabs control — same look as agents/connections.
+// Hidden while a detail item is open (?item=), where there's nothing to switch.
+export function ExploreViewToggle() {
+  const [view, setView] = useQueryState(
+    "view",
+    parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
+  );
+  const [itemId] = useQueryState("item", parseAsString);
+  if (itemId) return null;
+
+  return (
+    <HeaderTabs
+      tabs={[
+        { value: "table", label: "Table view" },
+        { value: "grid", label: "Grid view" },
+      ]}
+      value={view}
+      onChange={(v) => void setView(v as ViewMode)}
+    />
+  );
+}
+
 // ── Component ──
 
 type CatalogGalleryProps = {
@@ -180,7 +202,9 @@ export default function CatalogGallery({
 
   const [query, setQuery] = useQueryState("q", parseAsString.withDefault(""));
   const [category, setCategory] = useQueryState("category", parseAsString.withDefault(ALL));
-  const [view, setView] = useQueryState(
+  // `view` is read-only here — the grid/table toggle lives in the subheader
+  // (ExploreViewToggle) and drives this same nuqs key.
+  const [view] = useQueryState(
     "view",
     parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
   );
@@ -282,17 +306,14 @@ export default function CatalogGallery({
             <DetailView entry={active} onBack={() => void setItemId(null)} />
           ) : (
           <>
-          <div className="flex items-center gap-2">
-            <div className="relative flex-1">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={query}
-                onChange={(e) => void setQuery(e.target.value)}
-                placeholder={`Search ${TYPES.find((t) => t.key === type)?.label.toLowerCase()}…`}
-                className="pl-9"
-              />
-            </div>
-            <ViewToggle view={view} onChange={(v) => void setView(v)} />
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => void setQuery(e.target.value)}
+              placeholder={`Search ${TYPES.find((t) => t.key === type)?.label.toLowerCase()}…`}
+              className="pl-9"
+            />
           </div>
 
           {error && (
@@ -337,40 +358,6 @@ export default function CatalogGallery({
           )}
         </div>
       </div>
-    </div>
-  );
-}
-
-// ── View toggle (grid / table) ──
-
-function ViewToggle({ view, onChange }: { view: ViewMode; onChange: (v: ViewMode) => void }) {
-  const opts: { key: ViewMode; icon: LucideIcon; label: string }[] = [
-    { key: "grid", icon: LayoutGrid, label: "Grid view" },
-    { key: "table", icon: Rows3, label: "Table view" },
-  ];
-  return (
-    <div className="flex shrink-0 rounded-md border border-border/60 p-0.5">
-      {opts.map((o) => {
-        const Icon = o.icon;
-        return (
-          <button
-            key={o.key}
-            type="button"
-            title={o.label}
-            aria-label={o.label}
-            aria-pressed={view === o.key}
-            onClick={() => onChange(o.key)}
-            className={cn(
-              "flex h-8 w-8 items-center justify-center rounded transition-colors",
-              view === o.key
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            <Icon className="h-4 w-4" />
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -50,8 +50,10 @@ import HeaderTabs from "@/components/HeaderTabs";
 import EmptyState from "@/components/EmptyState";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { cn } from "@/lib/utils";
+import { getCookie, setCookie } from "@/utils/cookies";
 import {
   ALL,
+  EXPLORE_VIEW_COOKIE,
   FEATURED_TAG,
   PAGE,
   TYPE_KEYS,
@@ -82,7 +84,7 @@ const TYPES: { key: CatalogType; label: string; icon: LucideIcon }[] = [
 
 const VIEW_KEYS = ["grid", "table"] as const;
 
-type ViewMode = (typeof VIEW_KEYS)[number];
+export type ViewMode = (typeof VIEW_KEYS)[number];
 
 // ── Data (client-side, for infinite-scroll "load more" only) ──
 // The first page is server-rendered (see explore/page.tsx); these helpers only
@@ -192,12 +194,34 @@ export function ExploreTypeTabs({ initialType }: { initialType: CatalogType }) {
 // Grid/table switcher for the subheader (right side, paired with the type
 // tabs). Reuses the shared HeaderTabs control — same look as agents/connections.
 // Hidden while a detail item is open (?item=), where there's nothing to switch.
-export function ExploreViewToggle() {
+export function ExploreViewToggle({
+  initialView = "grid",
+}: {
+  initialView?: ViewMode;
+}) {
   const [view, setView] = useQueryState(
     "view",
-    parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
+    parseAsStringLiteral(VIEW_KEYS).withDefault(initialView)
   );
   const [itemId] = useQueryState("item", parseAsString);
+
+  // Restore the persisted view when landing on /explore without an explicit
+  // ?view param (e.g. via the sidebar link). The server seeds `initialView`
+  // from the same cookie to avoid a flash, but client-side restoration is the
+  // authoritative path: a cached RSC or auth-gated SSR can serve a stale
+  // default, so on mount we reconcile against the freshly-read cookie and write
+  // the param if the saved choice differs from what's shown.
+  useEffect(() => {
+    const hasParam = new URLSearchParams(window.location.search).has("view");
+    if (hasParam) return;
+    const saved = getCookie(EXPLORE_VIEW_COOKIE);
+    if ((saved === "table" || saved === "grid") && saved !== view) {
+      void setView(saved);
+    }
+    // Run once on mount — restoring the persisted choice for this visit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (itemId) return null;
 
   return (
@@ -207,7 +231,11 @@ export function ExploreViewToggle() {
         { value: "grid", label: "Grid view" },
       ]}
       value={view}
-      onChange={(v) => void setView(v as ViewMode)}
+      onChange={(v) => {
+        // Persist so the choice survives leaving and returning to /explore.
+        setCookie(EXPLORE_VIEW_COOKIE, v);
+        void setView(v as ViewMode);
+      }}
     />
   );
 }
@@ -219,6 +247,8 @@ type CatalogGalleryProps = {
   initialEntries: CatalogEntry[];
   initialHasMore: boolean;
   initialError?: string | null;
+  /** Persisted grid/table choice (cookie), seeds the view nuqs default. */
+  initialView?: ViewMode;
 };
 
 export default function CatalogGallery({
@@ -226,6 +256,7 @@ export default function CatalogGallery({
   initialEntries,
   initialHasMore,
   initialError = null,
+  initialView = "grid",
 }: CatalogGalleryProps) {
   // Catalog UI state lives in the URL (nuqs) so views are shareable/back-able.
   // `type` uses shallow:false so switching tabs re-runs the Server Component
@@ -258,10 +289,12 @@ export default function CatalogGallery({
   const [query, setQuery] = useQueryState("q", parseAsString.withDefault(""));
   const [category, setCategory] = useQueryState("category", parseAsString.withDefault(ALL));
   // `view` is read-only here — the grid/table toggle lives in the subheader
-  // (ExploreViewToggle) and drives this same nuqs key.
+  // (ExploreViewToggle) and drives this same nuqs key. Default is seeded from
+  // the persisted cookie (via props) so it matches the toggle when there's no
+  // URL param yet.
   const [view] = useQueryState(
     "view",
-    parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
+    parseAsStringLiteral(VIEW_KEYS).withDefault(initialView)
   );
   const [itemId, setItemId] = useQueryState("item", parseAsString);
   // Deep-link fallback for ?item= that points outside the loaded page(s).
@@ -547,21 +580,39 @@ function CatalogTable({
                     </span>
                   )}
                 </td>
-                <td className="py-2 pl-2 pr-3 align-middle">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">{e.title}</span>
+                {/* Title column is capped (responsive) so a long name
+                    truncates with an ellipsis instead of wrapping to multiple
+                    lines and blowing up the row height. `min-w-0` on the flex
+                    row + the name lets the name shrink; the badges stay
+                    `shrink-0` so they're never clipped. */}
+                <td className="max-w-[160px] py-2 pl-2 pr-3 align-middle sm:max-w-[240px] lg:max-w-[340px]">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="min-w-0 truncate font-medium">{e.title}</span>
                     {e.verified && (
                       <BadgeCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
                     )}
                     {e.category && (
-                      <Badge variant="light" size="sm" className="capitalize">
+                      <Badge
+                        variant="light"
+                        size="sm"
+                        className="shrink-0 whitespace-nowrap capitalize"
+                      >
                         {e.category}
                       </Badge>
                     )}
                   </div>
                 </td>
-                <td className="hidden max-w-0 truncate py-2 pr-4 text-xs text-muted-foreground md:table-cell">
-                  {e.description}
+                {/* Description absorbs the remaining row width and truncates
+                    with an ellipsis. `w-full` grabs the leftover space (pinning
+                    the title column to its content, no dead gap); `max-w-0` is
+                    what makes truncation actually work — without it auto table
+                    layout grows the column to fit the nowrap text and it spills
+                    past the edge with no ellipsis. Together they give the inner
+                    block a definite width to clip against. Hidden below md. */}
+                <td className="hidden w-full max-w-0 py-2 pr-4 md:table-cell">
+                  <div className="table-description truncate">
+                    {e.description}
+                  </div>
                 </td>
               </tr>
             );
@@ -1288,15 +1339,28 @@ function ContentSkeleton({ view }: { view: ViewMode }) {
 // yet — shows the same chrome-preserving skeleton instead of the generic
 // full-screen spinner. Reads `type`/`view` from the URL so it matches the
 // destination view exactly.
-export function CatalogGallerySkeleton() {
+export function CatalogGallerySkeleton({
+  initialView = "grid",
+}: {
+  initialView?: ViewMode;
+}) {
   const [type] = useQueryState(
     "type",
     parseAsStringLiteral(TYPE_KEYS).withDefault("bundles")
   );
-  const [view] = useQueryState(
-    "view",
-    parseAsStringLiteral(VIEW_KEYS).withDefault("grid")
-  );
+  // Match the view the page will actually restore (URL param > persisted cookie
+  // > server-seeded default), read on the client via a lazy initializer. The
+  // server seed alone is unreliable (a cached RSC / auth-gated SSR can serve a
+  // stale default), which made the skeleton flash card placeholders while a
+  // table view was loading. Reading the cookie here keeps the skeleton shape in
+  // sync without a flash or a hydration mismatch (server + client agree on a
+  // fresh load).
+  const [view] = useState<ViewMode>(() => {
+    if (typeof document === "undefined") return initialView;
+    const fromUrl = new URLSearchParams(window.location.search).get("view");
+    const saved = fromUrl ?? getCookie(EXPLORE_VIEW_COOKIE);
+    return saved === "table" || saved === "grid" ? saved : initialView;
+  });
   const label = TYPES.find((t) => t.key === type)?.label.toLowerCase() ?? "";
   return (
     <div className="flex gap-6">
@@ -1352,7 +1416,7 @@ function CatalogTableSkeleton() {
               <td className="py-2 pl-2 pr-3">
                 <div className="h-4 w-40 animate-pulse rounded bg-muted" />
               </td>
-              <td className="hidden py-2 pr-4 md:table-cell">
+              <td className="hidden w-full max-w-0 py-2 pr-4 md:table-cell">
                 <div className="h-3 w-64 animate-pulse rounded bg-muted/60" />
               </td>
             </tr>

--- a/agentarea-webapp/src/app/(main)/bundles/components/catalog-data.ts
+++ b/agentarea-webapp/src/app/(main)/bundles/components/catalog-data.ts
@@ -18,6 +18,12 @@ export const PAGE = 96;
 export const ALL = "__all__";
 export const FEATURED_TAG = "featured";
 
+// Per-path cookie that persists the grid/table choice across navigation. Lives
+// here (not in the "use client" gallery) so the Server Components — explore
+// page.tsx + loading.tsx — import the real string, not a client-reference proxy.
+// Same `${param}_${path}` convention as HeaderTabs.
+export const EXPLORE_VIEW_COOKIE = "view_explore";
+
 export type RawSpec = Record<string, unknown>;
 
 export type RegistryItem = {

--- a/agentarea-webapp/src/app/(main)/explore/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/loading.tsx
@@ -1,0 +1,33 @@
+import ContentBlock from "@/components/ContentBlock";
+import {
+  CatalogGallerySkeleton,
+  ExploreTypeTabs,
+  ExploreViewToggle,
+} from "../bundles/components/CatalogGallery";
+
+// Route-level Suspense fallback for /explore. The page is an async Server
+// Component that awaits the first catalog page, so without this the nearest
+// loading boundary is the root full-screen spinner — a white flash on hard
+// refresh. Here we render the identical chrome (breadcrumb + type tabs + view
+// toggle) and a faceted skeleton body, so the page paints its real frame
+// instantly and only the content area fills in. Matches the in-component `busy`
+// skeleton the gallery shows on type switches.
+export default function Loading() {
+  return (
+    <ContentBlock
+      header={{
+        breadcrumb: [{ label: "Explore" }],
+        description:
+          "Browse the catalog. Filter by type, use case, or integration, then add to your workspace.",
+      }}
+      subheader={
+        <>
+          <ExploreTypeTabs initialType="bundles" />
+          <ExploreViewToggle />
+        </>
+      }
+    >
+      <CatalogGallerySkeleton />
+    </ContentBlock>
+  );
+}

--- a/agentarea-webapp/src/app/(main)/explore/loading.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/loading.tsx
@@ -1,9 +1,11 @@
+import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock";
 import {
   CatalogGallerySkeleton,
   ExploreTypeTabs,
   ExploreViewToggle,
 } from "../bundles/components/CatalogGallery";
+import { EXPLORE_VIEW_COOKIE } from "../bundles/components/catalog-data";
 
 // Route-level Suspense fallback for /explore. The page is an async Server
 // Component that awaits the first catalog page, so without this the nearest
@@ -12,7 +14,13 @@ import {
 // toggle) and a faceted skeleton body, so the page paints its real frame
 // instantly and only the content area fills in. Matches the in-component `busy`
 // skeleton the gallery shows on type switches.
-export default function Loading() {
+export default async function Loading() {
+  // Seed the skeleton from the persisted view so a hard refresh skeletons the
+  // same layout (grid vs table) the page will paint.
+  const cookieStore = await cookies();
+  const initialView =
+    cookieStore.get(EXPLORE_VIEW_COOKIE)?.value === "table" ? "table" : "grid";
+
   return (
     <ContentBlock
       header={{
@@ -23,11 +31,11 @@ export default function Loading() {
       subheader={
         <>
           <ExploreTypeTabs initialType="bundles" />
-          <ExploreViewToggle />
+          <ExploreViewToggle initialView={initialView} />
         </>
       }
     >
-      <CatalogGallerySkeleton />
+      <CatalogGallerySkeleton initialView={initialView} />
     </ContentBlock>
   );
 }

--- a/agentarea-webapp/src/app/(main)/explore/page.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import ContentBlock from "@/components/ContentBlock";
 import { fetchCatalogPage } from "@/lib/api";
-import CatalogGallery from "../bundles/components/CatalogGallery";
+import CatalogGallery, {
+  ExploreTypeTabs,
+} from "../bundles/components/CatalogGallery";
 import {
   PAGE,
   isCatalogType,
@@ -40,6 +42,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
         description:
           "Browse the catalog. Filter by type, use case, or integration, then add to your workspace.",
       }}
+      subheader={<ExploreTypeTabs initialType={type} />}
     >
       <CatalogGallery
         key={type}

--- a/agentarea-webapp/src/app/(main)/explore/page.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import ContentBlock from "@/components/ContentBlock";
 import { fetchCatalogPage } from "@/lib/api";
 import CatalogGallery, {
+  ExplorePendingProvider,
   ExploreTypeTabs,
   ExploreViewToggle,
 } from "../bundles/components/CatalogGallery";
@@ -37,25 +38,29 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
   );
 
   return (
-    <ContentBlock
-      header={{
-        breadcrumb: [{ label: "Explore" }],
-        description:
-          "Browse the catalog. Filter by type, use case, or integration, then add to your workspace.",
-      }}
-      subheader={
-        <>
-          <ExploreTypeTabs initialType={type} />
-          <ExploreViewToggle />
-        </>
-      }
-    >
-      <CatalogGallery
-        initialType={type}
-        initialEntries={entries}
-        initialHasMore={hasMore}
-        initialError={error ? "Failed to load catalog." : null}
-      />
-    </ContentBlock>
+    // Provider wraps both the subheader (type tabs trigger the transition) and
+    // the content (gallery skeletons on isPending) so the switch is flash-free.
+    <ExplorePendingProvider>
+      <ContentBlock
+        header={{
+          breadcrumb: [{ label: "Explore" }],
+          description:
+            "Browse the catalog. Filter by type, use case, or integration, then add to your workspace.",
+        }}
+        subheader={
+          <>
+            <ExploreTypeTabs initialType={type} />
+            <ExploreViewToggle />
+          </>
+        }
+      >
+        <CatalogGallery
+          initialType={type}
+          initialEntries={entries}
+          initialHasMore={hasMore}
+          initialError={error ? "Failed to load catalog." : null}
+        />
+      </ContentBlock>
+    </ExplorePendingProvider>
   );
 }

--- a/agentarea-webapp/src/app/(main)/explore/page.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/page.tsx
@@ -3,6 +3,7 @@ import ContentBlock from "@/components/ContentBlock";
 import { fetchCatalogPage } from "@/lib/api";
 import CatalogGallery, {
   ExploreTypeTabs,
+  ExploreViewToggle,
 } from "../bundles/components/CatalogGallery";
 import {
   PAGE,
@@ -42,7 +43,12 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
         description:
           "Browse the catalog. Filter by type, use case, or integration, then add to your workspace.",
       }}
-      subheader={<ExploreTypeTabs initialType={type} />}
+      subheader={
+        <>
+          <ExploreTypeTabs initialType={type} />
+          <ExploreViewToggle />
+        </>
+      }
     >
       <CatalogGallery
         key={type}

--- a/agentarea-webapp/src/app/(main)/explore/page.tsx
+++ b/agentarea-webapp/src/app/(main)/explore/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import ContentBlock from "@/components/ContentBlock";
 import { fetchCatalogPage } from "@/lib/api";
 import CatalogGallery, {
@@ -7,6 +8,7 @@ import CatalogGallery, {
   ExploreViewToggle,
 } from "../bundles/components/CatalogGallery";
 import {
+  EXPLORE_VIEW_COOKIE,
   PAGE,
   isCatalogType,
   normalize,
@@ -32,6 +34,17 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
   const sp = await searchParams;
   const type: CatalogType = isCatalogType(sp.type) ? sp.type : "bundles";
 
+  // Persisted grid/table choice: URL param wins, otherwise the cookie written
+  // by the view toggle, otherwise grid. Seeds the toggle + gallery defaults so
+  // the user's last view is restored on return.
+  const cookieStore = await cookies();
+  const initialView =
+    sp.view === "table" || sp.view === "grid"
+      ? sp.view
+      : cookieStore.get(EXPLORE_VIEW_COOKIE)?.value === "table"
+        ? "table"
+        : "grid";
+
   const { items, hasMore, error } = await fetchCatalogPage(type, 0, PAGE);
   const entries: CatalogEntry[] = (items as RegistryItem[]).map((it) =>
     normalize(type, it)
@@ -50,7 +63,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
         subheader={
           <>
             <ExploreTypeTabs initialType={type} />
-            <ExploreViewToggle />
+            <ExploreViewToggle initialView={initialView} />
           </>
         }
       >
@@ -59,6 +72,7 @@ export default async function ExplorePage({ searchParams }: ExplorePageProps) {
           initialEntries={entries}
           initialHasMore={hasMore}
           initialError={error ? "Failed to load catalog." : null}
+          initialView={initialView}
         />
       </ContentBlock>
     </ExplorePendingProvider>

--- a/agentarea-webapp/src/app/globals.css
+++ b/agentarea-webapp/src/app/globals.css
@@ -380,6 +380,11 @@
     @apply text-xs text-zinc-400;
   }
 
+  /* Shared style for the description column in list/table views. */
+  .table-description {
+    @apply text-xs font-light text-muted-foreground;
+  }
+
   .form-content {
     @apply space-y-5;
   }

--- a/agentarea-webapp/src/components/ui/count-segmented-control.tsx
+++ b/agentarea-webapp/src/components/ui/count-segmented-control.tsx
@@ -10,10 +10,35 @@ export interface CountSegmentedControlItem<T extends string = string> {
   count?: ReactNode;
 }
 
+// Active-pill palette by role. Pick via the `variant` prop; the per-instance
+// className props below still win (twMerge) for one-off tweaks.
+export type CountSegmentedControlVariant = "subtle" | "solid";
+
+const VARIANTS: Record<
+  CountSegmentedControlVariant,
+  { pill: string; activeText: string; activeCount: string }
+> = {
+  // Quiet secondary filter (e.g. inbox status filter): light raised pill.
+  subtle: {
+    pill: "bg-zinc-100 dark:bg-zinc-900",
+    activeText: "text-foreground",
+    activeCount: "text-muted-foreground dark:text-zinc-300",
+  },
+  // Primary page-level navigation (e.g. explore type switcher): solid pill
+  // with inverted text. Theme-aware via foreground/background tokens, so it
+  // flips to a light pill + dark text in dark mode.
+  solid: {
+    pill: "bg-foreground dark:bg-foreground",
+    activeText: "text-background",
+    activeCount: "text-background/70",
+  },
+};
+
 interface CountSegmentedControlProps<T extends string = string> {
   items: CountSegmentedControlItem<T>[];
   value: T;
   onChange: (value: T) => void;
+  variant?: CountSegmentedControlVariant;
   className?: string;
   itemClassName?: string;
   activePillClassName?: string;
@@ -28,6 +53,7 @@ export function CountSegmentedControl<T extends string = string>({
   items,
   value,
   onChange,
+  variant = "subtle",
   className,
   itemClassName,
   activePillClassName,
@@ -37,6 +63,7 @@ export function CountSegmentedControl<T extends string = string>({
   activeCountClassName,
   layoutId = "count-segmented-control",
 }: CountSegmentedControlProps<T>) {
+  const styles = VARIANTS[variant];
   return (
     <div
       className={cn(
@@ -55,7 +82,7 @@ export function CountSegmentedControl<T extends string = string>({
             className={cn(
               "relative inline-flex h-7 shrink-0 items-center gap-2 rounded-[10px] px-3 text-[12.5px] font-normal tracking-normal transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
               isActive
-                ? "text-foreground"
+                ? styles.activeText
                 : "text-muted-foreground hover:text-foreground dark:text-zinc-400 dark:hover:text-zinc-100",
               itemClassName,
               isActive ? activeItemClassName : inactiveItemClassName
@@ -65,7 +92,8 @@ export function CountSegmentedControl<T extends string = string>({
               <motion.span
                 layoutId={`${layoutId}-active-pill`}
                 className={cn(
-                  "absolute inset-0 rounded-[8px] bg-zinc-100 ring-0 shadow-none dark:bg-zinc-900",
+                  "absolute inset-0 rounded-[8px] ring-0 shadow-none",
+                  styles.pill,
                   activePillClassName
                 )}
                 initial={false}
@@ -83,7 +111,7 @@ export function CountSegmentedControl<T extends string = string>({
                 className={cn(
                   "relative z-10 text-[11px] font-normal text-muted-foreground/80 transition-colors dark:text-zinc-500",
                   countClassName,
-                  isActive && "text-muted-foreground dark:text-zinc-300",
+                  isActive && styles.activeCount,
                   isActive && activeCountClassName
                 )}
               >


### PR DESCRIPTION
**Explore: reuse shared UI components & polish**

Reworks the Explore catalog to use our existing shared components instead of bespoke ones, and aligns it with the subheader pattern used across the app.

- Replace the custom type menu with CountSegmentedControl (new variant: subtle | solid prop) and the grid/table switch with the shared HeaderTabs
- Move the type tabs and view toggle into the ContentBlock subheader, matching /agents & /connections
- Swap the local empty states for the shared EmptyState component
- Add a deep-link fallback so ?item= opens an item that isn't on the first page
- Minor cleanups: drop the empty facet gutter, fix extra padding, add a search aria-label

<img width="1470" height="807" alt="Снимок экрана 2026-06-30 в 18 25 06" src="https://github.com/user-attachments/assets/a7566718-b65e-4c62-b138-2d4bb2fd2554" />
