### PR TITLE
fix(logging): enforce the documented redact-then-sanitize filter order

### DIFF
--- a/agentarea-platform/libs/common/agentarea_common/logging/config.py
+++ b/agentarea-platform/libs/common/agentarea_common/logging/config.py
@@ -164,10 +164,16 @@ def install_log_filters() -> None:
         ),
     ):
         for handler in logger.handlers:
-            # Same order as the console handler: redact first, then strip control chars.
-            for filter_cls in (SecretRedactingFilter, LogSanitizerFilter):
-                if not any(isinstance(f, filter_cls) for f in handler.filters):
-                    handler.addFilter(filter_cls())
+            # Normalize rather than append. The console handler declares
+            # redact-then-sanitize, and only adding whichever filter is missing
+            # would invert that order on a handler that already carried the
+            # sanitizer — leaving the documented order and the real one apart.
+            others = [
+                f
+                for f in handler.filters
+                if not isinstance(f, SecretRedactingFilter | LogSanitizerFilter)
+            ]
+            handler.filters = [*others, SecretRedactingFilter(), LogSanitizerFilter()]
 
 
 def _current_trace_ids() -> dict[str, str]:

--- a/agentarea-platform/libs/common/tests/test_logging_sanitizer.py
+++ b/agentarea-platform/libs/common/tests/test_logging_sanitizer.py
@@ -120,3 +120,30 @@ class TestInstallLogFiltersCoversForeignHandlers:
             assert sum(isinstance(f, SecretRedactingFilter) for f in handler.filters) == 1
         finally:
             logger.removeHandler(handler)
+
+    def test_redaction_runs_before_sanitization_even_if_sanitizer_was_already_there(self):
+        """Order is documented as redact-then-sanitize; it has to hold, not just be stated."""
+        logger, handler, _ = self._foreign_logger("uvicorn.access.test_order")
+        handler.addFilter(LogSanitizerFilter())
+        try:
+            install_log_filters()
+
+            ours = [
+                type(f)
+                for f in handler.filters
+                if isinstance(f, SecretRedactingFilter | LogSanitizerFilter)
+            ]
+            assert ours == [SecretRedactingFilter, LogSanitizerFilter]
+        finally:
+            logger.removeHandler(handler)
+
+    def test_unrelated_filters_are_preserved(self):
+        logger, handler, _ = self._foreign_logger("uvicorn.access.test_preserve")
+        marker = logging.Filter(name="unrelated")
+        handler.addFilter(marker)
+        try:
+            install_log_filters()
+
+            assert marker in handler.filters
+        finally:
+            logger.removeHandler(handler)


### PR DESCRIPTION
Follow-up to #281. `install_log_filters()` claimed in a comment that it installs
the two filters in the same order the console handler declares them, but it only
added whichever one was missing. A handler that already carried
`LogSanitizerFilter` would get `SecretRedactingFilter` appended after it,
inverting the order the comment promised.

Not reachable today — the sanitizer only ever arrives via dictConfig, which
declares both in the right order, or via this function. But a comment asserting
a guarantee the code does not make is worse than no comment, and the invariant
matters: sanitization collapses message and args into one rendered string, so
running it before redaction changes what the redactor sees.

Normalize the handler's filter list instead of appending: drop our own filters
and re-add them in order, leaving any unrelated filters in place. Tests cover
the inverted-order case and that unrelated filters survive.

Reported by Copilot on #281.


---