### PR TITLE
fix(tasks): scope GET /tasks/{id}/events to the caller's workspace

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -24,6 +24,7 @@ from agentarea_api.api.deps.services import (
     get_temporal_workflow_service,
 )
 from agentarea_common.auth.dependencies import UserContextDep
+from agentarea_common.base import ReadRepositoryFactoryDep
 from agentarea_common.config.app import get_app_settings
 from agentarea_common.events.contract import TASK_CANCELLED, TASK_COMPLETED, TASK_FAILED
 from agentarea_common.money import ZERO, Money, serialize_money
@@ -31,6 +32,7 @@ from agentarea_common.utils.types import UtcDatetime
 from agentarea_governance.domain.policies import PolicyDocument, PolicyValidationError
 from agentarea_llm.application.model_instance_service import ModelInstanceService
 from agentarea_tasks.domain.exceptions import AgentModelNotConfiguredError
+from agentarea_tasks.infrastructure.repository import TaskEventRepository
 from agentarea_tasks.schemas.dto import RunCreate
 from agentarea_tasks.task_service import TaskService
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -1726,7 +1728,7 @@ async def resolve_task_escalation(
 async def get_task_events(
     agent_id: UUID,
     task_id: UUID,
-    user_context: UserContextDep,
+    repository_factory: ReadRepositoryFactoryDep,
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=100, description="Number of events per page"),
     event_type: str | None = Query(None, description="Filter by event type"),
@@ -1739,74 +1741,39 @@ async def get_task_events(
         raise HTTPException(status_code=404, detail="Agent not found")
 
     try:
-        from agentarea_api.api.deps.database import get_db_session
-        from sqlalchemy import text
+        # Read through the workspace-scoped repository. The check above only
+        # proves the caller owns an agent with this id — `agent_id` is a route
+        # parameter and is never tied to the task — so the workspace filter
+        # inside the repository is the actual authorization boundary here.
+        event_repository = repository_factory.create_repository(TaskEventRepository)
+        records, total_events = await event_repository.list_for_task(
+            task_id,
+            event_type=event_type,
+            limit=page_size,
+            offset=(page - 1) * page_size,
+        )
 
-        # Get database session
-        async with get_db_session() as session:
-            # Build the query with optional event type filter
-            base_query = """
-                SELECT id, task_id, event_type, timestamp, data, event_metadata,
-                       COUNT(*) OVER() as total_count
-                FROM task_events
-                WHERE task_id = :task_id
-            """
-
-            params: dict[str, Any] = {"task_id": str(task_id)}
-
-            if event_type:
-                base_query += " AND event_type = :event_type"
-                params["event_type"] = event_type
-
-            base_query += """
-                ORDER BY timestamp ASC
-                LIMIT :limit OFFSET :offset
-            """
-
-            params.update({"limit": page_size, "offset": (page - 1) * page_size})
-
-            # Execute query
-            result = await session.execute(text(base_query), params)
-            rows = result.fetchall()
-
-        if not rows:
-            # No events found - return empty response
-            return TaskEventResponse(
-                events=[],
-                total=0,
-                page=page,
-                page_size=page_size,
-                has_next=False,
+        events = [
+            TaskEvent(
+                id=str(record.id),
+                task_id=str(record.task_id),
+                agent_id=str(agent_id),
+                execution_id=record.data.get("execution_id")
+                or record.metadata.get("execution_id", "unknown"),
+                timestamp=record.timestamp,
+                event_type=record.event_type,
+                message=record.data.get("message", f"Event: {record.event_type}"),
+                metadata=dict(record.data) if record.data else {},
             )
-
-        # Convert database rows to TaskEvent objects
-        total_events = rows[0].total_count if rows else 0
-        events = []
-
-        for row in rows:
-            events.append(
-                TaskEvent(
-                    id=str(row.id),
-                    task_id=str(row.task_id),
-                    agent_id=str(agent_id),
-                    execution_id=row.data.get("execution_id")
-                    or row.event_metadata.get("execution_id", "unknown"),
-                    timestamp=row.timestamp,
-                    event_type=row.event_type,
-                    message=row.data.get("message", f"Event: {row.event_type}"),
-                    metadata=dict(row.data) if row.data else {},
-                )
-            )
-
-        # Calculate pagination info
-        has_next = (page * page_size) < total_events
+            for record in records
+        ]
 
         return TaskEventResponse(
             events=events,
             total=total_events,
             page=page,
             page_size=page_size,
-            has_next=has_next,
+            has_next=(page * page_size) < total_events,
         )
 
     except Exception as e:

--- a/agentarea-platform/libs/tasks/agentarea_tasks/infrastructure/repository.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/infrastructure/repository.py
@@ -411,6 +411,39 @@ class TaskEventRepository(WorkspaceScopedRepository[TaskEventORM]):
 
         return [self._orm_to_domain(event_orm) for event_orm in event_orms]
 
+    async def list_for_task(
+        self,
+        task_id: UUID,
+        *,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[TaskEvent], int]:
+        """Return one workspace-scoped page of a task's events, plus the total.
+
+        Readers of ``task_events`` must come through here rather than hand-writing
+        SQL: the event payload carries message content and tool arguments, and a
+        query filtered on ``task_id`` alone reads across every workspace.
+        """
+        conditions = [TaskEventORM.task_id == task_id, self._get_workspace_filter()]
+        if event_type:
+            conditions.append(TaskEventORM.event_type == event_type)
+
+        total = (
+            await self.session.scalar(
+                select(func.count()).select_from(TaskEventORM).where(*conditions)
+            )
+        ) or 0
+
+        result = await self.session.execute(
+            select(TaskEventORM)
+            .where(*conditions)
+            .order_by(TaskEventORM.timestamp.asc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return [self._orm_to_domain(orm) for orm in result.scalars().all()], total
+
     async def get_events_by_type(
         self, event_type: str, limit: int = 100, offset: int = 0
     ) -> list[TaskEvent]:

--- a/agentarea-platform/libs/tasks/tests/unit/test_task_event_repository_scoping.py
+++ b/agentarea-platform/libs/tasks/tests/unit/test_task_event_repository_scoping.py
@@ -1,0 +1,91 @@
+"""`task_events` must never be readable across workspaces.
+
+The event payload carries message content, tool arguments and tool results, so a
+query filtered on ``task_id`` alone discloses the full transcript of any task in
+any workspace. These tests pin the workspace predicate onto every statement the
+repository issues, including the pagination count.
+
+TaskEventORM uses JSONB columns, which SQLite cannot compile, so this asserts on
+the emitted SQL rather than round-tripping through an in-memory database.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from agentarea_common.auth.context import UserContext
+from agentarea_tasks.infrastructure.repository import TaskEventRepository
+
+
+def _capturing_session() -> MagicMock:
+    session = MagicMock()
+    session.scalar = AsyncMock(return_value=0)
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+def _sql(statement) -> str:
+    return str(statement.compile())
+
+
+class TestListForTaskIsWorkspaceScoped:
+    @pytest.mark.asyncio
+    async def test_page_query_filters_by_workspace(self):
+        session = _capturing_session()
+        repo = TaskEventRepository(session, UserContext(user_id="alice", workspace_id="alice-ws"))
+
+        await repo.list_for_task(uuid4())
+
+        sql = _sql(session.execute.await_args.args[0])
+        assert "task_events.workspace_id" in sql
+        assert "task_events.task_id" in sql
+
+    @pytest.mark.asyncio
+    async def test_count_query_filters_by_workspace(self):
+        """The total drives has_next; an unscoped count leaks the size of foreign tasks."""
+        session = _capturing_session()
+        repo = TaskEventRepository(session, UserContext(user_id="alice", workspace_id="alice-ws"))
+
+        await repo.list_for_task(uuid4())
+
+        sql = _sql(session.scalar.await_args.args[0])
+        assert "task_events.workspace_id" in sql
+
+    @pytest.mark.asyncio
+    async def test_event_type_filter_does_not_drop_the_workspace_predicate(self):
+        session = _capturing_session()
+        repo = TaskEventRepository(session, UserContext(user_id="alice", workspace_id="alice-ws"))
+
+        await repo.list_for_task(uuid4(), event_type="LLMCallCompleted")
+
+        sql = _sql(session.execute.await_args.args[0])
+        assert "task_events.workspace_id" in sql
+        assert "task_events.event_type" in sql
+
+    @pytest.mark.asyncio
+    async def test_membership_widens_to_an_in_clause_not_to_everything(self):
+        session = _capturing_session()
+        context = UserContext(
+            user_id="alice",
+            workspace_id="alice-ws",
+            accessible_workspaces=["alice-ws", "shared-ws"],
+        )
+        repo = TaskEventRepository(session, context)
+
+        await repo.list_for_task(uuid4())
+
+        sql = _sql(session.execute.await_args.args[0])
+        assert "task_events.workspace_id IN" in sql
+
+    @pytest.mark.asyncio
+    async def test_returns_events_and_total(self):
+        session = _capturing_session()
+        session.scalar = AsyncMock(return_value=7)
+        repo = TaskEventRepository(session, UserContext(user_id="alice", workspace_id="alice-ws"))
+
+        events, total = await repo.list_for_task(uuid4(), limit=2, offset=4)
+
+        assert events == []
+        assert total == 7


### PR DESCRIPTION
The endpoint's only authorization step was `agent_service.get(agent_id)`, which
proves the caller owns *some* agent — `agent_id` is a route parameter and is
never related to the task. It then ran raw SQL filtered on `task_id` alone, so
any authenticated user could read the full event history of any task in any
workspace: message content, tool arguments and tool results. `user_context` was
injected into the handler and never reached the query.

The correct pattern was already in the same file: `get_task_summary` runs raw
SQL too and filters on task_id AND workspace_id AND agent_id. The difference was
not intent — `task_events` simply has no reason to be queried by hand. It has a
`WorkspaceScopedMixin` ORM model and a `TaskEventRepository` that were sitting
unused while this endpoint hand-wrote SQL around them.

Add `TaskEventRepository.list_for_task()` (workspace filter, optional event_type,
pagination total) and read through it. The count is scoped too — an unscoped
total would leak the size of foreign tasks through `has_next` even with the rows
filtered. Scoping now uses `_get_workspace_filter()`, so workspace memberships
are honoured as they are everywhere else.

Not addressed here, deliberately: `task_event_feed._load_snapshot` and
`task_service` also query `task_events` without a workspace predicate. Neither
is currently exploitable — their entry points resolve the task through the
workspace-scoped `task_service.get_task()` first — but they are safe by calling
convention rather than by construction. Threading workspace through the
streaming feed touches the A2A paths, which take their context from a
request-scoped global rather than an argument, so it does not belong in a
security fix.


Advisory: GHSA-pjvp-2gw3-cfh5

---