### PR TITLE
feat(mcp): make serverless MCP deployable and safe to run in production

### DIFF
--- a/agentarea-mcp-manager/internal/mcpidle/lock.go
+++ b/agentarea-mcp-manager/internal/mcpidle/lock.go
@@ -1,0 +1,66 @@
+package mcpidle
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+// sweepLockKey identifies the reaper's advisory lock.
+//
+// A literal rather than a hash of a name so the value is stable across builds
+// and greppable when someone finds it held in pg_locks. Chosen to not collide
+// with any other advisory lock in the platform.
+const sweepLockKey int64 = 0x6D63705F69646C65 // "mcp_idle"
+
+// sweepLock is a held advisory lock, pinned to the connection that took it.
+type sweepLock struct {
+	conn   *sql.Conn
+	logger *slog.Logger
+}
+
+// acquireSweepLock takes a cluster-wide advisory lock for one sweep.
+//
+// mcpManager.replicaCount is an operator knob, so more than one manager can be
+// running. Every replica would otherwise select the same idle rows and race to
+// delete the same workloads: the losers log failures for work that already
+// succeeded, and an instance provisioned between one replica's select and
+// another's delete can be torn down immediately after coming up. Serialising
+// the sweep is cheaper and clearer than making every step idempotent.
+//
+// The lock is session-scoped and pinned to a dedicated connection, so a manager
+// that crashes mid-sweep releases it when its connection closes — there is no
+// stuck lock to clear by hand.
+//
+// A second return of false means another replica is sweeping; that is the
+// normal, non-error outcome and the caller should simply skip this tick.
+func acquireSweepLock(ctx context.Context, db *sql.DB, logger *slog.Logger) (*sweepLock, bool, error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("acquiring connection for sweep lock: %w", err)
+	}
+
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", sweepLockKey).Scan(&acquired); err != nil {
+		conn.Close()
+		return nil, false, fmt.Errorf("taking sweep lock: %w", err)
+	}
+	if !acquired {
+		conn.Close()
+		return nil, false, nil
+	}
+
+	return &sweepLock{conn: conn, logger: logger}, true, nil
+}
+
+// release drops the advisory lock and returns the connection to the pool.
+func (l *sweepLock) release(ctx context.Context) {
+	if _, err := l.conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", sweepLockKey); err != nil {
+		// Closing the connection ends the session, which drops the lock anyway;
+		// log it because a failure here usually means the database went away
+		// mid-sweep and the rest of the sweep's results are suspect.
+		l.logger.Warn("Failed to release MCP idle sweep lock", slog.String("error", err.Error()))
+	}
+	l.conn.Close()
+}

--- a/agentarea-mcp-manager/internal/mcpidle/reaper.go
+++ b/agentarea-mcp-manager/internal/mcpidle/reaper.go
@@ -125,6 +125,18 @@ func (r *Reaper) Reap(ctx context.Context, db *sql.DB, idleTimeout time.Duration
 		return 0, nil
 	}
 
