### PR TITLE
feat(mcp): stop idle MCP instances instead of running them forever

### DIFF
--- a/agentarea-mcp-manager/internal/backends/docker_backend.go
+++ b/agentarea-mcp-manager/internal/backends/docker_backend.go
@@ -356,22 +356,9 @@ func (d *DockerBackend) specToCreateRequest(spec *InstanceSpec) (models.CreateCo
 
 	// Resolve the confinement for this workload. An MCP server is third-party
 	// code, so the default is a confined tier, not the daemon's defaults.
-	tier := spec.IsolationTier
-	if tier == "" {
-		tier = d.config.Container.DefaultIsolationTier
-	}
-	isolation, err := config.ResolveIsolation(tier)
+	isolation, err := resolveSpecIsolation(spec, d.config.Container.DefaultIsolationTier)
 	if err != nil {
 		return models.CreateContainerRequest{}, err
-	}
-	// The spec's explicit runtime/writable paths refine the resolved tier; they
-	// never weaken it, since a stricter runtime is the only thing they can add.
-	if spec.RuntimeClass != "" {
-		isolation.Runtime = spec.RuntimeClass
-	}
-	if len(spec.WritablePaths) > 0 {
-		isolation.ReadOnlyRootFilesystem = true
-		isolation.WritablePaths = spec.WritablePaths
 	}
 	req.Isolation = isolation
 

--- a/agentarea-mcp-manager/internal/backends/isolation.go
+++ b/agentarea-mcp-manager/internal/backends/isolation.go
@@ -1,0 +1,68 @@
+package backends
+
+import (
+	"slices"
+
+	"github.com/agentarea/mcp-manager/internal/config"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+// resolveSpecIsolation turns a spec's declared tier into concrete settings.
+//
+// Both backends call this so the meaning of a tier is defined once. What each
+// backend then does with it differs — Docker renders flags, Kubernetes builds a
+// pod security context — but "what does untrusted mean" must not.
+func resolveSpecIsolation(spec *InstanceSpec, defaultTier string) (models.Isolation, error) {
+	tier := spec.IsolationTier
+	if tier == "" {
+		tier = defaultTier
+	}
+
+	isolation, err := config.ResolveIsolation(tier)
+	if err != nil {
+		return models.Isolation{}, err
+	}
+
+	// An explicit runtime/writable-path on the spec refines the tier. Neither
+	// can weaken it: a runtime class is an addition, and marking paths writable
+	// only takes effect together with a read-only root.
+	if spec.RuntimeClass != "" {
+		isolation.Runtime = spec.RuntimeClass
+	}
+	if len(spec.WritablePaths) > 0 {
+		isolation.ReadOnlyRootFilesystem = true
+		isolation.WritablePaths = spec.WritablePaths
+	}
+
+	return isolation, nil
+}
+
+// tightenDropCapabilities merges the operator's configured drops with the
+// tier's. Dropping a capability twice is harmless; missing one is not, so the
+// union is the safe combination.
+func tightenDropCapabilities(configured []string, iso models.Isolation) []string {
+	merged := append([]string(nil), configured...)
+	for _, capability := range iso.DropCapabilities {
+		if !slices.Contains(merged, capability) {
+			merged = append(merged, capability)
+		}
+	}
+	return merged
+}
+
+// tightenRuntimeClass picks the runtime class for a workload.
+//
+// The operator's cluster-wide class always wins: a per-workload request must
+// never be able to drop a sandbox runtime the cluster enforces. Below that, a
+// tier asking for a runtime (untrusted wanting gVisor) outranks a bare spec
+// field, because the tier is the platform's judgement about the code and the
+// spec field is the caller's.
+func tightenRuntimeClass(configured string, iso models.Isolation, specRuntimeClass string) string {
+	if configured != "" {
+		return configured
+	}
+	if iso.Runtime != "" {
+		return iso.Runtime
+	}
+	return specRuntimeClass
+}

--- a/agentarea-mcp-manager/internal/backends/isolation_test.go
+++ b/agentarea-mcp-manager/internal/backends/isolation_test.go
@@ -1,0 +1,94 @@
+package backends
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agentarea/mcp-manager/internal/config"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+func TestResolveSpecIsolationUsesDefaultTierWhenSpecIsSilent(t *testing.T) {
+	iso, err := resolveSpecIsolation(&InstanceSpec{}, config.IsolationUntrusted)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if iso.Profile != config.IsolationUntrusted {
+		t.Errorf("profile = %q, want %q", iso.Profile, config.IsolationUntrusted)
+	}
+}
+
+func TestResolveSpecIsolationPrefersTheSpecTier(t *testing.T) {
+	iso, err := resolveSpecIsolation(
+		&InstanceSpec{IsolationTier: config.IsolationUntrusted},
+		config.IsolationStandard,
+	)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if iso.Runtime != config.UntrustedRuntime {
+		t.Errorf("runtime = %q, want %q", iso.Runtime, config.UntrustedRuntime)
+	}
+}
+
+func TestResolveSpecIsolationRejectsUnknownTier(t *testing.T) {
+	// Fail closed: an unrecognised tier must not silently degrade to a weaker
+	// profile, or a typo in a deployment value would unconfine third-party code.
+	if _, err := resolveSpecIsolation(&InstanceSpec{IsolationTier: "nope"}, config.IsolationStandard); err == nil {
+		t.Fatal("expected an error for an unknown tier")
+	}
+}
+
+func TestResolveSpecIsolationWritablePathsImplyReadOnlyRoot(t *testing.T) {
+	iso, err := resolveSpecIsolation(
+		&InstanceSpec{WritablePaths: []string{"/tmp"}},
+		config.IsolationStandard,
+	)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if !iso.ReadOnlyRootFilesystem {
+		t.Error("declaring writable paths must turn on the read-only root they carve out of")
+	}
+}
+
+func TestTightenRuntimeClassOperatorWins(t *testing.T) {
+	// A cluster-wide sandbox runtime must not be removable by a workload, or
+	// the per-workload knob becomes a downgrade path.
+	got := tightenRuntimeClass("kata-qemu", models.Isolation{Runtime: "runsc"}, "runc")
+	if got != "kata-qemu" {
+		t.Errorf("got %q, want the operator's kata-qemu", got)
+	}
+}
+
+func TestTightenRuntimeClassFallsBackToTierThenSpec(t *testing.T) {
+	if got := tightenRuntimeClass("", models.Isolation{Runtime: "runsc"}, "runc"); got != "runsc" {
+		t.Errorf("tier runtime should outrank the spec field, got %q", got)
+	}
+	if got := tightenRuntimeClass("", models.Isolation{}, "runc"); got != "runc" {
+		t.Errorf("spec field should apply when nothing else does, got %q", got)
+	}
+	if got := tightenRuntimeClass("", models.Isolation{}, ""); got != "" {
+		t.Errorf("expected empty (daemon default), got %q", got)
+	}
+}
+
+func TestTightenDropCapabilitiesIsAUnion(t *testing.T) {
+	got := tightenDropCapabilities([]string{"NET_RAW"}, models.Isolation{DropCapabilities: []string{"ALL", "NET_RAW"}})
+
+	if !slices.Contains(got, "NET_RAW") || !slices.Contains(got, "ALL") {
+		t.Errorf("union should keep both operator and tier drops, got %v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected no duplicates, got %v", got)
+	}
+}
+
+func TestTightenDropCapabilitiesDoesNotMutateTheConfiguredSlice(t *testing.T) {
+	configured := []string{"NET_RAW"}
+	tightenDropCapabilities(configured, models.Isolation{DropCapabilities: []string{"ALL"}})
+
+	if len(configured) != 1 {
+		t.Errorf("operator config was mutated: %v", configured)
+	}
+}

--- a/agentarea-mcp-manager/internal/backends/kubernetes_resources.go
+++ b/agentarea-mcp-manager/internal/backends/kubernetes_resources.go
@@ -121,18 +121,29 @@ func (k *KubernetesBackend) createDeployment(ctx context.Context, instanceName s
 		resourceRequirements.Limits[corev1.ResourceMemory] = resource.MustParse(limits.Memory)
 	}
 
+	// Resolve the workload's isolation tier and apply it on top of the
+	// operator's configured context. The tier may only tighten: the operator
+	// hardens the whole cluster, a tier hardens one workload further.
+	isolation, err := resolveSpecIsolation(spec, k.config.Container.DefaultIsolationTier)
+	if err != nil {
+		return err
+	}
+
+	readOnlyRoot := k.k8sConfig.SecurityContext.ReadOnlyRootFilesystem || isolation.ReadOnlyRootFilesystem
+	allowPrivilegeEscalation := k.k8sConfig.SecurityContext.AllowPrivilegeEscalation && !isolation.NoNewPrivileges
+
 	// Security context
 	securityContext := &corev1.SecurityContext{
 		RunAsNonRoot:             &k.k8sConfig.SecurityContext.RunAsNonRoot,
 		RunAsUser:                &k.k8sConfig.SecurityContext.RunAsUser,
-		ReadOnlyRootFilesystem:   &k.k8sConfig.SecurityContext.ReadOnlyRootFilesystem,
-		AllowPrivilegeEscalation: &k.k8sConfig.SecurityContext.AllowPrivilegeEscalation,
+		ReadOnlyRootFilesystem:   &readOnlyRoot,
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{},
 		},
 	}
 
