### PR TITLE
fix(mcp): apply the outbound-URL guard to validate-connection

### DIFF
--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
@@ -9,9 +9,10 @@ from uuid import UUID
 
 from agentarea_common.audit import audited
 from agentarea_common.base.service import BaseCrudService
-from agentarea_common.config import get_database
+from agentarea_common.config import get_database, get_settings
 from agentarea_common.events.broker import EventBroker
 from agentarea_common.infrastructure.secret_manager import BaseSecretManager
+from agentarea_common.utils.url_safety import UnsafeUrlError, validate_outbound_url
 
 from agentarea_mcp.application.auth_service import MCPAuthService, OAuthReauthRequiredError
 from agentarea_mcp.domain.events import (
@@ -1194,6 +1195,17 @@ class MCPServerInstanceService:
     ) -> dict[str, Any]:
         if not url:
             return {"valid": False, "errors": ["URL is required"]}
+
+        # This endpoint returns the upstream tool list to the caller, so an
+        # unguarded URL here is a full-read SSRF, not a blind one. Refuse before
+        # dialing: a check after the request would still reach the internal host.
+        try:
+            validate_outbound_url(url, allow_private=get_settings().mcp.ALLOW_PRIVATE_URLS)
+        except UnsafeUrlError:
+            # Deliberately generic: a specific reason would turn this into a DNS
+            # oracle telling the caller which internal names resolve.
+            logger.warning("Refused MCP connection validation for a non-public URL", exc_info=True)
+            return {"valid": False, "errors": ["URL is not allowed"]}
 
         try:
             result = await self._list_tools_via_mcp(url, headers or {})

--- a/agentarea-platform/libs/mcp/tests/test_validate_connection_ssrf.py
+++ b/agentarea-platform/libs/mcp/tests/test_validate_connection_ssrf.py
@@ -1,0 +1,72 @@
+"""SSRF guard on MCP connection validation.
+
+`POST /v1/mcp-server-instances/validate-connection` takes a URL from the request
+body and returns the upstream tool list to the caller, so an unguarded sink is a
+full-read SSRF, not a blind one: any authenticated user could enumerate internal
+services and read cloud metadata through it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agentarea_mcp.application.service import MCPServerInstanceService
+
+
+def _service() -> MCPServerInstanceService:
+    with patch("agentarea_mcp.application.service.get_database", MagicMock()):
+        return MCPServerInstanceService(
+            repository_factory=MagicMock(),
+            event_broker=MagicMock(),
+            secret_manager=MagicMock(),
+        )
+
+
+class TestValidateConnectionRefusesNonPublicTargets:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:8000/mcp",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.5/mcp",
+            "http://[::1]:8000/mcp",
+            "file:///etc/passwd",
+            "gopher://127.0.0.1:6379/_INFO",
+        ],
+    )
+    async def test_rejects_and_never_dials(self, url: str):
+        service = _service()
+
+        with patch.object(service, "_list_tools_via_mcp", new=AsyncMock()) as dial:
+            result = await service.validate_connection(url=url)
+
+        assert result["valid"] is False
+        assert result["errors"]
+        # The request must not be issued at all — a refused-after-dial guard
+        # would still leak timing and still hit the internal service.
+        dial.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_public_target_still_works(self):
+        service = _service()
+        listing = MagicMock()
+        listing.tools = []
+
+        with patch.object(
+            service, "_list_tools_via_mcp", new=AsyncMock(return_value=listing)
+        ) as dial:
+            # IP literal so the guard has nothing to resolve and the test stays offline.
+            result = await service.validate_connection(url="https://8.8.8.8/mcp")
+
+        assert result["valid"] is True
+        dial.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_url_is_still_rejected(self):
+        service = _service()
+
+        with patch.object(service, "_list_tools_via_mcp", new=AsyncMock()) as dial:
+            result = await service.validate_connection(url="")
+
+        assert result["valid"] is False
+        dial.assert_not_awaited()


### PR DESCRIPTION
`POST /v1/mcp-server-instances/validate-connection` took `url` from the request
body and handed it to `_list_tools_via_mcp()` with no scheme, host or IP check,
then returned the upstream tool list to the caller. That makes it a full-read
SSRF rather than a blind one: any authenticated user could enumerate internal
services and read cloud metadata (169.254.169.254) through the API. The
attacker-supplied `headers` were forwarded to the target as well.

The sibling sink in model discovery was already fixed in c3ad933f; this one was
missed because it lives in the MCP service rather than the LLM one. Our CodeQL
`py/partial-ssrf` query never flagged it either.

Route it through the same `validate_outbound_url()` used by discovery, gated by
`ALLOW_PRIVATE_URLS` so self-hosted installs targeting a private MCP can still
opt in. The check runs before dialing — validating after the request would still
reach the internal host.

The refusal message is deliberately generic. Returning the guard's reason would
distinguish "bad scheme" from "resolved to a private address" and turn the
endpoint into a DNS oracle for internal names; the detail goes to the log.


Advisory: GHSA-8574-rcrf-v9g8 (sink 2)

---