+	// One sweeper at a time across every manager replica. Without this, two
+	// replicas select the same rows and race to delete the same workloads.
+	lock, acquired, err := acquireSweepLock(ctx, db, r.logger)
+	if err != nil {
+		return 0, err
+	}
+	if !acquired {
+		r.logger.Debug("Skipping MCP idle sweep: another replica holds the sweep lock")
+		return 0, nil
+	}
+	defer lock.release(ctx)
+
 	idle, err := r.findIdle(ctx, db, idleTimeout)
 	if err != nil {
 		return 0, err

--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -279,8 +279,9 @@ The following table lists configurable parameters of the chart and their default
 | mcpManager.image.tag | string | `"latest"` |  |
 | mcpManager.service.type | string | `"ClusterIP"` |  |
 | mcpManager.service.port | int | `80` |  |
-| mcpManager.idleTimeout | string | `"0"` |  |
-| mcpManager.idleSweepInterval | string | `"60s"` |  |
+| mcpManager.serverless.enabled | bool | `false` |  |
+| mcpManager.serverless.idleTimeout | string | `"10m"` |  |
+| mcpManager.serverless.sweepInterval | string | `"60s"` |  |
 | mcpManager.instanceNetworkPolicy.enabled | bool | `true` |  |
 | mcpManager.instanceNetworkPolicy.dnsNamespace | string | `"kube-system"` |  |
 | mcpManager.instanceNetworkPolicy.blockedEgressCIDRs[0] | string | `"10.0.0.0/8"` |  |

--- a/charts/agentarea/config.yaml
+++ b/charts/agentarea/config.yaml
@@ -83,6 +83,9 @@ groups:
       LOG_LEVEL: 'info'
       MCP_MANAGER_URL: 'http://{{ include "agentarea.fullname" . }}-mcp-manager:{{ .Values.mcpManager.service.port }}'
       MCP_CLIENT_TIMEOUT: '30'
+      # Read where instances are created and where tool calls are dispatched, so
+      # the API and the worker must agree with the manager on this.
+      MCP_LAZY_PROVISIONING_ENABLED: '{{ .Values.mcpManager.serverless.enabled }}'
       API_HOST: '{{ .Values.global.api.host }}'
       API_PORT: '{{ .Values.global.api.port }}'
       API_BASE_URL: '{{ include "agentarea.backend.apiUrl" . }}'
@@ -125,8 +128,14 @@ groups:
       KUBERNETES_DEFAULT_MEMORY_REQUEST: '128Mi'
       KUBERNETES_DEFAULT_MEMORY_LIMIT: '512Mi'
       MCP_FEATURES_ENABLED: '{{ join "," .Values.mcpManager.features.enabled }}'
-      MCP_IDLE_TIMEOUT: '{{ .Values.mcpManager.idleTimeout | default "0" }}'
-      MCP_IDLE_SWEEP_INTERVAL: '{{ .Values.mcpManager.idleSweepInterval | default "60s" }}'
+      # Reaping is derived from serverless.enabled rather than configured
+      # separately: only instances created as lazy are ever eligible, so a
+      # timeout without lazy start reclaims nothing, and lazy start without a
+      # timeout brings instances up on demand and then leaves them up forever.
+      # Deriving both from one switch makes the half-configured states
+      # unreachable.
+      MCP_IDLE_TIMEOUT: '{{ if .Values.mcpManager.serverless.enabled }}{{ .Values.mcpManager.serverless.idleTimeout }}{{ else }}0{{ end }}'
+      MCP_IDLE_SWEEP_INTERVAL: '{{ .Values.mcpManager.serverless.sweepInterval }}'
 
   temporalUi:
     configVars:
@@ -143,6 +152,9 @@ groups:
       DEBUG: 'false'
       ENVIRONMENT: 'production'
       MCP_MANAGER_URL: 'http://{{ include "agentarea.fullname" . }}-mcp-manager:{{ .Values.mcpManager.service.port }}'
+      # The worker dispatches agent tool calls, so it is a provisioning trigger
+      # in its own right; without this a reaped instance stays down for agents.
+      MCP_LAZY_PROVISIONING_ENABLED: '{{ .Values.mcpManager.serverless.enabled }}'
 
   application:
     secrets:

--- a/charts/agentarea/templates/configs/backend.env.tpl
+++ b/charts/agentarea/templates/configs/backend.env.tpl
@@ -8,6 +8,7 @@ PORT: "8000"
 LOG_LEVEL: "info"
 MCP_MANAGER_URL: "http://{{ include "agentarea.fullname" . }}-mcp-manager:{{ .Values.mcpManager.service.port }}"
 MCP_CLIENT_TIMEOUT: "30"
+MCP_LAZY_PROVISIONING_ENABLED: "{{ .Values.mcpManager.serverless.enabled }}"
 API_HOST: "{{ .Values.global.api.host }}"
 API_PORT: "{{ .Values.global.api.port }}"
 API_BASE_URL: "{{ include "agentarea.backend.apiUrl" . }}"
@@ -41,6 +42,11 @@ KRATOS_AUDIENCE: "{{ .Values.kratos.jwt.audience }}"
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-backend
       key: MCP_CLIENT_TIMEOUT
+- name: MCP_LAZY_PROVISIONING_ENABLED
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "agentarea.fullname" . }}-env-backend
+      key: MCP_LAZY_PROVISIONING_ENABLED
 - name: API_HOST
   valueFrom:
     configMapKeyRef:

