### PR TITLE
fix(webapp): raise @hono/node-server override to 2.0.10

### DIFF
--- a/agentarea-webapp/package.json
+++ b/agentarea-webapp/package.json
@@ -103,7 +103,7 @@
   "overrides": {
     "@babel/core@<=7.29.0": "7.29.6",
     "@babel/plugin-transform-modules-systemjs@<7.29.4": "7.29.4",
-    "@hono/node-server@<2.0.5": "2.0.5",
+    "@hono/node-server@<2.0.10": "2.0.10",
     "axios@>=1.0.0 <1.18.0": "1.18.0",
     "brace-expansion@<1.1.16": "1.1.16",
     "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",
@@ -125,7 +125,7 @@
     "overrides": {
       "@babel/core@<=7.29.0": "7.29.6",
       "@babel/plugin-transform-modules-systemjs@<7.29.4": "7.29.4",
-      "@hono/node-server@<2.0.5": "2.0.5",
+      "@hono/node-server@<2.0.10": "2.0.10",
       "axios@>=1.0.0 <1.18.0": "1.18.0",
       "brace-expansion@<1.1.16": "1.1.16",
       "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",

--- a/agentarea-webapp/pnpm-lock.yaml
+++ b/agentarea-webapp/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/core@<=7.29.0': 7.29.6
   '@babel/plugin-transform-modules-systemjs@<7.29.4': 7.29.4
-  '@hono/node-server@<2.0.5': 2.0.5
+  '@hono/node-server@<2.0.10': 2.0.10
   axios@>=1.0.0 <1.18.0: 1.18.0
   brace-expansion@<1.1.16: 1.1.16
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
@@ -1695,8 +1695,8 @@ packages:
   '@hey-api/types@0.1.4':
     resolution: {integrity: sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==}
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
@@ -9242,7 +9242,7 @@ snapshots:
 
   '@hey-api/types@0.1.4': {}
 
-  '@hono/node-server@2.0.5(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -9480,7 +9480,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5


### PR DESCRIPTION
#281 added an override for `@hono/node-server@<2.0.5` against the advisory
known at the time. That pinned the package to exactly 2.0.5, and a later
advisory covers `<= 2.0.9` (unauthenticated memory-leak DoS), so the pin left
the resolved version vulnerable rather than fixing it.

Raise the override bound to `<2.0.10` -> 2.0.10. The tree carries hono@4.12.27
and @hono/node-server@2.0.10 requires hono ^4, so the constraint is satisfied.
pnpm-lock.yaml now resolves 2.0.10; webapp type-check and production build both
pass.

Not bumping esbuild, which is the one remaining open advisory. The tree holds
both 0.25.12 and 0.27.4; only 0.27.4 falls in the affected range
(>=0.27.3, <0.28.1), and it is pulled by vite/vitest/tsup, where tsup@8.5.1
declares `esbuild: ^0.27.0` — forcing 0.28.1 would break its declared range.
The advisory is a low-severity arbitrary file read in esbuild's own dev server,
which this repo never starts. It resolves itself when vite/tsup move on.


---