### PR TITLE
fix(ci): stop mcp-runner manifest job from consuming mcp-runner-locked digests

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -212,7 +212,12 @@ jobs:
         if: ${{ inputs.push }}
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ inputs.component }}-${{ matrix.arch }}
+          # `.` separates the component from the arch, NOT `-`. The merge job
+          # globs these by component name, and one component name is a prefix of
+          # another (mcp-runner / mcp-runner-locked), so a `-` separator lets
+          # `digests-mcp-runner-*` swallow the locked image's digests and the
+          # manifest step then asks for them under the wrong repository.
+          name: digests-${{ inputs.component }}.${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -241,7 +246,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ inputs.component }}-*
+          pattern: digests-${{ inputs.component }}.*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
docker-agentarea-mcp-runner / merge has been failing on main since 2d048734
with `docker.io/.../-mcp-runner@sha256:<digest>: not found`, even though both
per-arch builds succeed and the -locked variant of the same job passes.

Each build uploads its digest as `digests-<component>-<arch>`, and the merge
job collects them with `pattern: digests-<component>-*` plus merge-multiple.
`mcp-runner` is a prefix of `mcp-runner-locked`, so that glob also matches
`digests-mcp-runner-locked-amd64` and `-arm64`. All four digests land in one
flattened directory and `imagetools create` then asks for the locked image's
digests under the agentarea-mcp-runner repository, where they do not exist.
The digest in the last failure, df376fc1…, is exactly the artifact uploaded by
docker-agentarea-mcp-runner-locked / build (linux/arm64). The reverse never
breaks, because `digests-mcp-runner-locked-*` matches only its own two.

Separate the component from the arch with `.` instead of `-`, so no component
name can prefix another. Verified against minimatch (what download-artifact
uses) for all eight components: the old pattern returns 4 artifacts for
mcp-runner, the new one returns exactly 2 for every component.

This job only runs when agentarea-mcp-manager/** changes, which is why the
failure sat unnoticed through #278, #279 and #280 — and why this workflow-only
commit will not re-run it. It is exercised on the next mcp-manager change.


---