### PR TITLE
fix(mcp): authorize X-Workspace-ID on the /mcp auth path

### DIFF
--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/mcp_server/auth.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/mcp_server/auth.py
@@ -184,6 +184,8 @@ class MCPAuthMiddleware:
                 user_context = await _validate_api_key(bearer_token, request)
                 if user_context:
                     await _resolve_accessible_workspaces(user_context)
+                    if not await _select_workspace(user_context, request):
+                        return
                     _mcp_user_context_var.set(user_context)
                     return
 
@@ -192,12 +194,15 @@ class MCPAuthMiddleware:
             auth_result = await auth_provider.verify_token(bearer_token)
 
             if auth_result.is_authenticated and auth_result.token:
-                workspace_id = request.headers.get("X-Workspace-ID") or auth_result.token.user_id
+                # Start on the caller's own workspace; an X-Workspace-ID/-Slug
+                # override is applied only after the membership check below.
                 user_context = UserContext(
                     user_id=auth_result.token.user_id,
-                    workspace_id=workspace_id,
+                    workspace_id=auth_result.token.user_id,
                 )
                 await _resolve_accessible_workspaces(user_context)
+                if not await _select_workspace(user_context, request):
+                    return
                 _mcp_user_context_var.set(user_context)
                 return
 
@@ -217,6 +222,32 @@ class MCPAuthMiddleware:
 # ---------------------------------------------------------------------------
 # Helpers (module-level for testability)
 # ---------------------------------------------------------------------------
+
+
+async def _select_workspace(user_context: Any, request: Request) -> bool:
+    """Authorize an X-Workspace-ID/-Slug override, reusing the REST guard.
+
+    `/mcp` is a second authentication path alongside the `/v1` router. It must
+    not re-implement the membership check, or the two drift and only one of them
+    gets hardened — which is exactly how the header became spoofable here.
+
+    Returns False when the caller asked for a workspace they are not a member of;
+    the caller then leaves the context unset so the request fails closed.
+    """
+    from agentarea_common.auth.dependencies import _apply_workspace_selection
+
+    try:
+        await _apply_workspace_selection(user_context, request)
+        return True
+    except Exception:
+        logger.warning(
+            "MCP auth: rejected workspace override user=%s requested=%s accessible=%s",
+            user_context.user_id,
+            request.headers.get("X-Workspace-ID") or request.headers.get("X-Workspace-Slug"),
+            user_context.accessible_workspaces,
+            exc_info=True,
+        )
+        return False
 
 
 def _parse_jsonrpc(body: bytes) -> tuple[str, Any]:

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_mcp_auth_middleware.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_mcp_auth_middleware.py
@@ -40,3 +40,109 @@ async def test_mcp_auth_accepts_agentarea_pat_prefix():
         assert _mcp_user_context_var.get(None) is user_context
     finally:
         _mcp_user_context_var.reset(token)
