### PR TITLE
fix(compose): provide dev sandbox auth secrets in .env.example (unbreak main)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,14 @@ ARTIFACTS_BUCKET=artifacts
 # Generate a key with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 SECRET_MANAGER_ENCRYPTION_KEY=bibLeh67aw7ltAr1ZS_FcE5DTLC3m5k_ZR9LdWaCsU4=
 
+## Sandbox runtime auth (HMAC shared secrets, must be >= 32 bytes)
+# The control plane signs short-lived activation tokens the sandbox runner
+# verifies before executing untrusted commands; the worker uses the cleanup
+# secret to retire finished task sandboxes. Dev values only — set real secrets
+# in production. compose fails hard if these are unset (no default there).
+SANDBOX_ACTIVATION_AUTH_SECRET=dev-sandbox-activation-hmac-secret-change-in-prod
+SANDBOX_CLEANUP_AUTH_SECRET=dev-sandbox-cleanup-hmac-secret-change-in-prod-00
+
 REDIS_URL=redis://valkey:6379
 
 # Ory Kratos (Identity Management)


### PR DESCRIPTION
## What
PR #277 added `SANDBOX_ACTIVATION_AUTH_SECRET` and `SANDBOX_CLEANUP_AUTH_SECRET` to docker-compose as **required** `${VAR:?...}` interpolation vars but never added them to `.env.example`.

The live-stack CI job (`OpenAPI fuzz (live stack)`) and `make up-dev` both do `cp .env.example .env` then `docker compose up`. With the vars unset, compose aborts before start:
```
error while interpolating services.sandbox-executor.environment.SANDBOX_ACTIVATION_AUTH_SECRET: required variable ... must be set
```
This broke the fuzz job on `main` after #277 merged.

## Fix
Add both to `.env.example` with filled dev values (>=32 bytes, matching the existing `SECRET_MANAGER_ENCRYPTION_KEY` / `RUSTFS_SECRET_KEY` pattern — `.env.example` is intentionally a complete ready-to-run config). compose keeps its fail-hard `${VAR:?}` guard; **no default is added in compose** (respects no-silent-security-default).

## Verified
- `docker compose --env-file .env.example -f docker-compose.yaml -f docker-compose.ci.yaml config` → exit 0, both secrets resolve (previously errored).
- Labeled `run-integration-tests` so the live-stack fuzz job exercises the fix on this PR.

## Not addressed (transient)
The `docker-frontend (arm64)` + `docker-mcp-runner (merge)` failures on the #277 merge were a Docker Hub registry timeout (`request canceled ... moby/buildkit`) in the same ~3-min window; the merge 'not found' is the downstream effect. These re-run on the next main push.