### PR TITLE
fix(auth): route A2A through the shared edge auth + single policy decision (ADR-006)

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/a2a_auth.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/a2a_auth.py
@@ -10,6 +10,8 @@ from uuid import UUID
 
 from agentarea_agents.application.agent_service import AgentService
 from agentarea_api.api.deps.services import get_agent_service
+from agentarea_common.auth.context import UserContext
+from agentarea_common.auth.dependencies import get_optional_user
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer
 from pydantic import BaseModel
@@ -58,146 +60,13 @@ class A2APermissions:
     ]
 
 
-async def extract_auth_from_request(request: Request) -> dict[str, Any]:
-    """Extract authentication information from request."""
-    auth_info = {"method": None, "credentials": None, "metadata": {}}
-
-    # Check Authorization header (Bearer token)
-    auth_header = request.headers.get("authorization")
-    if auth_header and auth_header.startswith("Bearer "):
-        auth_info["method"] = "bearer"
-        auth_info["credentials"] = auth_header[7:]  # Remove "Bearer " prefix
-
-    # Check API Key header
-    api_key = request.headers.get("x-api-key")
-    if api_key:
-        auth_info["method"] = "api_key"
-        auth_info["credentials"] = api_key
-
-    # Extract additional metadata
-    auth_info["metadata"] = {
+def _a2a_metadata(request: Request, **extra: str | None) -> dict[str, Any]:
+    """Request metadata carried on the A2A auth context."""
+    return {
         "user_agent": request.headers.get("user-agent"),
         "client_ip": request.client.host if request.client else None,
-        "forwarded_for": request.headers.get("x-forwarded-for"),
+        **{k: v for k, v in extra.items() if v is not None},
     }
-
-    return auth_info
-
-
-async def authenticate_bearer_token(token: str) -> dict[str, Any] | None:
-    """Authenticate bearer token using Kratos auth provider."""
-    from agentarea_common.auth.providers.factory import AuthProviderFactory
-    from agentarea_common.config.auth import get_auth_settings
-
-    try:
-        settings = get_auth_settings()
-        auth_provider = AuthProviderFactory.create_provider(
-            "kratos",
-            config={
-                "jwks_b64": settings.KRATOS_JWKS_B64,
-                "issuer": settings.KRATOS_ISSUER,
-                "audience": settings.KRATOS_AUDIENCE,
-            },
-        )
-
-        # Verify token using Kratos provider
-        auth_result = await auth_provider.verify_token(token)
-
-        if not auth_result.is_authenticated or not auth_result.token:
-            logger.warning(f"Bearer token authentication failed: {auth_result.error}")
-            return None
-
-        # Extract user information from validated token
-        # Extract workspace_id from token claims if available
-        workspace_id = None
-        if auth_result.token.claims:
-            workspace_id = auth_result.token.claims.get("workspace_id")
-
-        if not workspace_id:
-            workspace_id = auth_result.token.user_id
-
-        return {
-            "user_id": auth_result.token.user_id,
-            "workspace_id": workspace_id,
-            "permissions": A2APermissions.USER_PERMISSIONS,
-            "valid": True,
-        }
-
-    except Exception as e:
-        logger.error(f"Error authenticating bearer token: {e}")
-        return None
-
-
-async def authenticate_api_key(api_key: str) -> dict[str, Any] | None:
-    """Authenticate API key and extract user context including workspace.
-
-    TODO: Implement proper API key authentication with database lookup.
-    API keys should be stored hashed in the database with associated user/workspace context.
-    """
-    # API key authentication not yet implemented
-    logger.warning("API key authentication attempted but not yet implemented")
-    return None
-
-
-async def get_a2a_auth_context(
-    request: Request, agent_id: UUID | None = None, required_permission: str | None = None
-) -> A2AAuthContext:
-    """Get A2A authentication context for request."""
-    # Extract authentication info
-    auth_info = await extract_auth_from_request(request)
-
-    # Initialize context with defaults
-    context = A2AAuthContext(
-        authenticated=False,
-        permissions=A2APermissions.PUBLIC_PERMISSIONS,
-        metadata=auth_info["metadata"],
-    )
-
-    # Authenticate based on method
-    auth_result = None
-
-    if auth_info["method"] == "bearer" and auth_info["credentials"]:
-        auth_result = await authenticate_bearer_token(auth_info["credentials"])
-        context.auth_method = "bearer"
-    elif auth_info["method"] == "api_key" and auth_info["credentials"]:
-        auth_result = await authenticate_api_key(auth_info["credentials"])
-        context.auth_method = "api_key"
-
-    # Update context if authenticated
-    if auth_result and auth_result.get("valid"):
-        context.authenticated = True
-        context.user_id = auth_result["user_id"]
-        workspace_id = auth_result.get("workspace_id")
-        if not workspace_id:
-            logger.warning(
-                f"Authentication result missing workspace_id for user {auth_result['user_id']}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Authentication token missing required workspace_id claim",
-            )
-        context.workspace_id = workspace_id
-        context.permissions = auth_result["permissions"]
-        context.agent_id = agent_id
-
-        logger.info(
-            f"A2A authentication successful: user={context.user_id}, "
-            f"workspace={context.workspace_id}, method={context.auth_method}"
-        )
-    else:
-        logger.info(f"A2A authentication failed or not provided: method={auth_info['method']}")
-
-    # Check required permission
-    if required_permission and required_permission not in context.permissions:
-        logger.warning(
-            f"A2A authorization failed: user={context.user_id}, required={required_permission}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Insufficient permissions. Required: {required_permission}",
-        )
-
-    return context
 
 
 async def require_a2a_auth(
@@ -205,53 +74,105 @@ async def require_a2a_auth(
     agent_id: UUID,
     permission: str = A2APermissions.AGENT_READ,
     agent_service: AgentService = Depends(get_agent_service),
+    subject: UserContext | None = Depends(get_optional_user),
 ) -> A2AAuthContext:
-    """Require A2A authentication with specific permission."""
-    # Verify agent exists
+    """Authenticate + authorize an A2A request through the shared edge policy.
+
+    A2A carries no auth or permission model of its own (ADR-006). The subject
+    is resolved by the SAME dependency every optional-auth REST endpoint uses
+    (``get_optional_user`` → the shared ``HTTPBearer`` scheme, handling Kratos
+    JWT + ``aat_`` API key + Hydra OAuth), and the allow/deny decision is made
+    by the single edge authorizer (``authorize_agent_action``). An ``aat_`` key
+    that works over REST works here too; a public-execution grant is honored
+    without a key.
+    """
+    from agentarea_common.auth.access import authorize_agent_action
+
     agent = await agent_service.get(agent_id)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    # Get auth context with required permission
-    context = await get_a2a_auth_context(request, agent_id, permission)
-
-    # Ensure user is authenticated
-    if not context.authenticated:
+    decision = await authorize_agent_action(
+        subject,
+        permission,
+        agent_workspace_id=str(agent.workspace_id),
+        agent_id=str(agent_id),
+    )
+    if not decision.allowed:
+        if subject is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        logger.warning(
+            f"A2A authorization denied: user={subject.user_id}, "
+            f"agent={agent_id}, required={permission}, reason={decision.reason}"
+        )
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication required",
-            headers={"WWW-Authenticate": "Bearer"},
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Insufficient permissions. Required: {permission}",
         )
 
-    # Add agent info to context
-    context.metadata["agent_name"] = agent.name
-    context.metadata["agent_status"] = agent.status
-
-    return context
+    return A2AAuthContext(
+        authenticated=subject is not None,
+        user_id=subject.user_id if subject else None,
+        workspace_id=str(subject.workspace_id) if subject else str(agent.workspace_id),
+        agent_id=agent_id,
+        permissions=[permission],
+        auth_method="bearer" if subject else "anonymous",
+        metadata=_a2a_metadata(request, agent_name=agent.name, agent_status=agent.status),
+    )
 
 
 async def require_a2a_write_auth(
-    request: Request, agent_id: UUID, agent_service: AgentService = Depends(get_agent_service)
+    request: Request,
+    agent_id: UUID,
+    agent_service: AgentService = Depends(get_agent_service),
+    subject: UserContext | None = Depends(get_optional_user),
 ) -> A2AAuthContext:
     """Require A2A write permission."""
-    return await require_a2a_auth(request, agent_id, A2APermissions.AGENT_WRITE, agent_service)
+    return await require_a2a_auth(
+        request, agent_id, A2APermissions.AGENT_WRITE, agent_service, subject
+    )
 
 
 async def require_a2a_execute_auth(
-    request: Request, agent_id: UUID, agent_service: AgentService = Depends(get_agent_service)
+    request: Request,
+    agent_id: UUID,
+    agent_service: AgentService = Depends(get_agent_service),
+    subject: UserContext | None = Depends(get_optional_user),
 ) -> A2AAuthContext:
     """Require A2A execute permission."""
-    return await require_a2a_auth(request, agent_id, A2APermissions.AGENT_EXECUTE, agent_service)
+    return await require_a2a_auth(
+        request, agent_id, A2APermissions.AGENT_EXECUTE, agent_service, subject
+    )
 
 
 async def require_a2a_stream_auth(
-    request: Request, agent_id: UUID, agent_service: AgentService = Depends(get_agent_service)
+    request: Request,
+    agent_id: UUID,
+    agent_service: AgentService = Depends(get_agent_service),
+    subject: UserContext | None = Depends(get_optional_user),
 ) -> A2AAuthContext:
     """Require A2A stream permission."""
-    return await require_a2a_auth(request, agent_id, A2APermissions.AGENT_STREAM, agent_service)
+    return await require_a2a_auth(
+        request, agent_id, A2APermissions.AGENT_STREAM, agent_service, subject
+    )
 
 
-# Public dependency - no auth required
-async def allow_public_access(request: Request) -> A2AAuthContext:
-    """Allow public access (for discovery endpoints)."""
-    return await get_a2a_auth_context(request)
+async def allow_public_access(
+    request: Request,
+    subject: UserContext | None = Depends(get_optional_user),
+) -> A2AAuthContext:
+    """Public discovery endpoints: resolve the subject if a token is present,
+    but require no permission. Uses the same shared resolver — no bespoke auth.
+    """
+    return A2AAuthContext(
+        authenticated=subject is not None,
+        user_id=subject.user_id if subject else None,
+        workspace_id=str(subject.workspace_id) if subject else None,
+        permissions=[A2APermissions.AGENT_READ],
+        auth_method="bearer" if subject else "anonymous",
+        metadata=_a2a_metadata(request),
+    )

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -696,12 +696,18 @@ async def get_agent_task_status(
         raise HTTPException(status_code=404, detail="Agent not found")
 
     try:
-        task = await task_service.get_task(task_id)
+        # DB is the source of truth for the task lifecycle; Temporal only
+        # upgrades to a terminal state. The workflow may stay alive in
+        # await_follow_up after writing "completed" to the DB, so reading the
+        # raw live workflow status here would report "running" for a finished
+        # task. get_task_with_workflow_status applies the same enrichment the
+        # plain task get uses, keeping the two endpoints consistent.
+        task = await task_service.get_task_with_workflow_status(task_id)
         if not task or str(task.agent_id) != str(agent_id):
             raise HTTPException(status_code=404, detail="Task not found")
 
-        # Get workflow status using the execution ID pattern
-        execution_id = f"task-{task_id}"
+        # Get workflow status for live execution detail (timing, session, etc.)
+        execution_id = task.execution_id or f"task-{task_id}"
         status = await workflow_task_service.get_workflow_status(execution_id)
         stored_artifacts = await _list_task_artifact_items(
             agent_id=agent_id,
@@ -716,12 +722,13 @@ async def get_agent_task_status(
             "task_id": str(task_id),
             "agent_id": str(agent_id),
             "execution_id": execution_id,
-            "status": status.get("status", "unknown"),
+            # Authoritative lifecycle status/result come from the persisted task.
+            "status": task.status,
             "start_time": status.get("start_time"),
             "end_time": status.get("end_time"),
             "execution_time": status.get("execution_time"),
             "error": status.get("error"),
-            "result": status.get("result"),
+            "result": task.result if task.result is not None else status.get("result"),
             # A2A-compatible fields for frontend
             "message": status.get("message"),
             "artifacts": status_artifacts,

--- a/agentarea-platform/libs/common/agentarea_common/auth/dependencies.py
+++ b/agentarea-platform/libs/common/agentarea_common/auth/dependencies.py
@@ -403,6 +403,77 @@ async def get_user_context(
         ) from e
 
 
+async def resolve_user_context_from_token(
+    token: str | None, request: Request
+) -> UserContext | None:
+    """Resolve a UserContext from a bearer token, or None if absent/invalid.
+
+    This is the single authentication resolution shared by every edge — REST
+    optional auth and the A2A protocol both go through it, so an AgentArea API
+    key (``aat_``), a Kratos JWT, and a Hydra OAuth token are all accepted the
+    same way at every entry point. It never raises for an auth failure; it
+    returns None so the caller decides the posture (401, anonymous subject, ...).
+    """
+    if not token:
+        return None
+
+    # API key (prefix-based routing)
+    if token.startswith(_API_KEY_PREFIX):
+        user_context = await _validate_api_key(token, request)
+        if user_context is None:
+            logger.debug("API key authentication failed: invalid or expired key")
+            return None
+        await _resolve_accessible_workspaces(user_context)
+        try:
+            await _apply_workspace_selection(user_context, request)
+        except HTTPException:
+            return None
+        ContextManager.set_context(user_context)
+        return user_context
+
+    # Kratos JWT, with Hydra OAuth token as a fallback (MCP clients).
+    auth_provider = get_auth_provider()
+    try:
+        auth_result: AuthResult = await auth_provider.verify_token(token)
+
+        if not auth_result.is_authenticated or not auth_result.token:
+            hydra_context = await _try_hydra_token(token, request)
+            if hydra_context is not None:
+                await _resolve_accessible_workspaces(hydra_context)
+                try:
+                    await _apply_workspace_selection(hydra_context, request)
+                except HTTPException:
+                    return None
+                ContextManager.set_context(hydra_context)
+                return hydra_context
+            logger.debug(f"Token authentication failed: {auth_result.error}")
+            return None
+
+        # Default workspace is the user's personal workspace (= user_id).
+        # Any X-Workspace-ID override is validated against accessible_workspaces.
+        user_context = UserContext(
+            user_id=auth_result.token.user_id,
+            workspace_id=auth_result.token.user_id,
+            email=auth_result.token.email,
+        )
+        await _resolve_accessible_workspaces(user_context)
+        try:
+            await _apply_workspace_selection(user_context, request)
+        except HTTPException:
+            return None
+        ContextManager.set_context(user_context)
+        return user_context
+
+    except Exception as e:
+        hydra_context = await _try_hydra_token(token, request)
+        if hydra_context is not None:
+            await _resolve_accessible_workspaces(hydra_context)
+            ContextManager.set_context(hydra_context)
+            return hydra_context
+        logger.warning(f"Error during token resolution: {e}")
+        return None
+
+
 async def get_optional_user(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security_optional),
@@ -410,16 +481,8 @@ async def get_optional_user(
     """Optionally authenticate user if token is provided (OPTIONAL authentication).
 
     This dependency allows endpoints to work with or without authentication.
-    Returns UserContext if a valid token is provided, None otherwise.
-
-    Does NOT raise 401 if no token provided.
-
-    Args:
-        request: FastAPI request object
-        credentials: Optional HTTP Bearer token from Authorization header
-
-    Returns:
-        Optional[UserContext]: User context if authenticated, None otherwise
+    Returns UserContext if a valid token is provided, None otherwise. Does NOT
+    raise 401 if no token provided.
 
     Example:
         @router.get("/optional")
@@ -432,61 +495,7 @@ async def get_optional_user(
         logger.debug("No authentication credentials provided (optional auth)")
         return None
 
-    token = credentials.credentials
-
-    # Check if this is an API key (prefix-based routing)
-    if token.startswith(_API_KEY_PREFIX):
-        user_context = await _validate_api_key(token, request)
-        if user_context is None:
-            logger.debug("Optional API key authentication failed: invalid or expired key")
-            return None
-        await _resolve_accessible_workspaces(user_context)
-        try:
-            await _apply_workspace_selection(user_context, request)
-        except HTTPException:
-            return None
-        ContextManager.set_context(user_context)
-        logger.debug(
-            f"Authenticated via API key: user={user_context.user_id} workspace={user_context.workspace_id}"
-        )
-        return user_context
-
-    # Otherwise, verify as JWT
-    auth_provider = get_auth_provider()
-
-    try:
-        # Verify token using auth provider
-        auth_result: AuthResult = await auth_provider.verify_token(token)
-
-        if not auth_result.is_authenticated or not auth_result.token:
-            logger.debug(f"Optional authentication failed: {auth_result.error}")
-            return None
-
-        # Default workspace is the user's personal workspace (= user_id).
-        # See the required-auth path above for the threat model.
-        user_context = UserContext(
-            user_id=auth_result.token.user_id,
-            workspace_id=auth_result.token.user_id,
-            email=auth_result.token.email,
-        )
-
-        # Resolve accessible workspaces
-        await _resolve_accessible_workspaces(user_context)
-        try:
-            await _apply_workspace_selection(user_context, request)
-        except HTTPException:
-            return None
-
-        # Set context in ContextManager
-        ContextManager.set_context(user_context)
-
-        logger.debug(f"Optionally authenticated user: {user_context.user_id}")
-
-        return user_context
-
-    except Exception as e:
-        logger.warning(f"Error during optional authentication: {e}")
-        return None
+    return await resolve_user_context_from_token(credentials.credentials, request)
 
 
 async def verify_workspace_access(


### PR DESCRIPTION
## Why

#260 landed `access.py` (the single edge authorizer) and ADR-006 but not the wiring that calls them, leaving them orphaned and re-introducing two bugs. This completes the wiring.

A2A had its own parallel authn (JWT-only, API-key stub) and hardcoded permission lists, so an `aat_` API key that works over REST returned **403** on `/a2a/rpc`, and public execution was inexpressible.

## What

- **dependencies**: extract `resolve_user_context_from_token` (JWT + `aat_` key + Hydra); `get_optional_user` delegates to it — one auth resolution for every edge.
- **a2a_auth**: `require_a2a_auth` resolves the subject via that resolver and decides via `authorize_agent_action` (ADR-006 single decision point); deletes the dead parallel model.
- **agents_tasks**: task status endpoint reads the persisted (enriched) task as source of truth instead of raw live workflow status — a completed task no longer reports `running` while the workflow lingers in `await_follow_up`.

## Verified live (curl)

- `aat_` API key now executes over A2A (`SendMessage` → task WORKING) — was 403.
- Foreign-workspace agent denied (404).
- REST unaffected (agents list works).
- Status endpoint reports `completed` for a finished task.

Related: ADR-006 (`docs/decisions/adr-006-...`), ADR-005 (in-execution governance).