+
+
+def _grant(*workspaces: str):
+    """Stub _resolve_accessible_workspaces that grants a fixed workspace set."""
+
+    async def _resolve(user_context: UserContext) -> None:
+        user_context.accessible_workspaces = list(workspaces)
+
+    return AsyncMock(side_effect=_resolve)
+
+
+def _jwt_auth_result(user_id: str) -> MagicMock:
+    auth_result = MagicMock()
+    auth_result.is_authenticated = True
+    auth_result.token = MagicMock()
+    auth_result.token.user_id = user_id
+    return auth_result
+
+
+async def _authenticate_jwt(request, *, granted: tuple[str, ...]) -> UserContext | None:
+    """Run the JWT path of the middleware with a stubbed provider and grant set."""
+    middleware = MCPAuthMiddleware(MagicMock())
+    token = _mcp_user_context_var.set(None)
+    try:
+        with (
+            patch(
+                "agentarea_common.auth.dependencies._resolve_accessible_workspaces",
+                new=_grant(*granted),
+            ),
+            patch("agentarea_common.auth.dependencies.get_auth_provider") as get_auth_provider,
+        ):
+            auth_provider = MagicMock()
+            auth_provider.verify_token = AsyncMock(return_value=_jwt_auth_result("alice"))
+            get_auth_provider.return_value = auth_provider
+
+            await middleware._try_authenticate("jwt-token", request)
+        return _mcp_user_context_var.get(None)
+    finally:
+        _mcp_user_context_var.reset(token)
+
+
+class TestMCPWorkspaceOverrideIsAuthorized:
+    """`/mcp` must not accept an X-Workspace-ID the caller is not a member of.
+
+    The REST router enforces this through `_apply_workspace_selection`; the MCP
+    middleware is a separate auth path, and when it skipped that check any
+    authenticated user could read another workspace by setting the header.
+    """
+
+    @pytest.mark.asyncio
+    async def test_foreign_workspace_header_is_rejected(self):
+        request = MagicMock()
+        request.headers = {"X-Workspace-ID": "bob-workspace"}
+
+        context = await _authenticate_jwt(request, granted=("alice",))
+
+        # Fail closed: no context at all, rather than a context on Bob's workspace.
+        assert context is None
+
+    @pytest.mark.asyncio
+    async def test_member_workspace_header_is_applied(self):
+        request = MagicMock()
+        request.headers = {"X-Workspace-ID": "shared-workspace"}
+
+        context = await _authenticate_jwt(request, granted=("alice", "shared-workspace"))
+
+        assert context is not None
+        assert context.user_id == "alice"
+        assert context.workspace_id == "shared-workspace"
+
+    @pytest.mark.asyncio
+    async def test_without_header_defaults_to_own_workspace(self):
+        request = MagicMock()
+        request.headers = {}
+
+        context = await _authenticate_jwt(request, granted=("alice",))
+
+        assert context is not None
+        assert context.workspace_id == "alice"
+
+    @pytest.mark.asyncio
+    async def test_api_key_path_also_rejects_foreign_workspace(self):
+        """_validate_api_key deliberately ignores the header; the caller must check it."""
+        middleware = MCPAuthMiddleware(MagicMock())
+        request = MagicMock()
+        request.headers = {"X-Workspace-ID": "bob-workspace"}
+        issued_for = UserContext(user_id="alice", workspace_id="alice-workspace")
+        token = _mcp_user_context_var.set(None)
+
+        try:
+            with (
+                patch(
+                    "agentarea_common.auth.dependencies._validate_api_key",
+                    new=AsyncMock(return_value=issued_for),
+                ),
+                patch(
+                    "agentarea_common.auth.dependencies._resolve_accessible_workspaces",
+                    new=_grant("alice-workspace"),
+                ),
+                patch("agentarea_common.auth.dependencies.get_auth_provider"),
+            ):
+                await middleware._try_authenticate("aat_key", request)
+
+            assert _mcp_user_context_var.get(None) is None
+        finally:
+            _mcp_user_context_var.reset(token)


### PR DESCRIPTION
`/mcp` authenticates separately from the `/v1` router. Both read an
X-Workspace-ID header, but only the REST path validated it: it calls
`_apply_workspace_selection()`, which rejects a workspace outside the caller's
`accessible_workspaces` with 403. The MCP middleware called
`_resolve_accessible_workspaces()` and stopped there — and that function only
populates the accessible list, it never rejects. The requested workspace went
straight into `UserContext`, so any authenticated user could read or write
another workspace through the platform MCP tools by setting one header.

This affects both credential types, not just JWTs. `_validate_api_key()`
deliberately returns the key's own workspace and leaves the header override to
its caller; the MCP path never applied it, so API keys were spoofable the same
way.

Route both paths through `_apply_workspace_selection()` rather than adding a
second copy of the membership check — a duplicated check is what let the two
paths drift in the first place. The middleware contract is "never raises", so a
rejected override is logged and leaves the context unset, and the request fails
closed downstream.

The Kratos path now starts on the caller's own workspace and applies the
override only after the check, instead of seeding UserContext from the header.
The Hydra path is unchanged and was never affected: it derives the workspace
from the signed token and never reads the header.

Tests cover both credential types and both outcomes, and they fail against the
previous implementation.


Advisory: GHSA-jv7w-w5rm-xr7r / GHSA-m64w-82pj-72v4

---