### PR TITLE
fix(prompts): stop naming libraries in the base prompt; state scope and honesty rules

### DIFF
--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/prompts.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/prompts.py
@@ -49,8 +49,11 @@ Date: {current_date}
 
 - Think about what the task requires before acting. Understand the goal, then work towards it systematically.
 - Use available tools when they help achieve the goal. Prefer tool calls over guessing.
-- When you have completed the task, call the `completion` tool with your response in the result field. This is the ONLY way to finish.
-- If something is unclear, state your assumption and proceed. Do not stall.
+- Finish by calling the `completion` tool with your response in the result field.
+- The requested scope is the deliverable. Do not quietly narrow, widen, or transform it. If part of it turns out to be blocked, finish every other part and say which part you left out and why.
+- Report outcomes faithfully. If a step failed, could not be run, or produced nothing, say so in the result instead of implying success. An accurately described partial result is more useful than a confident summary of work that did not happen.
+- If something is unclear, state the assumption you made and proceed. Do not stall.
+- The user sees a card for each tool call with its status and any files it produced, but not the full output. Put the substance in your result rather than assuming it was already read.
 
 # Tone and Style
 

--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/file_toolset.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/file_toolset.py
@@ -258,8 +258,7 @@ class FileToolset(Toolset):
             return (
                 f"Error: save_file writes UTF-8 text only and would corrupt a .{_ext} file. "
                 "Produce binary deliverables by running a program in the shell that writes the "
-                "file into your workspace (e.g. python with openpyxl/python-pptx/python-docx/"
-                "reportlab, or matplotlib.savefig for images)."
+                "file into your workspace."
             )
         try:
             path = self._resolve(file_name)

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/runtime_discovery.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/runtime_discovery.py
@@ -95,10 +95,10 @@ def render_runtime_prompt(
         "visible to the user for this task. Use plain relative paths (e.g. `report.xlsx`); a "
         "file written to an absolute path outside your working directory is scratch and is "
         "NOT delivered.\n"
-        "- Binary deliverables (.xlsx, .pptx, .docx, .pdf, images): generate them by running a "
-        "program in the shell that writes the file into your working directory (e.g. python "
-        "with openpyxl/python-pptx/python-docx). The file tool saves text only, so writing "
-        "binary through it corrupts the file."
+        "- Binary deliverables (.xlsx, .pptx, .docx, .pdf, images): the file tool saves text "
+        "only, so writing binary through it corrupts the file. Generate them by running a "
+        "program in the shell that writes the file into your working directory, using a "
+        "library from the preinstalled packages listed above."
     )
 
 

