### PR TITLE
fix(mcp-manager): make both backends honour one isolation contract

### DIFF
--- a/agentarea-mcp-manager/internal/backends/docker_backend.go
+++ b/agentarea-mcp-manager/internal/backends/docker_backend.go
@@ -356,22 +356,9 @@ func (d *DockerBackend) specToCreateRequest(spec *InstanceSpec) (models.CreateCo
 
 	// Resolve the confinement for this workload. An MCP server is third-party
 	// code, so the default is a confined tier, not the daemon's defaults.
-	tier := spec.IsolationTier
-	if tier == "" {
-		tier = d.config.Container.DefaultIsolationTier
-	}
-	isolation, err := config.ResolveIsolation(tier)
+	isolation, err := resolveSpecIsolation(spec, d.config.Container.DefaultIsolationTier)
 	if err != nil {
 		return models.CreateContainerRequest{}, err
-	}
-	// The spec's explicit runtime/writable paths refine the resolved tier; they
-	// never weaken it, since a stricter runtime is the only thing they can add.
-	if spec.RuntimeClass != "" {
-		isolation.Runtime = spec.RuntimeClass
-	}
-	if len(spec.WritablePaths) > 0 {
-		isolation.ReadOnlyRootFilesystem = true
-		isolation.WritablePaths = spec.WritablePaths
 	}
 	req.Isolation = isolation
 

--- a/agentarea-mcp-manager/internal/backends/isolation.go
+++ b/agentarea-mcp-manager/internal/backends/isolation.go
@@ -1,0 +1,68 @@
+package backends
+
+import (
+	"slices"
+
+	"github.com/agentarea/mcp-manager/internal/config"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+// resolveSpecIsolation turns a spec's declared tier into concrete settings.
+//
+// Both backends call this so the meaning of a tier is defined once. What each
+// backend then does with it differs — Docker renders flags, Kubernetes builds a
+// pod security context — but "what does untrusted mean" must not.
+func resolveSpecIsolation(spec *InstanceSpec, defaultTier string) (models.Isolation, error) {
+	tier := spec.IsolationTier
+	if tier == "" {
+		tier = defaultTier
+	}
+
+	isolation, err := config.ResolveIsolation(tier)
+	if err != nil {
+		return models.Isolation{}, err
+	}
+
+	// An explicit runtime/writable-path on the spec refines the tier. Neither
+	// can weaken it: a runtime class is an addition, and marking paths writable
+	// only takes effect together with a read-only root.
+	if spec.RuntimeClass != "" {
+		isolation.Runtime = spec.RuntimeClass
+	}
+	if len(spec.WritablePaths) > 0 {
+		isolation.ReadOnlyRootFilesystem = true
+		isolation.WritablePaths = spec.WritablePaths
+	}
+
+	return isolation, nil
+}
+
+// tightenDropCapabilities merges the operator's configured drops with the
+// tier's. Dropping a capability twice is harmless; missing one is not, so the
+// union is the safe combination.
+func tightenDropCapabilities(configured []string, iso models.Isolation) []string {
+	merged := append([]string(nil), configured...)
+	for _, capability := range iso.DropCapabilities {
+		if !slices.Contains(merged, capability) {
+			merged = append(merged, capability)
+		}
+	}
+	return merged
+}
+
+// tightenRuntimeClass picks the runtime class for a workload.
+//
+// The operator's cluster-wide class always wins: a per-workload request must
+// never be able to drop a sandbox runtime the cluster enforces. Below that, a
+// tier asking for a runtime (untrusted wanting gVisor) outranks a bare spec
+// field, because the tier is the platform's judgement about the code and the
+// spec field is the caller's.
+func tightenRuntimeClass(configured string, iso models.Isolation, specRuntimeClass string) string {
+	if configured != "" {
+		return configured
+	}
+	if iso.Runtime != "" {
+		return iso.Runtime
+	}
+	return specRuntimeClass
+}

--- a/agentarea-mcp-manager/internal/backends/isolation_test.go
+++ b/agentarea-mcp-manager/internal/backends/isolation_test.go
@@ -1,0 +1,94 @@
+package backends
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agentarea/mcp-manager/internal/config"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+func TestResolveSpecIsolationUsesDefaultTierWhenSpecIsSilent(t *testing.T) {
+	iso, err := resolveSpecIsolation(&InstanceSpec{}, config.IsolationUntrusted)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if iso.Profile != config.IsolationUntrusted {
+		t.Errorf("profile = %q, want %q", iso.Profile, config.IsolationUntrusted)
+	}
+}
+
+func TestResolveSpecIsolationPrefersTheSpecTier(t *testing.T) {
+	iso, err := resolveSpecIsolation(
+		&InstanceSpec{IsolationTier: config.IsolationUntrusted},
+		config.IsolationStandard,
+	)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if iso.Runtime != config.UntrustedRuntime {
+		t.Errorf("runtime = %q, want %q", iso.Runtime, config.UntrustedRuntime)
+	}
+}
+
+func TestResolveSpecIsolationRejectsUnknownTier(t *testing.T) {
+	// Fail closed: an unrecognised tier must not silently degrade to a weaker
+	// profile, or a typo in a deployment value would unconfine third-party code.
+	if _, err := resolveSpecIsolation(&InstanceSpec{IsolationTier: "nope"}, config.IsolationStandard); err == nil {
+		t.Fatal("expected an error for an unknown tier")
+	}
+}
+
+func TestResolveSpecIsolationWritablePathsImplyReadOnlyRoot(t *testing.T) {
+	iso, err := resolveSpecIsolation(
+		&InstanceSpec{WritablePaths: []string{"/tmp"}},
+		config.IsolationStandard,
+	)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if !iso.ReadOnlyRootFilesystem {
+		t.Error("declaring writable paths must turn on the read-only root they carve out of")
+	}
+}
+
+func TestTightenRuntimeClassOperatorWins(t *testing.T) {
+	// A cluster-wide sandbox runtime must not be removable by a workload, or
+	// the per-workload knob becomes a downgrade path.
+	got := tightenRuntimeClass("kata-qemu", models.Isolation{Runtime: "runsc"}, "runc")
+	if got != "kata-qemu" {
+		t.Errorf("got %q, want the operator's kata-qemu", got)
+	}
+}
+
+func TestTightenRuntimeClassFallsBackToTierThenSpec(t *testing.T) {
+	if got := tightenRuntimeClass("", models.Isolation{Runtime: "runsc"}, "runc"); got != "runsc" {
+		t.Errorf("tier runtime should outrank the spec field, got %q", got)
+	}
+	if got := tightenRuntimeClass("", models.Isolation{}, "runc"); got != "runc" {
+		t.Errorf("spec field should apply when nothing else does, got %q", got)
+	}
+	if got := tightenRuntimeClass("", models.Isolation{}, ""); got != "" {
+		t.Errorf("expected empty (daemon default), got %q", got)
+	}
+}
+
+func TestTightenDropCapabilitiesIsAUnion(t *testing.T) {
+	got := tightenDropCapabilities([]string{"NET_RAW"}, models.Isolation{DropCapabilities: []string{"ALL", "NET_RAW"}})
+
+	if !slices.Contains(got, "NET_RAW") || !slices.Contains(got, "ALL") {
+		t.Errorf("union should keep both operator and tier drops, got %v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected no duplicates, got %v", got)
+	}
+}
+
+func TestTightenDropCapabilitiesDoesNotMutateTheConfiguredSlice(t *testing.T) {
+	configured := []string{"NET_RAW"}
+	tightenDropCapabilities(configured, models.Isolation{DropCapabilities: []string{"ALL"}})
+
+	if len(configured) != 1 {
+		t.Errorf("operator config was mutated: %v", configured)
+	}
+}

--- a/agentarea-mcp-manager/internal/backends/kubernetes_resources.go
+++ b/agentarea-mcp-manager/internal/backends/kubernetes_resources.go
@@ -121,18 +121,29 @@ func (k *KubernetesBackend) createDeployment(ctx context.Context, instanceName s
 		resourceRequirements.Limits[corev1.ResourceMemory] = resource.MustParse(limits.Memory)
 	}
 
+	// Resolve the workload's isolation tier and apply it on top of the
+	// operator's configured context. The tier may only tighten: the operator
+	// hardens the whole cluster, a tier hardens one workload further.
+	isolation, err := resolveSpecIsolation(spec, k.config.Container.DefaultIsolationTier)
+	if err != nil {
+		return err
+	}
+
+	readOnlyRoot := k.k8sConfig.SecurityContext.ReadOnlyRootFilesystem || isolation.ReadOnlyRootFilesystem
+	allowPrivilegeEscalation := k.k8sConfig.SecurityContext.AllowPrivilegeEscalation && !isolation.NoNewPrivileges
+
 	// Security context
 	securityContext := &corev1.SecurityContext{
 		RunAsNonRoot:             &k.k8sConfig.SecurityContext.RunAsNonRoot,
 		RunAsUser:                &k.k8sConfig.SecurityContext.RunAsUser,
-		ReadOnlyRootFilesystem:   &k.k8sConfig.SecurityContext.ReadOnlyRootFilesystem,
-		AllowPrivilegeEscalation: &k.k8sConfig.SecurityContext.AllowPrivilegeEscalation,
+		ReadOnlyRootFilesystem:   &readOnlyRoot,
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{},
 		},
 	}
 
