### PR TITLE
fix(sandbox): stamp the real version into the runtime manifest, not "dev"

### DIFF
--- a/agentarea-mcp-manager/Dockerfile.runner
+++ b/agentarea-mcp-manager/Dockerfile.runner
@@ -47,7 +47,14 @@ COPY runtime/requirements.txt /opt/runtime/requirements.txt
 RUN python -m venv /opt/runtime/venv \
     && pip install --no-cache-dir -r /opt/runtime/requirements.txt
 
-ARG RUNTIME_VERSION=dev
+# The version stamped into the runtime manifest. APP_VERSION is what the build
+# workflow already injects into every image from the VERSION file, so reading it
+# here means there is one version source instead of a second one to forget: the
+# previous RUNTIME_VERSION arg was passed by nobody, and every published runner
+# reported "dev" — which made the manifest useless for the one question it
+# exists to answer, "which build is this sandbox actually running".
+# Local builds (compose) pass nothing and keep the dev default.
+ARG APP_VERSION=dev
 ARG MANAGED_ENVIRONMENT=mutable
 COPY runtime/generate_manifest.py /opt/runtime/generate_manifest.py
 COPY runtime/test_locked_profile.sh /opt/runtime/test_locked_profile.sh
@@ -70,7 +77,7 @@ RUN mkdir -p /etc/agentarea \
            ;; \
          *) echo "MANAGED_ENVIRONMENT must be mutable or immutable" >&2; exit 1 ;; \
        esac \
-    && RUNTIME_VERSION=${RUNTIME_VERSION} MANAGED_ENVIRONMENT=${MANAGED_ENVIRONMENT} \
+    && RUNTIME_VERSION=${APP_VERSION} MANAGED_ENVIRONMENT=${MANAGED_ENVIRONMENT} \
        python /opt/runtime/generate_manifest.py \
        > /etc/agentarea/runtime.json \
     && cat /etc/agentarea/runtime.json \


### PR DESCRIPTION
## The bug

`Dockerfile.runner` declared `ARG RUNTIME_VERSION=dev` and **nothing ever passed it**. Every published sandbox runner baked `image_version: "dev"` into `/etc/agentarea/runtime.json`, which the activation service serves at `/runtime/manifest`.

So the one question that manifest exists to answer — *which build is this sandbox actually running* — could not be answered on any host.

That matters exactly when it is needed. After shipping the pillow/pypdf/lxml CVE fixes into the runtime image, there was no way to confirm from a running gVisor host whether they had landed.

## The fix

Read `APP_VERSION` instead of adding a second version input. The build workflow already injects it into every image from the `VERSION` file, on both the push path and the build-only path — so this removes the class rather than patching the instance. There is no second arg left to forget.

Local compose builds pass nothing and keep the `dev` default, which is accurate for them.

`managed_environment` in the same manifest was always passed correctly and is load-bearing (it gates locked pools through `SupportsPackageInstall`). Only the version was broken.

## Validation limits — stated, not glossed

This image builds only on `main` and `release/*`, never on a regular PR, so **CI will not exercise this Dockerfile before merge**. I verified statically instead:

- the `ARG` sits in the same build stage as the `RUN` that consumes it (both after the second `FROM`) — ARG scope is per-stage, which is the easy thing to get wrong here
- `generate_manifest.py` still receives a non-empty `RUNTIME_VERSION` and keeps its fail-on-empty guard, so a regression surfaces as a failed build rather than an empty field
- no other file passes `RUNTIME_VERSION` as a build arg that would now be silently ignored

After this merges to main, the runner build runs and `/runtime/manifest` should report the VERSION file's value.