--- a/charts/agentarea/templates/configs/mcpManager.env.tpl
+++ b/charts/agentarea/templates/configs/mcpManager.env.tpl
@@ -23,8 +23,8 @@ KUBERNETES_DEFAULT_CPU_LIMIT: "500m"
 KUBERNETES_DEFAULT_MEMORY_REQUEST: "128Mi"
 KUBERNETES_DEFAULT_MEMORY_LIMIT: "512Mi"
 MCP_FEATURES_ENABLED: "{{ join "," .Values.mcpManager.features.enabled }}"
-MCP_IDLE_TIMEOUT: "{{ .Values.mcpManager.idleTimeout | default "0" }}"
-MCP_IDLE_SWEEP_INTERVAL: "{{ .Values.mcpManager.idleSweepInterval | default "60s" }}"
+MCP_IDLE_TIMEOUT: "{{ if .Values.mcpManager.serverless.enabled }}{{ .Values.mcpManager.serverless.idleTimeout }}{{ else }}0{{ end }}"
+MCP_IDLE_SWEEP_INTERVAL: "{{ .Values.mcpManager.serverless.sweepInterval }}"
 {{- end }}
 
 {{- define "agentarea.mcpManager.envs" }}

--- a/charts/agentarea/templates/configs/worker.env.tpl
+++ b/charts/agentarea/templates/configs/worker.env.tpl
@@ -12,6 +12,7 @@ TASK__ENABLE_DYNAMIC_ACTIVITY_DISCOVERY: "true"
 DEBUG: "false"
 ENVIRONMENT: "production"
 MCP_MANAGER_URL: "http://{{ include "agentarea.fullname" . }}-mcp-manager:{{ .Values.mcpManager.service.port }}"
+MCP_LAZY_PROVISIONING_ENABLED: "{{ .Values.mcpManager.serverless.enabled }}"
 {{- end }}
 
 {{- define "agentarea.worker.envs" }}
@@ -55,4 +56,9 @@ MCP_MANAGER_URL: "http://{{ include "agentarea.fullname" . }}-mcp-manager:{{ .Va
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-worker
       key: MCP_MANAGER_URL
+- name: MCP_LAZY_PROVISIONING_ENABLED
+  valueFrom:
+    configMapKeyRef:
+      name: {{ include "agentarea.fullname" . }}-env-worker
+      key: MCP_LAZY_PROVISIONING_ENABLED
 {{- end }}

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -502,14 +502,24 @@ mcpManager:
     type: ClusterIP
     port: 80
 
-  # Stop a lazily-provisioned MCP instance whose workload has gone unused for
-  # this long; the next tool call provisions it again. "0" keeps every instance
-  # running once started, which is the behaviour before this knob existed — so
-  # reclaiming is something an operator turns on, not something a chart upgrade
-  # does to them. Eagerly-provisioned instances are never reaped.
-  idleTimeout: "0"
-  # How often to look for idle instances.
-  idleSweepInterval: "60s"
+  # Serverless MCP instances: a container-backed instance is started on its
+  # first call and reclaimed once it has gone idle, instead of running from
+  # creation until it is deleted.
+  #
+  # Off by default. Enabling changes two user-visible things: an instance's
+  # first call pays a cold start, and creating a connection no longer verifies
+  # it immediately — a bad image or a missing variable surfaces on first use
+  # rather than in the form. That is a product decision, not a chart upgrade.
+  #
+  # Only instances created while this is on are serverless; the choice is
+  # recorded per instance, so turning it on does not retroactively change the
+  # lifetime of instances that already exist.
+  serverless:
+    enabled: false
+    # How long an instance may go uncalled before its workload is reclaimed.
+    idleTimeout: "10m"
+    # How often to look for idle instances.
+    sweepInterval: "60s"
 
   # Egress restriction for spawned MCP instance pods (which may run untrusted,
   # user-supplied images). Denies cluster-internal + cloud-metadata egress while

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,7 @@
           "agent-governance",
           "mcp-integration",
           "mcp-oauth",