-	for _, cap := range k.k8sConfig.SecurityContext.DropCapabilities {
+	for _, cap := range tightenDropCapabilities(k.k8sConfig.SecurityContext.DropCapabilities, isolation) {
 		securityContext.Capabilities.Drop = append(securityContext.Capabilities.Drop, corev1.Capability(cap))
 	}
 
@@ -239,10 +250,7 @@ func (k *KubernetesBackend) createDeployment(ctx context.Context, instanceName s
 	// Determine runtime class. The operator-configured class wins: a caller may
 	// only choose a runtime class when none is enforced cluster-wide, so a request
 	// can never downgrade away a sandbox runtime (e.g. gVisor/Kata) set by config.
-	runtimeClassName := k.k8sConfig.RuntimeClass
-	if runtimeClassName == "" && spec.RuntimeClass != "" {
-		runtimeClassName = spec.RuntimeClass
-	}
+	runtimeClassName := tightenRuntimeClass(k.k8sConfig.RuntimeClass, isolation, spec.RuntimeClass)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#292 gave the Docker backend per-workload isolation tiers, but left Kubernetes
building its pod security context from a single global config — identical for
every instance, regardless of whether the image is ours, a catalog MCP server,
or user-supplied code. So the two backends still disagreed about what running a
workload means; only the direction of the gap had changed.

Resolve the tier once, in resolveSpecIsolation, and let each backend express it
in its own vocabulary: Docker renders run flags, Kubernetes builds a security
context and runtime class. What "untrusted" means is now defined in one place.

On Kubernetes the tier may only tighten what the operator configured:

- read-only root if either the cluster config or the tier asks for it
- privilege escalation off if the tier blocks it, even where config allows it
- dropped capabilities are the union of both
- runtime class keeps its existing precedence — a cluster-wide class still wins,
  so a workload cannot drop an enforced gVisor/Kata runtime. Below that a tier
  asking for a runtime now outranks a bare spec field, because the tier is the
  platform's judgement about the code and the field is the caller's.

Not doing the rest of the planned placement work yet. Adding an isolation tier
to Capabilities/Constraints has no consumer today: there is one target, built
from a single pair of env vars, and MCP does not route through the placer at
all. The Redis task->target pin that would let the "one target per region"
invariant be lifted guards a real bug — a task re-routed mid-session loses the
workspace living on the first host's disk — but that only becomes reachable with
two same-tier sandbox hosts, which is a capacity decision nobody has made.
Building either now would be speculative structure.


---