### PR TITLE
refactor(mcp-manager): drop the warm-pool config that configured nothing

### DIFF
--- a/agentarea-mcp-manager/internal/features/features.go
+++ b/agentarea-mcp-manager/internal/features/features.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strconv"
 	"strings"
-	"time"
 )
 
 // Feature represents a feature flag
@@ -247,10 +245,6 @@ func (s *Service) GetVariantCtx(ctx context.Context, feature Feature) map[string
 }
 
 // Check helpers for specific features
-func (s *Service) WarmPoolEnabled() bool {
-	return s.IsEnabled(WarmPool)
-}
-
 func (s *Service) KataRuntimeEnabled() bool {
 	return s.IsEnabled(KataRuntime)
 }
@@ -267,37 +261,13 @@ func (s *Service) GatewayAPIEnabled() bool {
 	return s.IsEnabled(GatewayAPI)
 }
 
-// GetWarmPoolConfig returns warm pool configuration
-func (s *Service) GetWarmPoolConfig() WarmPoolConfig {
-	variant := s.GetVariant(WarmPool)
-
-	cfg := WarmPoolConfig{
-		Enabled:     s.WarmPoolEnabled(),
-		Size:        10, // default
-		IdleTimeout: 5 * time.Minute,
-	}
-
-	if size, ok := variant["size"]; ok {
-		if n, err := strconv.Atoi(size); err == nil {
-			cfg.Size = n
-		}
-	}
-
-	if timeout, ok := variant["idle_timeout"]; ok {
-		if d, err := time.ParseDuration(timeout); err == nil {
-			cfg.IdleTimeout = d
-		}
-	}
-
-	return cfg
-}
-
-// WarmPoolConfig holds warm pool configuration
-type WarmPoolConfig struct {
-	Enabled     bool
-	Size        int
-	IdleTimeout time.Duration
-}
+// GetWarmPoolConfig and its WarmPoolConfig struct were removed here. They had no
+// callers: nothing read Size, and nothing read IdleTimeout — the pool size comes
+// from the chart, and MCP instance idleness is owned by internal/mcpidle via
+// MCP_IDLE_TIMEOUT. Keeping them was worse than dead weight, because an
+// `idle_timeout` variant on the warm_pool flag reads as the way to configure
+// exactly the thing it did not configure. Restore from git history if a warm
+// pool ever needs per-variant tuning.
 
 // Reload reloads feature configuration
 func (s *Service) Reload() error {


### PR DESCRIPTION
`GetWarmPoolConfig`, `WarmPoolConfig` and `WarmPoolEnabled` had **no callers anywhere** outside `features.go`. Nothing read `Size` — the pool size comes from the chart — and nothing read `IdleTimeout`.

## Why this is worth removing rather than leaving

Dead code is usually just weight. This was worse: it advertised an `idle_timeout` variant on the `warm_pool` flag, which reads as the supported way to configure exactly the thing it did not configure.

That was merely useless while nothing reclaimed idle MCP instances. Now that `MCP_IDLE_TIMEOUT` does (#295–#298), it is a trap sitting next to the real knob — an operator who found it first would tune a value nobody reads and conclude reaping is broken.

## Scope

Removed the three symbols and the `strconv`/`time` imports they were the last users of.

**Kept** the `GetVariant` provider seam. It is a general extension point of the feature system rather than warm-pool-specific, so removing an interface method with three implementations would be a larger change than the problem warrants.

## Verification

`go build` / `go vet` clean, 180 tests pass, `gofmt` clean.

Checked docs and charts: the only remaining `idle_timeout` is the real reaper's log line quoted in `docs/serverless-mcp.md`, which is unrelated to the removed variant.