+          "serverless-mcp",
           "compound-mcps",
           "event-triggers"
         ]

--- a/docs/serverless-mcp.md
+++ b/docs/serverless-mcp.md
@@ -1,0 +1,121 @@
+---
+title: "Serverless MCP instances"
+description: "Start MCP servers on first use and reclaim them once idle, instead of running every connected server continuously."
+---
+
+By default, connecting an MCP server starts its container and leaves it running
+until someone deletes the connection. A workspace with thirty connections runs
+thirty containers, whether or not an agent has called any of them this month.
+
+Serverless mode changes that: a container-backed instance is started on its
+first call and stopped again once it has gone idle. The connection, its
+credentials, and its discovered tools all stay exactly as they were — only the
+running workload comes and goes.
+
+## What changes when you enable it
+
+Two things become visible to users, and both are inherent to the model rather
+than defects to work around.
+
+**The first call after an idle period pays a cold start.** How long depends
+entirely on the server: a small published image starts in a second or two, while
+a `uvx`/`npx` server that clones and installs on boot can take a minute or more.
+The call waits for provisioning rather than failing.
+
+**Creating a connection no longer verifies it immediately.** Verification is
+what starts the container and lists its tools, so deferring the start defers the
+check. A bad image reference or a missing environment variable surfaces on first
+use instead of in the connection form.
+
+If neither trade is acceptable for your users, leave it off. It is off by
+default.
+
+## Enabling it
+
+```yaml
+mcpManager:
+  serverless:
+    enabled: true
+    # How long an instance may go uncalled before it is reclaimed.
+    idleTimeout: "10m"
+    # How often to look for idle instances.
+    sweepInterval: "60s"
+```
+
+One switch drives every component that has to agree about it — the API and the
+worker (which create instances and dispatch tool calls) and the MCP manager
+(which reclaims them). Configuring them separately is not possible by design: an
+idle timeout without lazy start reclaims nothing, and lazy start without a
+timeout brings instances up on demand and then leaves them up forever.
+
+## Which instances are affected
+
+Only instances **created while serverless is on**. The choice is recorded on
+each instance when it is created, so enabling the setting later does not
+retroactively shorten the life of connections that already exist, and turning it
+off does not strand the ones that were created serverless.
+
+Also excluded:
+
+- **Remote (`url`-type) connections** — there is no container to start or stop.
+- **Instances that have never been called.** An instance with no recorded use is
+  treated as new, not as idle. Reclaiming requires evidence of disuse, not the
+  absence of evidence of use.
+
+## How reclaiming works
+
+The MCP proxy records a timestamp when traffic passes through it — it is the
+only component that sees MCP calls, since the gateway routes to the container
+directly. Writes are throttled to one per instance per minute, so an active
+instance does not put the database on the hot path of every tool call.
+
+The manager sweeps on `sweepInterval`. For each instance past its idle window it
+stops the workload and marks the instance unprovisioned; the database row, the
+credentials, and the tool list are untouched. The next call finds it
+unprovisioned and starts it again through the same path that started it the
+first time.
+
+Sweeping is serialised with a Postgres advisory lock, so running more than one
+manager replica does not mean more than one sweeper. If a manager dies
+mid-sweep, its lock is released with its connection — there is nothing to clear
+by hand.
+
+## Verifying it works
+
+With serverless on, create a container-backed connection and watch the manager:
+
+```bash
+kubectl logs -l app.kubernetes.io/component=mcp-manager -f | grep -i idle
+```
+
+On startup you should see the reaper announce its window:
+
+```
+Starting MCP idle reaper idle_timeout=10m interval=1m0s
+```
+
+Call a tool on the connection, leave it alone for longer than `idleTimeout`, and
+the sweep reports the reclamation:
+
+```
+Stopped idle MCP instance instance_id=... instance_name=...
+```
+
+Calling the same connection again starts it back up. If instead you see nothing
+at all, the most likely cause is that the instances predate the setting — check
+one:
+
+```sql
+SELECT name, json_spec->>'lazy_provisioning' AS serverless
+FROM mcp_server_instances;
+```
+
+Instances showing `false` or an empty value were created eagerly and are never
+reclaimed. Recreate the connection to make it serverless.
+
+## Turning it off
+
+Set `serverless.enabled: false`. Instances already created serverless keep that
+property, but nothing reclaims them any more: each one starts on its next call
+and then stays up. To make them permanently resident, recreate the connections
+with the setting off.


