### PR TITLE
fix(delegation): raise sub-agent poll timeout (120s → 600s, env-overridable)

### DIFF
--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/agent_delegation_tool.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/agent_delegation_tool.py
@@ -6,6 +6,7 @@ For external agents, use A2AAgentTool instead.
 
 import asyncio
 import logging
+import os
 import time
 from typing import Any
 from uuid import UUID, uuid4
@@ -15,8 +16,12 @@ from .base_tool import BaseTool, ToolExecutionError
 
 logger = logging.getLogger(__name__)
 
-# Max time to wait for delegated task to complete (seconds)
-DELEGATION_POLL_TIMEOUT = 120.0
+# Max time the coordinator waits for a delegated task to complete (seconds). A
+# delegated task is itself a full agent run — a research sub-agent doing web
+# calls can legitimately need several minutes — so the old 120s abandoned
+# still-working sub-agents and forced the coordinator to fall back. Default to
+# a task-scale horizon; override via env for longer/shorter delegations.
+DELEGATION_POLL_TIMEOUT = float(os.getenv("AGENT_DELEGATION_POLL_TIMEOUT", "600"))
 DELEGATION_POLL_INTERVAL = 2.0
 
 


### PR DESCRIPTION
## Problem
`AgentDelegationTool` polled a delegated task for only `DELEGATION_POLL_TIMEOUT = 120s`. But a delegated task is a **full agent run** — a research sub-agent doing web calls (~34s/iteration) can legitimately need several minutes. At 120s the coordinator abandoned a still-working sub-agent, received an empty result, and fell back to its own knowledge — the exact delegation antipattern the evals flag (DELEG-01). 120s is also inconsistent with the ~1200s/task the platform allows elsewhere.

## Fix
Default `DELEGATION_POLL_TIMEOUT` to a task-scale **600s**, env-overridable via `AGENT_DELEGATION_POLL_TIMEOUT`. The delegated sub-task already inherits the normal 50-iteration budget (created with `task_parameters={}`), so no change there.

## Scope / honesty
This is a **robustness fix** — it stops the coordinator giving up on live sub-agents. It does **not** by itself make a weak local model's sub-agent converge (that sub-agent over-researches and needs a stronger model per the eval README); DELEG-01 remains model-quality-gated. No behavior change for fast sub-agents (they complete well under 120s either way).

## Verified
`ruff check` clean; import yields `DELEGATION_POLL_TIMEOUT = 600.0`; no test pinned the old value.