-	for _, cap := range k.k8sConfig.SecurityContext.DropCapabilities {
+	for _, cap := range tightenDropCapabilities(k.k8sConfig.SecurityContext.DropCapabilities, isolation) {
 		securityContext.Capabilities.Drop = append(securityContext.Capabilities.Drop, corev1.Capability(cap))
 	}
 
@@ -239,10 +250,7 @@ func (k *KubernetesBackend) createDeployment(ctx context.Context, instanceName s
 	// Determine runtime class. The operator-configured class wins: a caller may
 	// only choose a runtime class when none is enforced cluster-wide, so a request
 	// can never downgrade away a sandbox runtime (e.g. gVisor/Kata) set by config.
-	runtimeClassName := k.k8sConfig.RuntimeClass
-	if runtimeClassName == "" && spec.RuntimeClass != "" {
-		runtimeClassName = spec.RuntimeClass
-	}
+	runtimeClassName := tightenRuntimeClass(k.k8sConfig.RuntimeClass, isolation, spec.RuntimeClass)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/agentarea-mcp-manager/internal/config/config.go
+++ b/agentarea-mcp-manager/internal/config/config.go
@@ -76,6 +76,13 @@ type ContainerConfig struct {
 	// because the containers this manager starts are third-party MCP servers.
 	DefaultIsolationTier string `json:"default_isolation_tier"`
 
+	// MCPIdleTimeout stops a lazily-provisioned instance whose container has
+	// gone unused for this long; the next call provisions it again. Zero
+	// disables reaping, which is the pre-existing behaviour of running forever.
+	MCPIdleTimeout time.Duration `json:"mcp_idle_timeout"`
+	// MCPIdleSweepInterval is how often the reaper looks for idle instances.
+	MCPIdleSweepInterval time.Duration `json:"mcp_idle_sweep_interval"`
+
 	// SandboxExecutorURL is the HTTP endpoint of the sandbox-executor data
 	// plane used by the docker backend (dev/compose). When set, sandbox
 	// executions are routed here instead of a Kubernetes warm pod.
@@ -118,6 +125,11 @@ func Load() *Config {
 			SandboxExecutorURL: getEnv("SANDBOX_EXECUTOR_URL", ""),
 
 			DefaultIsolationTier: getEnv("DEFAULT_ISOLATION_TIER", IsolationStandard),
+
+			// Off by default: enabling reaping changes how long an instance
+			// lives, so an operator opts in rather than discovering it.
+			MCPIdleTimeout:       getEnvDuration("MCP_IDLE_TIMEOUT", 0),
+			MCPIdleSweepInterval: getEnvDuration("MCP_IDLE_SWEEP_INTERVAL", 60*time.Second),
 		},
 		Logging: LoggingConfig{
 			Level:  getEnv("LOG_LEVEL", "INFO"),

--- a/agentarea-mcp-manager/internal/container/idle_reaper.go
+++ b/agentarea-mcp-manager/internal/container/idle_reaper.go
@@ -1,0 +1,160 @@
+package container
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/agentarea/mcp-manager/internal/database"
+)
+
+// idleReaperSQL selects lazily-provisioned instances that have gone quiet.
+//
+// Only lazy instances are eligible: an instance provisioned eagerly was asked
+// to stay up, and stopping it would be a behaviour change rather than a
+// reclamation. NULL last_used_at is deliberately NOT idle — it means no call has
+// been observed through the proxy yet (including every row predating that
+// column), and treating "unknown" as "idle" would stop instances that are
+// simply new.
+const idleReaperSQL = `
+SELECT id::text, name
+FROM mcp_server_instances
+WHERE status = 'running'
+  AND COALESCE((json_spec->>'lazy_provisioning')::boolean, false) = true
+  AND last_used_at IS NOT NULL
+  AND last_used_at < now() - make_interval(secs => $1)
+`
+
+// runIdleReaper owns the reaper's database handle for the process lifetime.
+//
+// It opens its own connection rather than sharing the short-lived ones the
+// startup paths use, because this loop outlives them. A missing database
+// configuration disables reaping instead of failing startup: the manager's
+// other work does not depend on it.
+func (m *Manager) runIdleReaper(ctx context.Context) {
+	if m.config.Container.MCPIdleTimeout <= 0 {
+		m.logger.Info("MCP idle reaper disabled (MCP_IDLE_TIMEOUT unset)")
+		return
+	}
+
+	connStr := database.BuildConnStr(m.logger)
+	if connStr == "" {
+		m.logger.Warn("MCP idle reaper not started: database credentials not configured")
+		return
+	}
+
+	db, err := sql.Open("pgx", connStr)
+	if err != nil {
+		m.logger.Warn("MCP idle reaper not started", slog.String("error", err.Error()))
+		return
+	}
+	defer db.Close()
+
+	m.StartIdleReaper(
+		ctx,
+		db,
+		m.config.Container.MCPIdleTimeout,
+		m.config.Container.MCPIdleSweepInterval,
+	)
+}
+
+// StartIdleReaper sweeps for idle instances until ctx is cancelled.
+//
+// Runs in the control plane rather than beside the containers so one sweeper
+// covers every data plane, matching how the sandbox runner already owns its
+// pods' idleness.
+func (m *Manager) StartIdleReaper(ctx context.Context, db *sql.DB, idleTimeout, interval time.Duration) {
+	if idleTimeout <= 0 {
+		m.logger.Info("MCP idle reaper disabled (no idle timeout configured)")
+		return
+	}
+
+	m.logger.Info("Starting MCP idle reaper",
+		slog.Duration("idle_timeout", idleTimeout),
+		slog.Duration("interval", interval))
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("MCP idle reaper stopped")
+			return
+		case <-ticker.C:
+			stopped, err := m.ReapIdleInstances(ctx, db, idleTimeout)
+			if err != nil {
+				// A failed sweep is not fatal: the next tick retries, and the
+				// worst case is instances staying up longer than intended.
+				m.logger.Warn("MCP idle sweep failed", slog.String("error", err.Error()))
+				continue
+			}
+			if stopped > 0 {
+				m.logger.Info("Reaped idle MCP instances", slog.Int("stopped", stopped))
+			}
+		}
+	}
+}
+
+// ReapIdleInstances stops containers for lazily-provisioned MCP instances that
+// have not been called for longer than idleTimeout.
+//
+// This is the half of serverless that was missing: lazy provisioning starts an
+// instance on demand, but nothing ever stopped it, so instances accumulated and
+// ran indefinitely. Stopping only the container — never the database row — is
+// what makes it reversible: the next proxied call provisions it again through
+// the same path that started it the first time.
+func (m *Manager) ReapIdleInstances(ctx context.Context, db *sql.DB, idleTimeout time.Duration) (int, error) {
+	if idleTimeout <= 0 {
+		return 0, nil
+	}
+
+	rows, err := db.QueryContext(ctx, idleReaperSQL, idleTimeout.Seconds())
+	if err != nil {
+		return 0, fmt.Errorf("querying idle mcp instances: %w", err)
+	}
+	defer rows.Close()
+
+	type idleInstance struct {
+		id   string
+		name string
+	}
+	var idle []idleInstance
+	for rows.Next() {
+		var inst idleInstance
+		if err := rows.Scan(&inst.id, &inst.name); err != nil {
+			m.logger.Warn("Failed to scan idle instance row", slog.String("error", err.Error()))
+			continue
+		}
+		idle = append(idle, inst)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating idle mcp instances: %w", err)
+	}
+
+	stopped := 0
+	for _, inst := range idle {
+		// The instance row survives — only the container goes — so the next
+		// proxied call provisions it again through the path that started it
+		// the first time. `name` is the service name the manager keys on, the
+		// same mapping the DB-driven auto-restart uses.
+		//
+		// A container that is already gone is the desired end state, so a
+		// failure is logged and skipped rather than aborting the sweep: one
+		// stuck instance must not keep every other one running.
+		if err := m.DeleteContainer(ctx, inst.name); err != nil {
+			m.logger.Warn("Failed to stop idle MCP instance",
+				slog.String("instance_id", inst.id),
+				slog.String("error", err.Error()))
+			continue
+		}
+		stopped++
+		m.logger.Info("Stopped idle MCP instance",
+			slog.String("instance_id", inst.id),
+			slog.Duration("idle_timeout", idleTimeout))
+	}
+
+	return stopped, nil
+}

--- a/agentarea-mcp-manager/internal/container/idle_reaper_test.go
+++ b/agentarea-mcp-manager/internal/container/idle_reaper_test.go
@@ -1,0 +1,95 @@
+package container
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The reaper's selection predicate (only lazy instances, only running, NULL
+// last_used_at is NOT idle) lives in SQL and is not covered here: this
+// repository has no database-backed Go tests, and adding a harness for one
+// query would introduce a pattern rather than verify Postgres semantics.
+// Verify it against a real database — see the PR's manual check.
+//
+// What is covered is the guard that decides whether the loop runs at all,
+// because getting that wrong silently either disables reclamation or starts a
+// sweep that deletes containers on a deployment that never opted in.
+
+func TestReapIdleInstancesDisabledWithoutTimeout(t *testing.T) {
+	manager := newTestManager(t)
+
+	// A nil handle proves the disabled path returns before touching the
+	// database: reaping must be opt-in, not "on with a zero window".
+	stopped, err := manager.ReapIdleInstances(context.Background(), nil, 0)
+	if err != nil {
+		t.Fatalf("expected no error when disabled, got %v", err)
+	}
+	if stopped != 0 {
+		t.Errorf("expected nothing stopped when disabled, got %d", stopped)
+	}
+}
+
+func TestReapIdleInstancesRejectsNegativeTimeout(t *testing.T) {
+	manager := newTestManager(t)
+
+	stopped, err := manager.ReapIdleInstances(context.Background(), nil, -1*time.Minute)
+	if err != nil || stopped != 0 {
+		t.Errorf("a negative window must disable reaping, got stopped=%d err=%v", stopped, err)
+	}
+}
+
+func TestStartIdleReaperReturnsImmediatelyWhenDisabled(t *testing.T) {
+	manager := newTestManager(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.StartIdleReaper(context.Background(), nil, 0, time.Second)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartIdleReaper blocked with reaping disabled; it must not hold a goroutine")
+	}
+}
+
+func TestStartIdleReaperStopsOnContextCancel(t *testing.T) {
+	manager := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// A long interval means the loop is parked on the ticker, so returning
+		// proves cancellation wins rather than a tick happening to fire.
+		manager.StartIdleReaper(ctx, nil, time.Hour, time.Hour)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartIdleReaper ignored context cancellation")
+	}
+}
+
+func TestRunIdleReaperReturnsWhenTimeoutUnset(t *testing.T) {
+	// The default config leaves MCPIdleTimeout at zero, so the goroutine
+	// Initialize starts must exit rather than sit idle forever.
+	manager := newTestManager(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.runIdleReaper(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runIdleReaper blocked although no idle timeout is configured")
+	}
+}

--- a/agentarea-mcp-manager/internal/container/manager.go
+++ b/agentarea-mcp-manager/internal/container/manager.go
@@ -151,6 +151,10 @@ func (m *Manager) Initialize(ctx context.Context) error {
 	}
 	m.logger.Info("Auto-restart check completed")
 
+	// Reclaim instances nobody is calling. Lazy provisioning starts them on
+	// demand; without this half they are never stopped again.
+	go m.runIdleReaper(ctx)
+
 	m.logger.Info("Container manager initialized successfully")
 	return nil
 }

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
@@ -20,6 +20,7 @@ Dispatch by instance type:
 
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -31,6 +32,7 @@ from agentarea_common.base.repository_factory import RepositoryFactory
 from agentarea_common.config import get_settings
 from agentarea_governance.application import GovernancePolicyResolver
 from agentarea_mcp.application.auth_service import MCPAuthService