--- a/agentarea-platform/uv.lock
+++ b/agentarea-platform/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "agentarea-agents"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/agents" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -94,7 +94,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-agents-sdk"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/agentarea-agents-sdk" }
 dependencies = [
     { name = "httpx" },
@@ -124,7 +124,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "agentarea-api"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "apps/api" }
 dependencies = [
     { name = "agentarea-agents" },
@@ -189,7 +189,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-bundles"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/bundles" }
 dependencies = [
     { name = "agentarea-agents" },
@@ -214,7 +214,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-common"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/common" }
 dependencies = [
     { name = "asyncpg" },
@@ -255,7 +255,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-execution"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/execution" }
 dependencies = [
     { name = "agentarea-agents-sdk" },
@@ -289,7 +289,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "agentarea-governance"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/governance" }
 dependencies = [
     { name = "agentarea-common" },
@@ -315,7 +315,7 @@ provides-extras = ["temporal"]
 
 [[package]]
 name = "agentarea-llm"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/llm" }
 dependencies = [
     { name = "agentarea-common" },
@@ -332,7 +332,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-mcp"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/mcp" }
 dependencies = [
     { name = "agentarea-common" },
@@ -349,7 +349,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-openapi"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/openapi" }
 dependencies = [
     { name = "agentarea-common" },
@@ -368,7 +368,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-payment"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/payment" }
 dependencies = [
     { name = "agentarea-common" },
@@ -406,7 +406,7 @@ provides-extras = ["x402", "mpp", "all"]
 
 [[package]]
 name = "agentarea-projects"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/projects" }
 dependencies = [
     { name = "agentarea-common" },
@@ -421,7 +421,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-registry"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/registry" }
 dependencies = [
     { name = "agentarea-common" },
@@ -440,7 +440,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-secrets"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/secrets" }
 dependencies = [
     { name = "agentarea-common" },
@@ -457,7 +457,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-tasks"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/tasks" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -478,7 +478,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-triggers"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/triggers" }
 dependencies = [
     { name = "agentarea-common" },
@@ -497,7 +497,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-wallet"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "libs/wallet" }
 dependencies = [
     { name = "agentarea-common" },
@@ -514,7 +514,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-worker"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "apps/worker" }
 dependencies = [
     { name = "agentarea-agents" },
@@ -547,7 +547,7 @@ requires-dist = [
 
 [[package]]
 name = "agentarea-workspace"
-version = "0.0.12"
+version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -127,6 +127,26 @@ def main():
                 go_file.write_text(updated)
                 print(f"✅ Updated {go_file.relative_to(root_dir)}")
 
+    # Refresh uv.lock: the workspace members are editable entries carrying their
+    # own version, so bumping the pyproject files alone leaves the lock behind.
+    # CI runs `uv sync` without --frozen and silently rewrites it, which hides
+    # the drift until someone gets an unrelated dirty uv.lock in their diff.
+    platform_dir = root_dir / 'agentarea-platform'
+    if (platform_dir / 'uv.lock').exists():
+        try:
+            subprocess.run(
+                ['uv', 'lock'],
+                cwd=platform_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            print("✅ Updated agentarea-platform/uv.lock")
+        except FileNotFoundError:
+            print("⚠️  Warning: uv not found; uv.lock left stale")
+        except subprocess.CalledProcessError as e:
+            print(f"⚠️  Warning: Failed to refresh uv.lock: {e.stderr}")
+
     print(f"\n✅ All versions bumped to {new_version}")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Following how Claude Code and Codex write their prompts: the base stays
library-agnostic and states the harness's own invariants, while concrete
"use this library like this" knowledge belongs in a skill loaded on demand.

Two places hardcoded package names in prose, and they had already drifted apart:
runtime_discovery listed openpyxl/python-pptx/python-docx, file_toolset listed
those plus reportlab and matplotlib. Neither named a PDF-capable library while
both advertised .pdf as a supported deliverable. All of it sat two lines below
the manifest's own `Preinstalled Python packages:` list, which is generated from
what actually installed and cannot go stale. Point at that instead.

System prompt guidelines:

- Drop "This is the ONLY way to finish". It is false —
  agent_execution_workflow treats a text-only reply as an implicit completion,
  by design and with a comment saying so. Telling the model otherwise misstates
  its own completion contract.
- Add scope discipline: don't quietly narrow or widen the request; if part is
  blocked, finish the rest and say what was left out.
- Add faithful reporting. Nothing counteracted the pull to declare success —
  the only instructions were to finish and not stall, so a partially failed run
  had no sanctioned way to say so.
- Say what the user actually sees: a card per tool call with status and produced
  files, not the full output, so the substance belongs in the result.

Deliberately not added, because this harness cannot honour them: an instruction
to ask the user (no such tool is exposed — the escalation read side exists in
inbox.py but nothing emits HumanApprovalRequested), and an instruction to
parallelize tool calls (only agent delegations run concurrently; regular tools
are sequential on purpose).

Also make bump-version.py refresh uv.lock. Workspace members are editable
entries carrying their own version, so bumping the pyproject files left the lock
on the previous release; CI runs `uv sync` without --frozen and silently
rewrote it, hiding the drift until it showed up as an unrelated dirty file in
someone's diff. The lock change here is v0.0.13 catching up.


---