### PR DESCRIPTION
Takes the serverless MCP model from "works" to "deployable". Three gaps stood in the way.

## 1. It could not be enabled

`MCP_LAZY_PROVISIONING_ENABLED` was **not in the chart at all**. A Helm deployment had no way to turn serverless on — which left the idle reaper from #295/#296 with nothing to reap. Now exposed on the API and the worker, both of which create instances and dispatch tool calls.

## 2. It could be half-configured

Idle reaping and lazy start were separate knobs, and the broken combinations fail silently:

- a timeout without lazy start reclaims nothing — only lazy instances are eligible
- lazy start without a timeout brings instances up on demand and then leaves them up forever

Collapsed into one `mcpManager.serverless` block, with the env derived from it, so the incoherent states are unreachable:

```yaml
mcpManager:
  serverless:
    enabled: true
    idleTimeout: "10m"
    sweepInterval: "60s"
```

The previous `idleTimeout`/`idleSweepInterval` values are replaced rather than deprecated — they landed after v0.0.13 and have never appeared in a release, so nothing can be pinned to them.

## 3. Two replicas would both sweep

`mcpManager.replicaCount` is an operator knob. Every replica would select the same idle rows and race to delete the same workloads: the losers log failures for work that already succeeded, and an instance provisioned between one replica's select and another's delete gets torn down right after coming up.

Sweeping is now serialised behind a Postgres advisory lock on a dedicated connection — cheaper and clearer than making every step idempotent, and a manager that dies mid-sweep releases the lock with its connection instead of leaving one stuck.

## Documentation

New operator page covering what enabling it changes for **users**, since both effects are inherent to the model rather than defects:

- the first call after an idle period pays a cold start
- creating a connection no longer verifies it immediately, so a bad image or missing variable surfaces on first use rather than in the form

That is why it stays off by default. The page also covers which instances are affected (only those created while it is on — the choice is recorded per instance), how to verify it is working, and how to turn it off.

## Verification

Against a real database, not only unit tests:

- a second session **cannot** take the sweep lock while the first holds it
- the lock becomes available again once the holder's session ends — the crash-recovery property the code claims

Chart rendered in both states to confirm one switch drives all four components coherently — off: `lazy=false`, `timeout=0`; on: `lazy=true`, `timeout=10m` — and that the vars reach the backend, worker and manager deployments.

Go 180 tests, `helm lint` clean, helm-docs and env templates regenerated.

## Not in this PR

Controlling **where** an MCP runs (the gVisor host) is untouched. The data plane can already host one — `activation-service` exposes `/activate` taking `mcp_image`/`port`/`env` — but the docker backend never calls it, `ActivatePod` is typed to `*corev1.Pod`, and the activation service is one-workload-per-instance, so hosting N MCPs needs a pool design on a plain VM. That is a separate piece of work.