+from agentarea_mcp.domain.mpc_server_instance_model import MCPServerInstance
 from agentarea_mcp.infrastructure.auth_repository import MCPAuthConfigRepository
 from agentarea_mcp.infrastructure.repository import (
     MCPServerInstanceRepository,
@@ -39,6 +41,7 @@ from agentarea_mcp.infrastructure.repository import (
 from agentarea_openapi.application.url_validator import build_pinned_target, validate_url
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
+from sqlalchemy import update
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +211,39 @@ def _guard_and_pin_upstream(
     return request_target, target.original_host, extensions
 
 
+_LAST_USED_WRITE_INTERVAL = timedelta(seconds=60)
+
+
+async def _stamp_last_used(db_session, instance) -> None:
+    """Record that this instance is in use, so the reaper leaves it alone.
+
+    The proxy is the only component that observes MCP traffic — Traefik routes
+    the container path directly — so idleness cannot be inferred anywhere else.
+
+    Throttled: a write per proxied call would put the database on the hot path
+    of every tool call for no extra signal. One write per minute per instance is
+    enough to keep an active instance comfortably outside any sane idle window.
+
+    Failing to stamp must never fail the call. The cost of a missed stamp is an
+    instance stopped a little early and lazily restarted on the next request;
+    the cost of raising here is a broken tool call.
+    """
+    now = datetime.now(UTC)
+    previous = instance.last_used_at
+    if previous is not None and now - previous < _LAST_USED_WRITE_INTERVAL:
+        return
+
+    try:
+        await db_session.execute(
+            update(MCPServerInstance)
+            .where(MCPServerInstance.id == instance.id)
+            .values(last_used_at=now)
+        )
+        await db_session.commit()
+    except Exception:
+        logger.warning("Failed to stamp MCP instance last_used_at", exc_info=True)
+
+
 @router.api_route(
     "/{instance_id}/mcp",
     methods=["GET", "POST", "DELETE"],
@@ -229,6 +265,8 @@ async def proxy_instance(
     if instance.server_spec_id:
         server_repo = MCPServerRepository(db_session, user_context)
         server_spec = await server_repo.get_server_by_id(instance.server_spec_id)
+
+    await _stamp_last_used(db_session, instance)
 
     upstream_url, instance_type = await _resolve_upstream_url(instance, server_spec)
     if not upstream_url:

--- a/agentarea-platform/apps/api/alembic/versions/20260727_0100_mcp_last_used_at.py
+++ b/agentarea-platform/apps/api/alembic/versions/20260727_0100_mcp_last_used_at.py
@@ -1,0 +1,46 @@
+"""Track when an MCP server instance was last used
+
+Lazy provisioning starts an instance's container on demand, but nothing ever
+stopped it: no column recorded activity, and the container monitor only sweeps
+verification state, so an instance started once ran until something else killed
+it. This adds the timestamp the MCP proxy stamps on each call, which is what
+lets the control plane tell an idle instance from a busy one and stop it.
+
+Nullable with no backfill on purpose. NULL means "never observed through the
+proxy", and the reaper treats that as not-idle rather than idle — an instance
+predating this column must not be stopped just because nothing recorded a use
+yet. The first proxied call sets it and the instance joins the normal cycle.
+
+Revision ID: 20260727_0100_mcp_last_used
+Revises: 20260719_0100_approval_rules
+Create Date: 2026-07-27 01:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260727_0100_mcp_last_used"
+down_revision: str | None = "20260719_0100_approval_rules"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_server_instances",
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # The reaper scans for idle instances across the whole table on a timer, so
+    # it filters on this column rather than looking rows up by id.
+    op.create_index(
+        "ix_mcp_server_instances_last_used_at",
+        "mcp_server_instances",
+        ["last_used_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mcp_server_instances_last_used_at", table_name="mcp_server_instances")
+    op.drop_column("mcp_server_instances", "last_used_at")

--- a/agentarea-platform/libs/mcp/agentarea_mcp/domain/mpc_server_instance_model.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/domain/mpc_server_instance_model.py
@@ -1,9 +1,10 @@
+from datetime import datetime
 from importlib import import_module
 from typing import Any
 from uuid import UUID
 
 from agentarea_common.base.models import BaseModel, WorkspaceScopedMixin
-from sqlalchemy import JSON, ForeignKey, String, Text
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -27,6 +28,12 @@ class MCPServerInstance(BaseModel, WorkspaceScopedMixin):
         JSON, nullable=False, default=lambda: dict(DEFAULT_VERIFICATION)
     )
     last_dispatch: Mapped[dict | None] = mapped_column(JSON, nullable=True, default=None)
+    # Stamped by the MCP proxy on each call so the control plane can tell an
+    # idle instance from a busy one. Lazy provisioning starts instances on
+    # demand but nothing stopped them, so they accumulated and ran forever.
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
     tools: Mapped[list | None] = mapped_column(JSON, nullable=True, default=None)
     network_scope: Mapped[str] = mapped_column(String(20), nullable=False, default="private")
     auth_config_id: Mapped[UUID | None] = mapped_column(


### PR DESCRIPTION
Lazy provisioning starts an instance's container on demand, but nothing ever
stopped it. Nothing recorded activity, and container_monitor.py — despite the
name — sweeps verification state, not containers: its _ORPHAN_GC_SQL marks
verifications stuck in_progress as failed. WarmPoolConfig.IdleTimeout is parsed
from a feature variant and read by nobody. So an instance started once ran until
something else killed it, which is the opposite of the intent behind starting it
lazily.

The sandbox half of the platform already does this properly (PendingIdle,
RetirePodForTask, idleTTL). This gives MCP the same lifecycle, with the control
plane owning it in both cases.

Usage is observed where the traffic is: the MCP proxy is the only component that
sees calls, since Traefik routes the container path directly. It stamps
last_used_at, throttled to one write per minute per instance — a write per
proxied call would put the database on the hot path of every tool call for no
extra signal. A failed stamp is logged, never raised: the cost is an instance
stopped early and lazily restarted, against a broken tool call.

The reaper stops the container and leaves the row, so the next call provisions
it again through the path that started it the first time.

Two deliberate conservative choices:

- NULL last_used_at is NOT idle. It means no call has been observed yet,
  including every row predating this column. Treating unknown as idle would
  stop instances that are merely new.
- Reaping is off unless MCP_IDLE_TIMEOUT is set. Turning it on changes how long
  an instance lives, so an operator opts in rather than discovering it.

Only lazily-provisioned instances are eligible: an eagerly provisioned one was
asked to stay up, and stopping it would be a behaviour change rather than
reclamation.

Test gap, stated plainly: the selection predicate lives in SQL and is not
covered. This repository has no database-backed Go tests, and adding a harness
for one query would establish a pattern rather than verify Postgres semantics.
Covered instead is the guard deciding whether the loop runs at all, where a
mistake either silently disables reclamation or deletes containers on a
deployment that never opted in. Verify the predicate against a real database:
set MCP_IDLE_TIMEOUT=60s, call an instance through /v1/mcp/{id}/mcp, confirm
last_used_at moves and the container is gone about a minute after the last call,
then confirm the next call brings it back.


---