### PR TITLE
fix(mcp): advertise Hydra as the authorization server, not ourselves

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
@@ -4,15 +4,20 @@ Discovery chain that Cursor / Claude Desktop follow:
 
     1. GET /mcp/{id}  →  401 + WWW-Authenticate: Bearer resource_metadata="…"
     2. GET /.well-known/oauth-protected-resource
-           →  {"resource": "<API>", "authorization_servers": ["<API>"]}
-    3. GET /.well-known/oauth-authorization-server   (we proxy → Hydra OIDC config)
+           →  {"resource": "<API>/mcp", "authorization_servers": ["<Hydra issuer>"]}
+    3. GET <Hydra issuer>/.well-known/oauth-authorization-server
            →  Hydra metadata: authorization_endpoint, token_endpoint, registration_endpoint, …
-    4. POST /oauth2/register   (Hydra DCR — proxied through us so the same AS URL works)
-    5. GET  /oauth2/auth        (Hydra auth — proxied)
-    6. POST /oauth2/token       (Hydra token — proxied)
+    4. POST <registration_endpoint>  →  our /oauth2/register proxy (Hydra has no public DCR)
+    5. GET  <authorization_endpoint> / POST <token_endpoint>  →  Hydra directly
 
-Steps 4-6 are proxied via /.well-known/... and the full oauth2/* proxy below so
-that the single AS URL (API_BASE_URL) works for both discovery and token ops.
+We advertise Hydra as the authorization server because Hydra issues the tokens:
+its issuer is what lands in the token's ``iss``, and clients that validate it
+reject tokens that disagree with the metadata they discovered. Hydra points step
+4 back at our proxy via ``webfinger.oidc_discovery.client_registration_url``.
+
+When Hydra does not advertise a registration endpoint (DCR unconfigured), we
+keep advertising ourselves and serve the AS metadata + oauth2/* proxy below, so
+dynamic client registration still works on deployments that rely on the shim.
 """
 
 import re
@@ -41,18 +46,55 @@ def _hydra_public_url() -> str:
     return get_settings().mcp.HYDRA_PUBLIC_URL.rstrip("/")
 
 
+# Hydra's discovery document, fetched once and reused.
+_hydra_discovery_cache: dict | None = None
+
+
+async def _hydra_discovery() -> dict | None:
+    """Hydra's OIDC discovery document, or None when it is unreachable."""
+    global _hydra_discovery_cache
+    if _hydra_discovery_cache is not None:
+        return _hydra_discovery_cache
+
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(5)) as client:
+            resp = await client.get(f"{_hydra_public_url()}/.well-known/openid-configuration")
+            resp.raise_for_status()
+            doc = resp.json()
+    except Exception:
+        return None
+
+    if isinstance(doc, dict):
+        _hydra_discovery_cache = doc
+    return _hydra_discovery_cache
+
+
 @oauth_as_router.get("/.well-known/oauth-protected-resource")
 async def oauth_protected_resource_metadata() -> JSONResponse:
-    """RFC 9728: point clients at our own API as the AS base URL."""
+    """RFC 9728: advertise the authorization server that actually issues tokens."""
     settings = get_settings()
     api_base = settings.app.API_BASE_URL.rstrip("/")
+
+    # Hydra mints the tokens, so Hydra — not this API — is the authorization
+    # server identity. Its issuer ends up in the token's `iss`, and clients that
+    # validate the issuer (RFC 9207, required by the MCP auth spec) reject a
+    # token whose `iss` disagrees with the metadata they discovered. Pointing at
+    # ourselves therefore only works for clients that skip that check.
+    #
+    # Only delegate when Hydra also advertises a registration endpoint: MCP
+    # clients need dynamic client registration, and Hydra exposes it in its own
+    # discovery document only when webfinger.oidc_discovery.client_registration_url
+    # is configured (it has no public DCR of its own — see the proxy below).
+    # Without it, stay on the local AS shim so DCR keeps working.
+    doc = await _hydra_discovery()
+    issuer = (doc or {}).get("issuer", "").rstrip("/")
+    as_url = issuer if issuer and (doc or {}).get("registration_endpoint") else api_base
+
     return JSONResponse(
         content={
             # MCP spec: canonical URI of the MCP server endpoint, not the API root.
             "resource": f"{api_base}/mcp",
-            # Using ourselves as the AS URL so clients resolve
-            # /.well-known/oauth-authorization-server against us (not Hydra directly).
-            "authorization_servers": [api_base],
+            "authorization_servers": [as_url],
             "bearer_methods_supported": ["header"],
         }
     )

--- a/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
@@ -1,11 +1,23 @@
-"""Tests for the Hydra OAuth2 proxy path hardening.
+"""Tests for the Hydra OAuth2 proxy path hardening and AS advertisement.
 
 The proxy forwards /oauth2/{path} to a fixed, config-driven Hydra host. The host
 cannot be changed by the caller, but the user-controlled subpath must not be able
 to traverse out of /oauth2/ on that host (partial-SSRF / path-traversal hardening).
 """
 
+import json
+
+from agentarea_api.api.v1 import mcp_oauth_as
 from agentarea_api.api.v1.mcp_oauth_as import _is_safe_oauth2_subpath
+
+API_BASE = "https://api.example.com"
+
+
+class _Settings:
+    """Minimal stand-in for the app settings the endpoint reads."""
+
+    class app:  # noqa: N801 - mirrors the settings attribute name
+        API_BASE_URL = API_BASE
 
 
 class TestOAuth2SubpathValidation:
@@ -28,3 +40,49 @@ class TestOAuth2SubpathValidation:
 
     def test_rejects_empty(self):
         assert not _is_safe_oauth2_subpath("")
+
+
+class TestProtectedResourceMetadata:
+    """Which authorization server the resource advertises (RFC 9728)."""
+
+    @staticmethod
+    def _patch(monkeypatch, discovery):
+        monkeypatch.setattr(mcp_oauth_as, "get_settings", lambda: _Settings())
+
+        async def _discovery():
+            return discovery
+
+        monkeypatch.setattr(mcp_oauth_as, "_hydra_discovery", _discovery)
+
+    @staticmethod
+    async def _metadata():
+        response = await mcp_oauth_as.oauth_protected_resource_metadata()
+        return json.loads(response.body)
+
+    async def test_advertises_hydra_when_it_exposes_dcr(self, monkeypatch):
+        # Hydra mints the tokens, so its issuer is what clients validate `iss`
+        # against — advertising ourselves would fail that check.
+        self._patch(
+            monkeypatch,
+            {
+                "issuer": "https://oauth.example.com/",
+                "registration_endpoint": f"{API_BASE}/oauth2/register",
+            },
+        )
+
+        metadata = await self._metadata()
+
+        assert metadata["authorization_servers"] == ["https://oauth.example.com"]
+        assert metadata["resource"] == f"{API_BASE}/mcp"
+
+    async def test_falls_back_to_self_when_hydra_has_no_dcr(self, monkeypatch):
+        # Without a registration endpoint MCP clients cannot register, so keep
+        # pointing at our own AS shim rather than breaking them.
+        self._patch(monkeypatch, {"issuer": "https://oauth.example.com"})
+
+        assert (await self._metadata())["authorization_servers"] == [API_BASE]
+
+    async def test_falls_back_to_self_when_hydra_unreachable(self, monkeypatch):
+        self._patch(monkeypatch, None)
+
+        assert (await self._metadata())["authorization_servers"] == [API_BASE]

--- a/agentarea-webapp/src/api/client/sdk.gen.ts
+++ b/agentarea-webapp/src/api/client/sdk.gen.ts
@@ -824,7 +824,7 @@ export const oauthAuthorizationServerMetadataWellKnownOauthAuthorizationServerGe
 /**
  * Oauth Protected Resource Metadata
  *
- * RFC 9728: point clients at our own API as the AS base URL.
+ * RFC 9728: advertise the authorization server that actually issues tokens.
  */
 export const oauthProtectedResourceMetadataWellKnownOauthProtectedResourceGet =
   <ThrowOnError extends boolean = false>(

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -11662,7 +11662,7 @@
     },
     "/.well-known/oauth-protected-resource": {
       "get": {
-        "description": "RFC 9728: point clients at our own API as the AS base URL.",
+        "description": "RFC 9728: advertise the authorization server that actually issues tokens.",
         "operationId": "oauth_protected_resource_metadata__well_known_oauth_protected_resource_get",
         "responses": {
           "200": {


### PR DESCRIPTION
## Problem

The RFC 9728 protected-resource metadata named this API as its own authorization server:

```python
"authorization_servers": [api_base]
```

But Hydra mints the tokens. So a client discovers `issuer: https://api.example.com` and then receives a token carrying `iss: https://oauth.example.com`. Clients that validate the issuer — required by the MCP auth spec — reject it.

Observed symptom: the OAuth flow completes (DCR, login, consent all fine) and then the connector fails with *"Couldn't reload tools from the server"*. Clients that skip issuer validation (Cursor) happened to work, which hid the bug.

Verified against a live deployment — token payload:

```json
{"iss":"https://oauth.<redacted>", "aud":[], ...}
```

while `/.well-known/oauth-authorization-server` advertised `"issuer":"https://api.<redacted>"`.

## Fix

Advertise Hydra's real issuer, read from its own discovery document.

Hydra has no public DCR endpoint of its own, so only delegate when Hydra advertises a `registration_endpoint` — set via `webfinger.oidc_discovery.client_registration_url`, pointing back at our `/oauth2/register` proxy. Without it, keep advertising ourselves so dynamic client registration still works on deployments relying on the local AS shim.

The resource server and the authorization server are separate identities; RFC 9728 exists to link them, so there is no need for the API to impersonate the AS.

## Tests

Added coverage for all three paths (Hydra with DCR → Hydra issuer; Hydra without DCR → self; Hydra unreachable → self). `8 passed`, ruff clean.