### PR TITLE
fix(mcp-manager): confine MCP containers on the docker backend

### DIFF
--- a/agentarea-mcp-manager/internal/backends/docker_backend.go
+++ b/agentarea-mcp-manager/internal/backends/docker_backend.go
@@ -107,7 +107,13 @@ func (d *DockerBackend) CreateInstance(ctx context.Context, spec *InstanceSpec) 
 		slog.String("image", spec.Image))
 
 	// Convert InstanceSpec to models.CreateContainerRequest
-	req := d.specToCreateRequest(spec)
+	req, err := d.specToCreateRequest(spec)
+	if err != nil {
+		d.logger.Error("Failed to resolve instance isolation",
+			slog.String("name", spec.Name),
+			slog.String("error", err.Error()))
+		return nil, err
+	}
 
 	// Use existing manager to create container
 	container, err := d.manager.CreateContainer(ctx, req)
@@ -338,7 +344,7 @@ func (d *DockerBackend) Shutdown(ctx context.Context) error {
 // Helper methods
 
 // specToCreateRequest converts InstanceSpec to models.CreateContainerRequest
-func (d *DockerBackend) specToCreateRequest(spec *InstanceSpec) models.CreateContainerRequest {
+func (d *DockerBackend) specToCreateRequest(spec *InstanceSpec) (models.CreateContainerRequest, error) {
 	req := models.CreateContainerRequest{
 		ServiceName: spec.ServiceName,
 		Image:       spec.Image,
@@ -347,6 +353,27 @@ func (d *DockerBackend) specToCreateRequest(spec *InstanceSpec) models.CreateCon
 		Labels:      spec.Labels,
 		Command:     spec.Command,
 	}
+
+	// Resolve the confinement for this workload. An MCP server is third-party
+	// code, so the default is a confined tier, not the daemon's defaults.
+	tier := spec.IsolationTier
+	if tier == "" {
+		tier = d.config.Container.DefaultIsolationTier
+	}
+	isolation, err := config.ResolveIsolation(tier)
+	if err != nil {
+		return models.CreateContainerRequest{}, err
+	}
+	// The spec's explicit runtime/writable paths refine the resolved tier; they
+	// never weaken it, since a stricter runtime is the only thing they can add.
+	if spec.RuntimeClass != "" {
+		isolation.Runtime = spec.RuntimeClass
+	}
+	if len(spec.WritablePaths) > 0 {
+		isolation.ReadOnlyRootFilesystem = true
+		isolation.WritablePaths = spec.WritablePaths
+	}
+	req.Isolation = isolation
 
 	// Add resource limits if specified
 	if spec.Resources.Limits.Memory != "" {
@@ -364,7 +391,7 @@ func (d *DockerBackend) specToCreateRequest(spec *InstanceSpec) models.CreateCon
 	req.Environment["MCP_SERVICE_NAME"] = spec.ServiceName
 	req.Environment["MCP_CONTAINER_PORT"] = fmt.Sprintf("%d", spec.Port)
 
-	return req
+	return req, nil
 }
 
 // findServiceNameByID finds the service name by container ID or instance ID

--- a/agentarea-mcp-manager/internal/backends/interface.go
+++ b/agentarea-mcp-manager/internal/backends/interface.go
@@ -57,6 +57,13 @@ type InstanceSpec struct {
 	// Runtime configuration
 	RuntimeClass string `json:"runtime_class,omitempty"`
 
+	// IsolationTier names the confinement this workload gets ("trusted",
+	// "standard", "untrusted"). It declares what we assume about the code
+	// rather than a flag list, so a caller cannot forget one. Empty means the
+	// backend applies its configured default; RuntimeClass and WritablePaths
+	// above still override the resolved profile.
+	IsolationTier string `json:"isolation_tier,omitempty"`
+
 	// Metadata
 	InstanceID  string `json:"instance_id"`
 	WorkspaceID string `json:"workspace_id,omitempty"`

--- a/agentarea-mcp-manager/internal/config/config.go
+++ b/agentarea-mcp-manager/internal/config/config.go
@@ -71,6 +71,11 @@ type ContainerConfig struct {
 	DefaultMemoryLimit string `json:"default_memory_limit"`
 	DefaultCPULimit    string `json:"default_cpu_limit"`
 
+	// DefaultIsolationTier is the confinement applied to instances whose spec
+	// does not name one. It defaults to "standard" rather than "trusted"
+	// because the containers this manager starts are third-party MCP servers.
+	DefaultIsolationTier string `json:"default_isolation_tier"`
+
 	// SandboxExecutorURL is the HTTP endpoint of the sandbox-executor data
 	// plane used by the docker backend (dev/compose). When set, sandbox
 	// executions are routed here instead of a Kubernetes warm pod.
@@ -111,6 +116,8 @@ func Load() *Config {
 			DefaultMemoryLimit: getEnv("DEFAULT_MEMORY_LIMIT", "512m"),
 			DefaultCPULimit:    getEnv("DEFAULT_CPU_LIMIT", "1.0"),
 			SandboxExecutorURL: getEnv("SANDBOX_EXECUTOR_URL", ""),
+
+			DefaultIsolationTier: getEnv("DEFAULT_ISOLATION_TIER", IsolationStandard),
 		},
 		Logging: LoggingConfig{
 			Level:  getEnv("LOG_LEVEL", "INFO"),

--- a/agentarea-mcp-manager/internal/config/isolation.go
+++ b/agentarea-mcp-manager/internal/config/isolation.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+// Isolation tiers. The tier names what we assume about the code, so the call
+// site declares trust rather than remembering a flag list.
+const (
+	// IsolationTrusted is for images we build and ship ourselves.
+	IsolationTrusted = "trusted"
+	// IsolationStandard is for third-party MCP servers from the catalog:
+	// confined, but on the host's default runtime.
+	IsolationStandard = "standard"
+	// IsolationUntrusted is for code a user supplied — custom MCP servers and
+	// agent-authored programs. Adds a syscall-interposing runtime on top.
+	IsolationUntrusted = "untrusted"
+)
+
+// UntrustedRuntime is the runtime class the untrusted tier asks for. gVisor's
+// runsc needs no KVM (systrap), so it is the portable choice; deployments with
+// /dev/kvm can point this at a microVM runtime instead.
+const UntrustedRuntime = "runsc"
+
+// isolationProfiles maps a tier to its resolved settings. Everything except the
+// trusted tier drops all capabilities and blocks privilege escalation — those
+// are cheap and break almost nothing, so the tiers differ mainly in runtime.
+var isolationProfiles = map[string]models.Isolation{
+	IsolationTrusted: {
+		Profile:         IsolationTrusted,
+		NoNewPrivileges: true,
+	},
+	IsolationStandard: {
+		Profile:          IsolationStandard,
+		DropCapabilities: []string{"ALL"},
+		NoNewPrivileges:  true,
+		PidsLimit:        512,
+	},
+	IsolationUntrusted: {
+		Profile:          IsolationUntrusted,
+		Runtime:          UntrustedRuntime,
+		DropCapabilities: []string{"ALL"},
+		NoNewPrivileges:  true,
+		PidsLimit:        256,
+	},
+}
+
+// ResolveIsolation returns the profile for a tier.
+//
+// An unknown tier is an error, never a silent fallback to a weaker one: a typo
+// in a deployment value must stop the workload, not quietly run third-party
+// code unconfined.
+func ResolveIsolation(tier string) (models.Isolation, error) {
+	profile, ok := isolationProfiles[tier]
+	if !ok {
+		return models.Isolation{}, fmt.Errorf(
+			"unknown isolation tier %q (known: %v)", tier, IsolationTiers(),
+		)
+	}
+	// Copy the slice so a caller appending to it cannot mutate the table.
+	profile.DropCapabilities = append([]string(nil), profile.DropCapabilities...)
+	return profile, nil
+}
+
+// IsolationTiers lists the known tiers in a stable order, for error messages
+// and operator-facing output.
+func IsolationTiers() []string {
+	tiers := make([]string, 0, len(isolationProfiles))
+	for name := range isolationProfiles {
+		tiers = append(tiers, name)
+	}
+	sort.Strings(tiers)
+	return tiers
+}

--- a/agentarea-mcp-manager/internal/container/isolation.go
+++ b/agentarea-mcp-manager/internal/container/isolation.go
@@ -1,0 +1,113 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+// isolationRunArgs renders an Isolation into `docker run` flags.
+//
+// Kept separate from buildContainerRunArgs so the mapping is testable without
+// constructing a Manager, and so the Kubernetes backend's equivalent (pod
+// security context) can be diffed against one readable list.
+func isolationRunArgs(iso models.Isolation) []string {
+	var args []string
+
+	if iso.Runtime != "" {
+		args = append(args, "--runtime", iso.Runtime)
+	}
+
+	for _, capability := range iso.DropCapabilities {
+		args = append(args, "--cap-drop", capability)
+	}
+
+	if iso.NoNewPrivileges {
+		args = append(args, "--security-opt", "no-new-privileges")
+	}
+
+	if iso.PidsLimit > 0 {
+		args = append(args, "--pids-limit", fmt.Sprintf("%d", iso.PidsLimit))
+	}
+
+	if iso.User != "" {
+		args = append(args, "--user", iso.User)
+	}
+
+	if iso.ReadOnlyRootFilesystem {
+		args = append(args, "--read-only")
+		// Without writable scratch a read-only rootfs breaks most images, so
+		// every declared path becomes a tmpfs rather than a host bind: the
+		// workload gets somewhere to write that does not outlive it.
+		for _, path := range iso.WritablePaths {
+			args = append(args, "--tmpfs", fmt.Sprintf("%s:rw,nosuid,nodev", path))
+		}
+	}
+
+	return args
+}
+
+// ensureRuntimeAvailable fails closed when the workload asked for a container
+// runtime this host does not have.
+//
+// Docker would otherwise reject `--runtime=runsc` at run time with a generic
+// error, which reads as "container failed to start" and invites a retry without
+// the flag. Checking up front makes the security requirement the explicit
+// reason for the refusal.
+func (m *Manager) ensureRuntimeAvailable(ctx context.Context, iso models.Isolation) error {
+	if !iso.RequiresRuntime() {
+		return nil
+	}
+
+	available, err := m.availableRuntimes(ctx)
+	if err != nil {
+		// Do not assume the runtime is present when we cannot tell.
+		return fmt.Errorf("cannot verify container runtime %q is installed: %w", iso.Runtime, err)
+	}
+	if slices.Contains(available, iso.Runtime) {
+		return nil
+	}
+	return &ErrRuntimeUnavailable{Runtime: iso.Runtime, Available: available}
+}
+
+// availableRuntimes lists the runtimes the daemon has registered.
+func (m *Manager) availableRuntimes(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, m.config.Container.Runtime, "info", "--format", "{{json .Runtimes}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("querying %s info: %w", m.config.Container.Runtime, err)
+	}
+
+	var runtimes map[string]any
+	if err := json.Unmarshal(out, &runtimes); err != nil {
+		return nil, fmt.Errorf("parsing runtime list: %w", err)
+	}
+
+	names := make([]string, 0, len(runtimes))
+	for name := range runtimes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// ErrRuntimeUnavailable reports that the isolation a workload asked for cannot
+// be provided by this daemon. It is a distinct error so callers can tell an
+// unmet security requirement apart from a generic Docker failure.
+type ErrRuntimeUnavailable struct {
+	Runtime   string
+	Available []string
+}
+
+func (e *ErrRuntimeUnavailable) Error() string {
+	return fmt.Sprintf(
+		"container runtime %q is not installed on this host (available: %s); refusing to start without the requested isolation",
+		e.Runtime, strings.Join(e.Available, ", "),
+	)
+}

--- a/agentarea-mcp-manager/internal/container/isolation_test.go
+++ b/agentarea-mcp-manager/internal/container/isolation_test.go
@@ -1,0 +1,141 @@
+package container
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/agentarea/mcp-manager/internal/config"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+// hasFlagPair reports whether args contains `flag value` adjacently.
+func hasFlagPair(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIsolationRunArgsRendersEachSetting(t *testing.T) {
+	args := isolationRunArgs(models.Isolation{
+		Runtime:                "runsc",
+		DropCapabilities:       []string{"ALL"},
+		NoNewPrivileges:        true,
+		ReadOnlyRootFilesystem: true,
+		WritablePaths:          []string{"/tmp", "/var/run"},
+		PidsLimit:              256,
+		User:                   "10001:10001",
+	})
+
+	for _, want := range [][2]string{
+		{"--runtime", "runsc"},
+		{"--cap-drop", "ALL"},
+		{"--security-opt", "no-new-privileges"},
+		{"--pids-limit", "256"},
+		{"--user", "10001:10001"},
+		{"--tmpfs", "/tmp:rw,nosuid,nodev"},
+		{"--tmpfs", "/var/run:rw,nosuid,nodev"},
+	} {
+		if !hasFlagPair(args, want[0], want[1]) {
+			t.Errorf("missing %s %s in %v", want[0], want[1], args)
+		}
+	}
+	if !slices.Contains(args, "--read-only") {
+		t.Errorf("missing --read-only in %v", args)
+	}
+}
+
+func TestIsolationRunArgsEmptyForZeroValue(t *testing.T) {
+	// A zero Isolation must not silently invent confinement — callers resolve a
+	// named tier, and rendering defaults here would hide a missing resolution.
+	if args := isolationRunArgs(models.Isolation{}); len(args) != 0 {
+		t.Errorf("expected no flags for zero isolation, got %v", args)
+	}
+}
+
+func TestIsolationRunArgsOmitsTmpfsWithoutReadOnlyRoot(t *testing.T) {
+	// tmpfs mounts exist to make a read-only rootfs usable; without one they
+	// would silently shadow real image directories.
+	args := isolationRunArgs(models.Isolation{WritablePaths: []string{"/tmp"}})
+	if slices.Contains(args, "--tmpfs") {
+		t.Errorf("tmpfs applied without read-only rootfs: %v", args)
+	}
+}
+
+func TestResolvedTiersConfineThirdPartyCode(t *testing.T) {
+	// standard and untrusted both run third-party code: dropping capabilities
+	// and blocking privilege escalation is the floor for both.
+	for _, tier := range []string{config.IsolationStandard, config.IsolationUntrusted} {
+		iso, err := config.ResolveIsolation(tier)
+		if err != nil {
+			t.Fatalf("resolving %s: %v", tier, err)
+		}
+		args := isolationRunArgs(iso)
+		if !hasFlagPair(args, "--cap-drop", "ALL") {
+			t.Errorf("%s does not drop capabilities: %v", tier, args)
+		}
+		if !hasFlagPair(args, "--security-opt", "no-new-privileges") {
+			t.Errorf("%s allows privilege escalation: %v", tier, args)
+		}
+	}
+}
+
+func TestUntrustedTierAsksForASyscallInterposingRuntime(t *testing.T) {
+	iso, err := config.ResolveIsolation(config.IsolationUntrusted)
+	if err != nil {
+		t.Fatalf("resolving untrusted: %v", err)
+	}
+	if iso.Runtime != config.UntrustedRuntime {
+		t.Errorf("untrusted tier runtime = %q, want %q", iso.Runtime, config.UntrustedRuntime)
+	}
+	if !iso.RequiresRuntime() {
+		t.Error("untrusted tier must report that it requires a runtime, so callers fail closed")
+	}
+}
+
+func TestStandardTierDoesNotRequireASpecialRuntime(t *testing.T) {
+	// standard must stay deployable on a stock daemon, otherwise every catalog
+	// MCP server would refuse to start on hosts without gVisor.
+	iso, err := config.ResolveIsolation(config.IsolationStandard)
+	if err != nil {
+		t.Fatalf("resolving standard: %v", err)
+	}
+	if iso.RequiresRuntime() {
+		t.Errorf("standard tier requires runtime %q; it must run on a stock daemon", iso.Runtime)
+	}
+}
+
+func TestResolveIsolationRejectsUnknownTier(t *testing.T) {
+	// A typo in a deployment value must stop the workload, not quietly run
+	// third-party code unconfined.
+	if _, err := config.ResolveIsolation("untrused"); err == nil {
+		t.Fatal("expected an error for an unknown tier, got nil")
+	}
+}
+
+func TestResolveIsolationDoesNotAliasTheProfileTable(t *testing.T) {
+	first, err := config.ResolveIsolation(config.IsolationUntrusted)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	first.DropCapabilities = append(first.DropCapabilities, "MUTATED")
+
+	second, err := config.ResolveIsolation(config.IsolationUntrusted)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if slices.Contains(second.DropCapabilities, "MUTATED") {
+		t.Error("mutating a resolved profile leaked into the shared table")
+	}
+}
+
+func TestErrRuntimeUnavailableNamesWhatWasRefused(t *testing.T) {
+	err := &ErrRuntimeUnavailable{Runtime: "runsc", Available: []string{"runc"}}
+	msg := err.Error()
+	if !strings.Contains(msg, "runsc") || !strings.Contains(msg, "runc") {
+		t.Errorf("error should name requested and available runtimes: %q", msg)
+	}
+}

--- a/agentarea-mcp-manager/internal/container/manager.go
+++ b/agentarea-mcp-manager/internal/container/manager.go
@@ -191,6 +191,13 @@ func (m *Manager) CreateContainer(ctx context.Context, req models.CreateContaine
 		Labels:      req.Labels,
 		Environment: req.Environment,
 		Command:     req.Command,
+		Isolation:   req.Isolation,
+	}
+
+	// Refuse rather than silently downgrade: starting third-party code without
+	// the isolation it was assigned is worse than not starting it.
+	if err := m.ensureRuntimeAvailable(ctx, container.Isolation); err != nil {
+		return nil, err
 	}
 
 	// Build container run command (Traefik labels are added automatically)
@@ -554,6 +561,11 @@ func (m *Manager) buildContainerRunArgs(container *models.Container) []string {
 		"--label", fmt.Sprintf("traefik.http.middlewares.%s-strip.stripprefix.prefixes=/mcp/%s", slug, slug),
 		"--label", fmt.Sprintf("traefik.http.routers.%s.middlewares=%s-strip", slug, slug),
 	)
+
+	// Add isolation flags. MCP servers are third-party code; without these the
+	// container runs with the daemon's full default capability set next to the
+	// control plane.
+	args = append(args, isolationRunArgs(container.Isolation)...)
 
 	// Add default resource limits
 	if m.config.Container.DefaultMemoryLimit != "" {

--- a/agentarea-mcp-manager/internal/models/isolation.go
+++ b/agentarea-mcp-manager/internal/models/isolation.go
@@ -1,0 +1,49 @@
+package models
+
+// Isolation is the resolved sandboxing applied to one workload container.
+//
+// It is a property of WHAT is being run, not of WHERE it runs: an MCP server
+// from the public catalog and an agent's bash session are both third-party code
+// and both need confinement, whether the data plane is Docker or Kubernetes.
+// The Kubernetes backend has always expressed this through the pod security
+// context; carrying it here is what lets the Docker backend honour the same
+// contract instead of silently dropping it.
+//
+// A zero value means "no confinement declared" and must never be treated as
+// "confinement not needed" — callers resolve a named profile first.
+type Isolation struct {
+	// Profile is the tier this was resolved from, kept for logging and events.
+	Profile string `json:"profile,omitempty"`
+
+	// Runtime selects the container runtime (Docker `--runtime`, Kubernetes
+	// runtimeClassName), e.g. "runsc" for gVisor. Empty means the daemon
+	// default, which is normally runc and provides no extra isolation.
+	Runtime string `json:"runtime,omitempty"`
+
+	// DropCapabilities lists Linux capabilities to drop; ["ALL"] is the norm.
+	DropCapabilities []string `json:"drop_capabilities,omitempty"`
+
+	// NoNewPrivileges blocks setuid/setgid escalation inside the container.
+	NoNewPrivileges bool `json:"no_new_privileges,omitempty"`
+
+	// ReadOnlyRootFilesystem mounts the image read-only. WritablePaths get
+	// tmpfs mounts so the workload still has scratch space.
+	ReadOnlyRootFilesystem bool `json:"read_only_root_filesystem,omitempty"`
+
+	// WritablePaths are the only paths writable under a read-only rootfs.
+	WritablePaths []string `json:"writable_paths,omitempty"`
+
+	// PidsLimit caps process count, bounding fork-bomb blast radius. 0 = unset.
+	PidsLimit int `json:"pids_limit,omitempty"`
+
+	// User is the uid[:gid] the entrypoint runs as. Empty keeps the image's own
+	// USER, which is frequently root.
+	User string `json:"user,omitempty"`
+}
+
+// RequiresRuntime reports whether this isolation depends on a non-default
+// container runtime being installed. Callers use it to fail closed rather than
+// starting an unconfined container when the runtime is missing.
+func (i Isolation) RequiresRuntime() bool {
+	return i.Runtime != ""
+}

--- a/agentarea-mcp-manager/internal/models/models.go
+++ b/agentarea-mcp-manager/internal/models/models.go
@@ -50,6 +50,7 @@ type Container struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Command     []string          `json:"command,omitempty"`
+	Isolation   Isolation         `json:"isolation,omitzero"`
 }
 
 // VolumeMount represents a volume mount
@@ -70,6 +71,7 @@ type CreateContainerRequest struct {
 	Volumes     []VolumeMount     `json:"volumes,omitempty"`
 	MemoryLimit string            `json:"memory_limit,omitempty"`
 	CPULimit    string            `json:"cpu_limit,omitempty"`
+	Isolation   Isolation         `json:"isolation,omitzero"`
 }
 
 // HealthResponse represents the health check response

--- a/deploy/sandbox-host/roles/sandbox_host/defaults/main.yml
+++ b/deploy/sandbox-host/roles/sandbox_host/defaults/main.yml
@@ -30,8 +30,13 @@ sandbox_runsc_smoketest_image: "mirror.gcr.io/library/alpine:3"
 sandbox_registry_mirrors:
   - "https://mirror.gcr.io"
 
-# Sandbox executor image (built from agentarea-mcp-manager/Dockerfile.runner).
-sandbox_executor_image: "agentarea/sandbox-executor:latest"
+# Sandbox executor image. This is the image CI publishes from
+# agentarea-mcp-manager/Dockerfile.runner — the same artifact the Kubernetes
+# warm pool runs, so a release reaches both data planes. It previously named an
+# image that was never published, which meant the pull always failed and the
+# host silently kept running whatever had been loaded onto it by hand: security
+# updates to the preinstalled parsers never arrived.
+sandbox_executor_image: "agentarea/agentarea-mcp-runner:latest"
 # Run the long-lived executor container now. Host provisioning (Docker + gVisor
 # + hardening) is useful on its own, so this can be turned off to prep a host.
 sandbox_executor_enabled: true

--- a/deploy/sandbox-host/roles/sandbox_host/tasks/executor.yml
+++ b/deploy/sandbox-host/roles/sandbox_host/tasks/executor.yml
@@ -1,4 +1,20 @@
 ---
+# Pull here, loudly, rather than relying on the unit's best-effort ExecStartPre.
+# That pull ignores failures on purpose so a transient registry outage cannot
+# stop a restart — but it also means a wrong or unpublished image name never
+# surfaces, and the host keeps running a stale executor indefinitely. Deploy is
+# the right place for that to be an error.
+- name: Pull the sandbox executor image
+  ansible.builtin.command:
+    argv:
+      - docker
+      - pull
+      - "{{ sandbox_executor_image }}"
+  register: _executor_pull
+  changed_when: "'Downloaded newer image' in _executor_pull.stdout"
+  when: sandbox_executor_enabled | bool
+  notify: Restart sandbox-executor
+
 - name: Ensure agentarea config directory
   ansible.builtin.file:
     path: /etc/agentarea


### PR DESCRIPTION
`InstanceSpec` has carried `RuntimeClass` and `WritablePaths` ("security
sandbox") all along, and the Kubernetes backend honours them — it builds a pod
securityContext and sets runtimeClassName. The Docker backend dropped both:
`specToCreateRequest` never copied them, `models.CreateContainerRequest` had no
field to copy them into, and `buildContainerRunArgs` emitted only
--name/--network/-e/--label/--memory/--cpus. Nothing set them either, so the
fields were declared, half-implemented and unused.

The result was a lopsided trust boundary. Agent bash runs under gVisor on a
dedicated host with caps dropped and egress filtered (deploy/sandbox-host).
MCP servers — third-party code a user installs from the catalog — ran with the
daemon's full default capability set, on the control plane's own host, on the
backend we actually deploy today.

Introduce isolation as a named tier rather than a flag list, so a call site
declares what it assumes about the code and cannot forget a flag:

- trusted    — images we build and ship
- standard   — catalog MCP servers: caps dropped, no-new-privileges, pids capped
- untrusted  — user-supplied code: the above plus a syscall-interposing runtime

`models.Isolation` carries the resolved settings; `config.ResolveIsolation` maps
a tier to them and rejects an unknown tier instead of falling back to a weaker
one. The docker backend resolves the tier (default `standard`, override with
DEFAULT_ISOLATION_TIER) and the manager renders the flags.

Fail closed on the runtime: if a workload asks for a runtime class the daemon
does not have, refuse with ErrRuntimeUnavailable naming what was requested and
what exists. Docker's own error for a missing --runtime reads as a generic
start failure and invites a retry without the flag, which is exactly the
downgrade this is meant to prevent.

Kubernetes behaviour is unchanged; this only closes the gap on the docker path.

Also fix delivery to the gVisor hosts. The Ansible role pointed at
`agentarea/sandbox-executor`, which CI has never published, and the unit's
`ExecStartPre=-docker pull` swallows the resulting failure and starts whatever
was loaded by hand — so v0.0.13's pillow/pypdf/lxml fixes never arrived. Point
it at the published `agentarea/agentarea-mcp-runner` (the same artifact the
Kubernetes warm pool runs) and pull explicitly at deploy time, where a bad image
name is an error. The unit keeps its best-effort pull so a transient registry
outage cannot block a restart.


---