### PR TITLE
feat(mcp): actually mark instances serverless, so lazy start + reaping apply

### DIFF
--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
@@ -539,6 +539,22 @@ class MCPServerInstanceService:
             # health checks against a url-type connection).
             spec.setdefault("type", instance_type)
 
+            # Record whether this instance is serverless — started on its first
+            # call and reclaimed once idle. Nothing else ever writes this field,
+            # so without stamping it here MCP_LAZY_PROVISIONING_ENABLED changes
+            # nothing: both the provisioning path and the reaper key off the
+            # instance, not the platform flag, and every instance stays eager and
+            # runs forever.
+            #
+            # Stored explicitly rather than left absent so the decision is the one
+            # in force when the instance was created. Flipping the platform flag
+            # later must not retroactively change how long existing instances
+            # live — an instance created eagerly was asked to stay up.
+            #
+            # url-type instances have no container to start or stop.
+            if instance_type != "url":
+                spec.setdefault("lazy_provisioning", _lazy_mcp_provisioning_enabled())
+
             create_kwargs: dict[str, Any] = {
                 "name": name,
                 "description": description,

--- a/agentarea-platform/libs/mcp/tests/test_service_and_api.py
+++ b/agentarea-platform/libs/mcp/tests/test_service_and_api.py
@@ -443,6 +443,96 @@ class TestServiceCreateInstance:
         await asyncio.sleep(0)
         assert len(verify_called) == 1
 
+    @pytest.mark.asyncio
+    async def test_container_instance_is_marked_lazy_when_enabled(self, monkeypatch):
+        """Nothing else writes lazy_provisioning, so if creation does not stamp
+        it the platform flag is inert: every instance stays eager, is never
+        reaped, and runs until someone deletes it."""
+        monkeypatch.setenv("MCP_LAZY_PROVISIONING_ENABLED", "true")
+        svc = _make_service()
+
+        with patch("agentarea_mcp.application.service.verify", new=AsyncMock()), \
+             patch("agentarea_mcp.application.service.MCPConfigurationValidator.validate_json_spec", return_value=[]):
+            inst = await svc.create_instance(
+                MCPServerInstanceCreate(
+                    name="docker-inst",
+                    server_spec_id="test-spec-id",
+                    json_spec={"type": "docker"},
+                )
+            )
+
+        assert inst is not None
+        assert inst.json_spec.get("lazy_provisioning") is True
+
+    @pytest.mark.asyncio
+    async def test_container_instance_is_eager_when_flag_off(self, monkeypatch):
+        """The decision is recorded at creation, so turning the flag on later
+        must not retroactively shorten the life of an existing instance."""
+        monkeypatch.setenv("MCP_LAZY_PROVISIONING_ENABLED", "false")
+        svc = _make_service()
+
+        with patch("agentarea_mcp.application.service.verify", new=AsyncMock()), \
+             patch("agentarea_mcp.application.service.MCPConfigurationValidator.validate_json_spec", return_value=[]):
+            inst = await svc.create_instance(
+                MCPServerInstanceCreate(
+                    name="docker-inst",
+                    server_spec_id="test-spec-id",
+                    json_spec={"type": "docker"},
+                )
+            )
+
+        assert inst is not None
+        assert inst.json_spec.get("lazy_provisioning") is False
+
+    @pytest.mark.asyncio
+    async def test_url_instance_is_never_lazy(self, monkeypatch):
+        """A url-type instance has no container to start or stop, so marking it
+        lazy would defer a verification that costs nothing to run now."""
+        monkeypatch.setenv("MCP_LAZY_PROVISIONING_ENABLED", "true")
+        svc = _make_service()
+        url_spec = MagicMock()
+        url_spec.id = "test-spec-id"
+        url_spec.workspace_id = svc.repository.user_context.workspace_id
+        url_spec.remote_url = "http://test.example.com/mcp"
+        url_spec.cmd = None
+        url_spec.docker_image_url = None
+        url_spec.json_spec = {"type": "url", "endpoint_url": "http://test.example.com/mcp"}
+        url_spec.env_schema = []
+        svc.mcp_server_repository.get_server_by_id = AsyncMock(return_value=url_spec)
+
+        fake_verification = {"schema_version": 1, "status": "succeeded", "at": "x", "error": None}
+        with patch("agentarea_mcp.application.service.verify", new=AsyncMock(return_value=fake_verification)), \
+             patch("agentarea_mcp.application.service.MCPConfigurationValidator.validate_json_spec", return_value=[]):
+            inst = await svc.create_instance(
+                MCPServerInstanceCreate(
+                    name="url-inst",
+                    server_spec_id="test-spec-id",
+                    json_spec={"type": "url", "endpoint_url": "http://test.example.com/mcp"},
+                )
+            )
+
+        assert inst is not None
+        assert "lazy_provisioning" not in inst.json_spec
+
+    @pytest.mark.asyncio
+    async def test_explicit_lazy_choice_is_not_overridden(self, monkeypatch):
+        """An explicit per-instance choice wins over the platform default."""
+        monkeypatch.setenv("MCP_LAZY_PROVISIONING_ENABLED", "false")
+        svc = _make_service()
+
+        with patch("agentarea_mcp.application.service.verify", new=AsyncMock()), \
+             patch("agentarea_mcp.application.service.MCPConfigurationValidator.validate_json_spec", return_value=[]):
+            inst = await svc.create_instance(
+                MCPServerInstanceCreate(
+                    name="docker-inst",
+                    server_spec_id="test-spec-id",
+                    json_spec={"type": "docker", "lazy_provisioning": True},
+                )
+            )
+
+        assert inst is not None
+        assert inst.json_spec.get("lazy_provisioning") is True
+
     def test_bundle_create_payload_is_rejected(self):
         """Bundle is no longer a valid MCP server instance type."""
         with pytest.raises(ValueError, match="bundle"):

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -30,6 +30,11 @@ services:
       # MCP settings
       - MCP_MANAGER_URL=http://mcp-manager:80
       - MCP_GATEWAY_URL=http://agentarea-traefik:8080
+      # Serverless MCPs: a container-backed instance is started on its first
+      # call and stopped again once idle (MCP_IDLE_TIMEOUT on mcp-manager),
+      # instead of running from creation until someone deletes it. The instance
+      # records this at creation, so the flag governs new instances only.
+      - MCP_LAZY_PROVISIONING_ENABLED=${MCP_LAZY_PROVISIONING_ENABLED:-true}
       - REDIS_URL=redis://valkey:6379
       - MCP_CLIENT_TIMEOUT=30
       # Hydra OAuth2 AS
@@ -284,6 +289,11 @@ services:
       # Cold start of git/uvx-based MCP servers (clone + install ~90s) needs more
       # than the 120s default before a container is declared unhealthy.
       STARTUP_TIMEOUT: 300s
+      # Stop lazily-provisioned MCP instances that have gone unused this long;
+      # the next call brings them back. Only instances created as lazy are
+      # eligible — eager ones were asked to stay up. 0 disables reclaiming.
+      MCP_IDLE_TIMEOUT: ${MCP_IDLE_TIMEOUT:-10m}
+      MCP_IDLE_SWEEP_INTERVAL: ${MCP_IDLE_SWEEP_INTERVAL:-60s}
       # Run the sandbox execution consumer in-process (no standalone runner in
       # compose) and route code-execution to the sandbox-executor container.
       SANDBOX_EMBEDDED_RUNNER: "true"
@@ -437,6 +447,11 @@ services:
       # MCP settings
       - MCP_MANAGER_URL=http://mcp-manager:80
       - MCP_GATEWAY_URL=http://agentarea-traefik:8080
+      # Serverless MCPs: a container-backed instance is started on its first
+      # call and stopped again once idle (MCP_IDLE_TIMEOUT on mcp-manager),
+      # instead of running from creation until someone deletes it. The instance
+      # records this at creation, so the flag governs new instances only.
+      - MCP_LAZY_PROVISIONING_ENABLED=${MCP_LAZY_PROVISIONING_ENABLED:-true}
       - SANDBOX_CLEANUP_AUTH_SECRET=${SANDBOX_CLEANUP_AUTH_SECRET:-agentarea-dev-sandbox-cleanup-secret-change-me}
 
       # Task execution


### PR DESCRIPTION
Completes the serverless MCP model. #295/#296 built the reaper; this gives it something to act on.

## The gap

`MCP_LAZY_PROVISIONING_ENABLED` has been **inert**. Both the lazy-provisioning path and the reaper key off `json_spec.lazy_provisioning` on the *instance* — and nothing in the product ever wrote that field. The only writer in the tree is `dev/agent_scenario_runner.py`.

Consequence: no instance was ever lazy, every instance was provisioned at creation and ran until deleted, and flipping the platform flag changed nothing. Confirmed against a live database — all 23 instances there have `lazy = false`.

This is the same shape as the isolation fields in #292: a well-formed consumer with no producer.

## What this does

Stamps the decision at creation for container-backed instances.

Recorded **explicitly** rather than left absent, so the stored value is the policy in force when the instance was created. Flipping the platform flag later must not retroactively shorten the life of instances that were provisioned eagerly — an eager instance was asked to stay up. An explicit per-instance choice still wins over the platform default, and `url`-type instances have no container to start or stop, so they stay unmarked.

Also enables the model in the dev stack (`app`, `agentarea-worker`, `mcp-manager`) so the path is exercised rather than only existing in code. Both knobs stay overridable and the platform default stays off — no deployment changes behaviour without opting in.

## Tradeoff worth naming

With lazy on, creating a connection no longer verifies it immediately, so a bad image or missing env surfaces on first use instead of at creation. That is inherent to serverless, not a defect — but it is why this is opt-in rather than the default.

## Verification

461 platform tests pass, ruff clean. Four new tests cover the decision matrix: marked lazy when enabled, eager when disabled, never lazy for url-type, and an explicit choice not overridden.

Compose YAML was parsed to confirm the vars land on the right three services. `docker compose config` cannot run in this worktree — it has no `.env` — so that check is not claimed.