### PR TITLE
fix(sandbox): require an explicit version instead of defaulting to "dev"

### DIFF
--- a/agentarea-mcp-manager/Dockerfile.runner
+++ b/agentarea-mcp-manager/Dockerfile.runner
@@ -47,14 +47,19 @@ COPY runtime/requirements.txt /opt/runtime/requirements.txt
 RUN python -m venv /opt/runtime/venv \
     && pip install --no-cache-dir -r /opt/runtime/requirements.txt
 
-# The version stamped into the runtime manifest. APP_VERSION is what the build
-# workflow already injects into every image from the VERSION file, so reading it
-# here means there is one version source instead of a second one to forget: the
-# previous RUNTIME_VERSION arg was passed by nobody, and every published runner
-# reported "dev" — which made the manifest useless for the one question it
-# exists to answer, "which build is this sandbox actually running".
-# Local builds (compose) pass nothing and keep the dev default.
-ARG APP_VERSION=dev
+# The version stamped into the runtime manifest, from the VERSION file via the
+# build workflow's APP_VERSION — one version source rather than a second one to
+# forget.
+#
+# Deliberately declared with NO default. A default is what caused the bug this
+# replaced: the old `ARG RUNTIME_VERSION=dev` was passed by nobody, so "dev" was
+# not a fallback for local builds, it was the only value any published image
+# ever carried — and the manifest silently lied about which build was running.
+# With no default, a build site that forgets to pass a version fails at
+# generate_manifest.py ("RUNTIME_VERSION must be set at build time") instead of
+# shipping a plausible-looking wrong answer. Every build site now states its
+# own version, including compose.
+ARG APP_VERSION
 ARG MANAGED_ENVIRONMENT=mutable
 COPY runtime/generate_manifest.py /opt/runtime/generate_manifest.py
 COPY runtime/test_locked_profile.sh /opt/runtime/test_locked_profile.sh

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -322,6 +322,12 @@ services:
     build:
       context: agentarea-mcp-manager
       dockerfile: Dockerfile.runner
+      args:
+        # Stamped into /etc/agentarea/runtime.json and served at
+        # /runtime/manifest. Dockerfile.runner declares no default, so this must
+        # be stated here — "dev" is the honest answer for a local build, and it
+        # is now a claim this file makes rather than one the image invents.
+        APP_VERSION: ${VERSION:-dev}
       platforms:
         - linux/amd64
         - linux/arm64


### PR DESCRIPTION
Follow-up to #301, which fixed the plumbing but left the thing that caused the bug.

## The default was the defect

#301 made the workflow pass a real version, but kept `ARG APP_VERSION=dev`.

That default is what hid the problem in the first place. The old `ARG RUNTIME_VERSION=dev` was passed by **nobody**, so `"dev"` was never a fallback for local builds — it was the only value any published image ever carried, and `/runtime/manifest` reported it as fact. A default that is wrong everywhere looks exactly like a default that is right somewhere.

## Change

Remove the default. `${APP_VERSION}` is then empty when a build site forgets to pass one, and `generate_manifest.py` already refuses an empty value:

```
RUNTIME_VERSION must be set at build time
```

So the build fails instead of shipping a plausible-looking wrong answer. This is the repo's own rule — never guess when a required value is missing.

Every build site now states its own version:

- **CI** already did. Verified in the actual main build for #301: `--build-arg APP_VERSION=0.0.13`, the manifest layer **executed rather than cached**, and printed `"image_version": "0.0.13"`.
- **compose** was the one site passing nothing, so it now declares `APP_VERSION: ${VERSION:-dev}`. `dev` is the honest answer for a local build — and it is now a claim `docker-compose.dev.yaml` makes, not one the image invents.

## Verification

This image builds only on `main`/`release/*`, so no container build here. Verified the parts directly instead:

- manifest generator exits 1 with its message on an empty version, and yields `image_version: "0.0.13"` on a real one
- compose parses with the arg attached to the right service
- the `ARG` still sits in the same build stage as the `RUN` that consumes it

## Note

`agentarea-webapp/Dockerfile` has the same shape (`ARG APP_VERSION=0.0.0`), but its value feeds a label rather than an operator-facing manifest, and CI passes the real version there too. Left alone deliberately rather than swept in.