### PR TITLE
fix(sandbox): make a failed image pull visible instead of silently stale

### DIFF
--- a/deploy/sandbox-host/roles/sandbox_host/templates/sandbox-executor.service.j2
+++ b/deploy/sandbox-host/roles/sandbox_host/templates/sandbox-executor.service.j2
@@ -16,6 +16,19 @@ ExecStartPre=-/usr/bin/docker rm -f {{ sandbox_executor_name }}
 # Best-effort: refresh from the registry when reachable, but still start from a
 # locally-loaded image (e.g. built from Dockerfile.runner and `docker load`ed).
 ExecStartPre=-/usr/bin/docker pull {{ sandbox_executor_image }}
+# The pull above is deliberately non-fatal, which means a failed pull is
+# indistinguishable from a successful one: the executor starts on whatever image
+# is already on disk. For a component whose whole job is confining untrusted
+# code, silently running last month's build after a transient registry failure
+# is the dangerous outcome — a shipped CVE fix would look applied and not be.
+#
+# Hard-failing the pull is the wrong trade: a network blip would take the
+# sandbox down even though a good image is present. So instead: refuse only when
+# there is no image at all (not a transient condition, and otherwise surfaces as
+# an obscure `docker run` error), and log the image id actually being started so
+# `journalctl -u agentarea-sandbox-executor` answers "which build is running"
+# — the same question /runtime/manifest answers from inside the container.
+ExecStartPre=/bin/sh -c 'id=$(/usr/bin/docker images --no-trunc --quiet {{ sandbox_executor_image }}); if [ -z "$id" ]; then echo "sandbox executor image {{ sandbox_executor_image }} is absent locally and could not be pulled - refusing to start"; exit 1; fi; echo "sandbox executor starting from image $id"'
 ExecStart=/usr/bin/docker run --rm --name {{ sandbox_executor_name }} \
   --runtime={{ sandbox_runtime }} \
   --cap-drop ALL \


### PR DESCRIPTION
Pairs with #301. That one made the runtime manifest report a real version; this one makes it possible to tell whether the image carrying that version is the one actually running.

## The hazard

`ExecStartPre=-/usr/bin/docker pull` is non-fatal by design — the `-` lets the executor start from a locally-loaded image. The cost is that **a failed pull is indistinguishable from a successful one**: the unit starts on whatever is already on disk, with no signal.

For the component whose entire job is confining untrusted code, that failure is quiet in the worst way. After a transient registry failure the host keeps running last month's build, and a shipped CVE fix looks applied while it isn't. This is not hypothetical for this repo — the pillow/pypdf/lxml fixes shipped into exactly this image.

## Why not just remove the `-`

That trades one failure for a worse one: a network blip would take the sandbox down even though a perfectly good image is present locally. Availability lost, freshness not actually gained.

## What this does instead

Keeps the pull best-effort and adds the two things that were missing:

- **Refuse to start when there is no image at all.** Not a transient condition, and today it surfaces as an obscure `docker run` error a moment later rather than a statement of what is wrong.
- **Log the image id being started**, so `journalctl -u agentarea-sandbox-executor` answers "which build is running" from outside the container — the same question `/runtime/manifest` answers from inside.

Staleness becomes *visible* rather than *prevented*, which is the right level here: the operator can see it, and availability is untouched.

## Verification

No CI job renders this template, so I verified locally:

- rendered the Jinja template with representative values — no leftover delimiters
- `sh -n` on the extracted `ExecStartPre`
- both branches with the docker call stubbed: absent image exits 1 with the message, present image exits 0 and logs the id