### PR TITLE
feat: run MCP servers and agent sandboxes on one isolated substrate

### DIFF
--- a/agentarea-mcp-manager/internal/backends/cluster_config.go
+++ b/agentarea-mcp-manager/internal/backends/cluster_config.go
@@ -1,0 +1,53 @@
+package backends
+
+import (
+	"fmt"
+	"log/slog"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// resolveClusterConfig picks the cluster this manager creates workloads in.
+//
+// An explicitly configured kubeconfig WINS over in-cluster credentials, and a
+// failure to load it is fatal rather than a reason to look elsewhere. The order
+// used to be the other way around — in-cluster first, kubeconfig only if that
+// failed — which meant a manager running inside the control-plane cluster would
+// silently create workloads there even when the operator had pointed it at a
+// separate execution cluster. Untrusted MCP servers and agent sandboxes would
+// land next to the control plane: exactly the arrangement a separate execution
+// cluster exists to prevent, arrived at without a single error being logged.
+//
+// An empty setting means "use whatever cluster I am in". That is discovery, not
+// a fallback: nothing was declared, so there is nothing to fall back from.
+func resolveClusterConfig(kubeconfig string, logger *slog.Logger) (*rest.Config, error) {
+	if kubeconfig != "" {
+		cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"loading the configured execution cluster kubeconfig %q: %w "+
+					"(KUBERNETES_KUBECONFIG names the cluster workloads run in; "+
+					"refusing to fall back to the manager's own cluster)",
+				kubeconfig, err)
+		}
+		logger.Info("Using configured execution cluster",
+			slog.String("kubeconfig", kubeconfig),
+			slog.String("host", cfg.Host))
+		return cfg, nil
+	}
+
+	if cfg, err := rest.InClusterConfig(); err == nil {
+		logger.Info("Using in-cluster credentials; workloads run in this manager's own cluster",
+			slog.String("host", cfg.Host))
+		return cfg, nil
+	}
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("no execution cluster available: not running in a cluster and no ambient kubeconfig found: %w", err)
+	}
+	logger.Info("Using ambient kubeconfig for the execution cluster", slog.String("host", cfg.Host))
+	return cfg, nil
+}

--- a/agentarea-mcp-manager/internal/backends/cluster_config_test.go
+++ b/agentarea-mcp-manager/internal/backends/cluster_config_test.go
@@ -1,0 +1,83 @@
+package backends
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+const testKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+  - name: execution
+    cluster:
+      server: https://execution.example:6443
+contexts:
+  - name: execution
+    context:
+      cluster: execution
+      user: manager
+current-context: execution
+users:
+  - name: manager
+    user:
+      token: test-token
+`
+
+func writeKubeconfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing test kubeconfig: %v", err)
+	}
+	return path
+}
+
+// A configured kubeconfig names the cluster workloads run in. It must be used,
+// not merely consulted — otherwise a manager running inside the control-plane
+// cluster creates untrusted workloads there instead of on the execution cluster.
+func TestConfiguredKubeconfigIsUsed(t *testing.T) {
+	path := writeKubeconfig(t, testKubeconfig)
+
+	cfg, err := resolveClusterConfig(path, quietLogger())
+	if err != nil {
+		t.Fatalf("resolving configured kubeconfig: %v", err)
+	}
+	if cfg.Host != "https://execution.example:6443" {
+		t.Errorf("targeting %q; the configured execution cluster was ignored", cfg.Host)
+	}
+}
+
+// The regression that matters: a broken or missing kubeconfig must abort. If it
+// fell through to in-cluster credentials, the operator would have declared one
+// cluster and silently got another — with untrusted code landing next to the
+// control plane and nothing in the logs saying so.
+func TestBrokenKubeconfigIsFatalRatherThanIgnored(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	_, err := resolveClusterConfig(missing, quietLogger())
+	if err == nil {
+		t.Fatal("a missing configured kubeconfig was accepted; the manager would silently use its own cluster")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("error does not name the offending path, so the operator cannot fix it: %v", err)
+	}
+	if !strings.Contains(err.Error(), "refusing to fall back") {
+		t.Errorf("error does not state that no fallback happened: %v", err)
+	}
+}
+
+func TestMalformedKubeconfigIsFatal(t *testing.T) {
+	path := writeKubeconfig(t, "this is not: [valid yaml\n")
+
+	if _, err := resolveClusterConfig(path, quietLogger()); err == nil {
+		t.Fatal("a malformed configured kubeconfig was accepted")
+	}
+}

--- a/agentarea-mcp-manager/internal/backends/kubernetes_backend.go
+++ b/agentarea-mcp-manager/internal/backends/kubernetes_backend.go
@@ -18,8 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -37,14 +35,9 @@ type KubernetesBackend struct {
 
 // NewKubernetesBackend creates a new Kubernetes backend
 func NewKubernetesBackend(cfg *config.Config, logger *slog.Logger) (*KubernetesBackend, error) {
-	// Get Kubernetes configuration
-	k8sConfig, err := rest.InClusterConfig()
+	k8sConfig, err := resolveClusterConfig(cfg.Kubernetes.Kubeconfig, logger)
 	if err != nil {
-		// Fallback to kubeconfig
-		k8sConfig, err = ctrl.GetConfig()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
-		}
+		return nil, err
 	}
 
 	// Create controller-runtime client

--- a/agentarea-mcp-manager/internal/config/config.go
+++ b/agentarea-mcp-manager/internal/config/config.go
@@ -200,6 +200,7 @@ func loadKubernetesConfig() KubernetesConfig {
 	config.Enabled = getEnvBool("KUBERNETES_ENABLED", config.Enabled)
 	config.Namespace = getEnv("KUBERNETES_NAMESPACE", config.Namespace)
 	config.RuntimeClass = getEnv("KUBERNETES_RUNTIME_CLASS", config.RuntimeClass)
+	config.Kubeconfig = getEnv("KUBERNETES_KUBECONFIG", config.Kubeconfig)
 	config.PodServiceAccountName = getEnv("KUBERNETES_POD_SERVICE_ACCOUNT_NAME", config.PodServiceAccountName)
 	config.ImagePullPolicy = getEnv("K8S_IMAGE_PULL_POLICY", config.ImagePullPolicy)
 	config.GatewayName = getEnv("KUBERNETES_GATEWAY_NAME", config.GatewayName)

--- a/agentarea-mcp-manager/internal/config/kubernetes.go
+++ b/agentarea-mcp-manager/internal/config/kubernetes.go
@@ -16,6 +16,16 @@ type KubernetesConfig struct {
 	// Runtime configuration
 	RuntimeClass string `json:"runtime_class"`
 
+	// Kubeconfig names the cluster this manager creates workloads in, when that
+	// is not the cluster the manager itself runs in. Setting it is how a control
+	// plane targets a separate execution cluster — the arrangement that keeps
+	// untrusted MCP servers and agent sandboxes off the control plane's nodes.
+	//
+	// When set it WINS over in-cluster credentials and a failure to load it is
+	// fatal. Leaving it empty means "use whatever cluster I am in", which is
+	// discovery, not a fallback: nothing was declared to fall back from.
+	Kubeconfig string `json:"kubeconfig"`
+
 	// Service account to use for MCP server pods created by the Kubernetes backend.
 	PodServiceAccountName string `json:"pod_service_account_name"`
 

--- a/charts/agentarea/templates/warm-pool/daemonset.yaml
+++ b/charts/agentarea/templates/warm-pool/daemonset.yaml
@@ -43,8 +43,22 @@ spec:
         mcp.agentarea.io/status: "waiting"
         mcp.agentarea.io/package-install: {{ $profile.packageInstall | quote }}
     spec:
-      {{- if has "kata_runtime" $root.Values.mcpManager.features.enabled }}
-      runtimeClassName: kata-qemu
+      {{- /*
+        Sandbox pods run LLM-written shell commands — the least trusted workload
+        on the platform. They take their isolation from mcpManager.runtimeClass,
+        the same value that drives MCP instance pods, so one setting governs both
+        and neither can silently end up weaker than the other.
+
+        Previously this hardcoded `kata-qemu` behind the kata_runtime flag, which
+        pinned the chart to one vendor's runtime and offered nothing to clusters
+        without KVM. The runtime class is now declared, not chosen for you.
+      */ -}}
+      {{- $runtimeClass := $root.Values.mcpManager.runtimeClass }}
+      {{- if and (has "kata_runtime" $root.Values.mcpManager.features.enabled) (not $runtimeClass) }}
+        {{- fail "mcpManager.features.enabled includes kata_runtime but mcpManager.runtimeClass is empty. The runtime class is no longer hardcoded: set mcpManager.runtimeClass explicitly (\"kata-qemu\" to keep the previous behaviour, or \"gvisor\")." }}
+      {{- end }}
+      {{- if $runtimeClass }}
+      runtimeClassName: {{ $runtimeClass | quote }}
       {{- end }}
       serviceAccountName: {{ include "agentarea.mcpRuntimeServiceAccountName" $root }}
       automountServiceAccountToken: false

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -587,9 +587,21 @@ mcpManager:
     name: "envoy-gateway"              # Name of the Gateway resource
     namespace: "envoy-gateway-system"  # Namespace where Gateway is deployed
   
-  # Runtime configuration for VM isolation (optional)
-  # Set to "kata-qemu" for Kata Containers (requires Kata runtime)
-  # Leave empty "" for standard container runtime
+  # Container runtime class for every workload that executes code we did not
+  # write: MCP server instances AND agent sandbox pods. One setting governs
+  # both, so the sandbox can never end up less confined than an MCP server.
+  #
+  #   "gvisor"    — gVisor/runsc. Needs no KVM or nested virtualization, so it
+  #                 works on ordinary cloud VMs. Requires runsc + the containerd
+  #                 shim installed on the nodes and a matching RuntimeClass.
+  #   "kata-qemu" — Kata Containers. A real kernel per pod, but requires KVM,
+  #                 which managed clusters on virtualized nodes rarely expose.
+  #   ""          — the node's default runtime (runc). NO kernel isolation:
+  #                 untrusted code shares the host kernel. Acceptable for local
+  #                 development only.
+  #
+  # The name must match a RuntimeClass that exists in the cluster; Kubernetes
+  # refuses to schedule the pod otherwise, which is the correct failure.
   runtimeClass: ""
 
   # Untrusted MCP runtime and sandbox task pods use this zero-RBAC

--- a/deploy/sandbox-host/README.md
+++ b/deploy/sandbox-host/README.md
@@ -44,6 +44,57 @@ on mcp-manager (the docker backend calls `/execute` there over the signed
 transport). The host is region-labelled via `sandbox_region`; once control-plane
 placement targets are declared, that label is how a task routes here.
 
+## Kubernetes mode — one substrate for sandboxes *and* MCP servers
+
+The mode above runs one executor container that the control plane calls over
+HTTP. It isolates agent `bash()`, but MCP servers — including images a user
+supplies — still run wherever the control plane can reach a Docker daemon,
+usually beside the control plane itself, on its kernel.
+
+Setting `sandbox_k3s_enabled: true` makes this host a single-node Kubernetes
+cluster instead. Both untrusted workload types then run here as pods under
+gVisor, through one mechanism:
+
+```bash
+ansible-playbook -i inventory.ini site.yml \
+  -e sandbox_k3s_enabled=true \
+  -e sandbox_activation_auth_secret="$SANDBOX_ACTIVATION_AUTH_SECRET"
+```
+
+This works because the control plane already speaks Kubernetes — it creates
+Deployments, honours `runtimeClassName`, and already implements warm pools,
+task→pod pinning and idle reaping against the Kubernetes backend. Nothing is
+ported; the substrate simply starts answering the API it already talks.
+
+k3s is used rather than a managed cluster for one reason: registering a custom
+container runtime means editing containerd's configuration, which k3s supports
+through a documented template. Managed providers generally revert it —
+DigitalOcean states that changes to worker nodes "are overwritten by the
+reconciler and do not persist."
+
+The play writes a kubeconfig to `sandbox_k3s_kubeconfig_local_path`
+(`./execution-cluster.kubeconfig` by default) with the API server address
+rewritten from k3s's `127.0.0.1` to something the control plane can reach. Give
+it to mcp-manager:
+
+```
+BACKEND_TYPE=kubernetes
+KUBERNETES_KUBECONFIG=/etc/agentarea/execution.kubeconfig
+KUBERNETES_RUNTIME_CLASS=gvisor
+```
+
+`KUBERNETES_KUBECONFIG` takes precedence over in-cluster credentials, so a
+control plane running inside its own cluster still schedules onto this one. If
+the file cannot be loaded, the manager refuses to start rather than quietly
+using the cluster it happens to live in.
+
+The play refuses to finish unless a pod actually ran under gVisor: it schedules
+one with `runtimeClassName: gvisor` and greps `dmesg` for the gVisor kernel
+banner. A provisioning run that skipped that check would prove nothing.
+
+In this mode the standalone executor container is not deployed — the sandbox is
+a pod now, and leaving a second execution path on the box would only rot.
+
 ## Verify on the host
 
 ```bash

--- a/deploy/sandbox-host/roles/sandbox_host/defaults/main.yml
+++ b/deploy/sandbox-host/roles/sandbox_host/defaults/main.yml
@@ -94,3 +94,22 @@ sandbox_egress_deny:
 
 # CPU architecture for the Docker/gVisor apt repos (follows the host).
 apt_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
+
+# Kubernetes mode. Off by default: enabling it changes what this host is — a
+# single-node cluster the control plane schedules onto, rather than a lone
+# executor container it calls over HTTP. Both untrusted workload types (agent
+# bash and MCP servers) then run here as pods under gVisor, on one mechanism.
+sandbox_k3s_enabled: false
+# Nothing this cluster hosts is reached through an ingress controller or a
+# LoadBalancer — the control plane talks to the API server, and workloads are
+# reached by the proxy. Disabling them keeps the box small and its surface small.
+sandbox_k3s_exec_args: "server --disable traefik --disable servicelb"
+# Address the control plane uses to reach the API server. Defaults to the host
+# ansible connected on, which is right for a single box on a public address;
+# override when the control plane reaches it over a private network.
+sandbox_k3s_advertise_host: "{{ ansible_host | default(inventory_hostname) }}"
+sandbox_k3s_runtime_class: "gvisor"
+sandbox_k3s_node_label: "runtime=gvisor"
+# Where the generated kubeconfig lands on the machine running ansible. Feed it
+# to the control plane as KUBERNETES_KUBECONFIG.
+sandbox_k3s_kubeconfig_local_path: "./execution-cluster.kubeconfig"

--- a/deploy/sandbox-host/roles/sandbox_host/handlers/main.yml
+++ b/deploy/sandbox-host/roles/sandbox_host/handlers/main.yml
@@ -22,3 +22,8 @@
     name: "{{ sandbox_executor_name }}"
     state: restarted
   when: sandbox_executor_enabled | bool
+
+- name: Restart k3s
+  ansible.builtin.systemd:
+    name: k3s
+    state: restarted

--- a/deploy/sandbox-host/roles/sandbox_host/tasks/k3s.yml
+++ b/deploy/sandbox-host/roles/sandbox_host/tasks/k3s.yml
@@ -1,0 +1,129 @@
+---
+# Turn this host into a single-node Kubernetes cluster that runs BOTH agent
+# sandboxes and MCP servers under gVisor.
+#
+# Why Kubernetes on a box that already runs Docker: the control plane already
+# speaks Kubernetes — it creates Deployments, honours RuntimeClass/nodeSelector,
+# and has warm pools, task->pod pinning and idle reaping implemented against the
+# Kubernetes backend. Speaking that API here means MCP servers stop running next
+# to the control plane without anyone writing an adapter, and both untrusted
+# workloads end up on one mechanism instead of two that drift apart.
+#
+# k3s is used rather than a managed cluster because registering a custom
+# container runtime requires editing containerd's config — which k3s supports
+# through a documented template, and managed providers (DOKS among them) revert.
+
+- name: Install k3s server
+  ansible.builtin.shell: |
+    set -o pipefail
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="{{ sandbox_k3s_exec_args }}" sh -
+  args:
+    executable: /bin/bash
+    creates: /usr/local/bin/k3s
+
+- name: Wait for the k3s node to be ready
+  ansible.builtin.command: k3s kubectl wait --for=condition=Ready node --all --timeout=180s
+  changed_when: false
+
+# k3s renders containerd's config from a template. Which file it reads depends
+# on the containerd major version k3s ships, and the plugin key changed with it
+# — writing the wrong one silently produces a cluster with no runsc runtime, so
+# detect rather than assume.
+- name: Detect the containerd config k3s generated
+  ansible.builtin.stat:
+    path: /var/lib/rancher/k3s/agent/etc/containerd/config-v3.toml
+  register: _containerd_v3
+
+- name: Select the containerd template name and runtime plugin key
+  ansible.builtin.set_fact:
+    _containerd_tmpl: >-
+      {{ '/var/lib/rancher/k3s/agent/etc/containerd/config-v3.toml.tmpl'
+         if _containerd_v3.stat.exists
+         else '/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl' }}
+    _containerd_runtime_key: >-
+      {{ 'io.containerd.cri.v1.runtime'
+         if _containerd_v3.stat.exists
+         else 'io.containerd.grpc.v1.cri' }}
+
+- name: Register runsc as a containerd runtime
+  ansible.builtin.copy:
+    dest: "{{ _containerd_tmpl }}"
+    mode: "0600"
+    content: |
+      {% raw %}{{ template "base" . }}{% endraw %}
+
+      [plugins."{{ _containerd_runtime_key }}".containerd.runtimes.runsc]
+        runtime_type = "io.containerd.runsc.v1"
+  notify: Restart k3s
+
+- name: Apply the containerd change now
+  ansible.builtin.meta: flush_handlers
+
+- name: Label this node as gVisor-capable
+  ansible.builtin.command: >-
+    k3s kubectl label node --all --overwrite {{ sandbox_k3s_node_label }}
+  changed_when: false
+
+# scheduling.nodeSelector/tolerations on the RuntimeClass mean a pod only has to
+# say `runtimeClassName: gvisor` — Kubernetes adds the placement itself. The
+# control plane therefore needs no knowledge of nodes, only of the class.
+- name: Define the gvisor RuntimeClass
+  ansible.builtin.copy:
+    dest: /var/lib/rancher/k3s/server/manifests/runtimeclass-gvisor.yaml
+    mode: "0600"
+    content: |
+      apiVersion: node.k8s.io/v1
+      kind: RuntimeClass
+      metadata:
+        name: {{ sandbox_k3s_runtime_class }}
+      handler: runsc
+      scheduling:
+        nodeSelector:
+          {{ sandbox_k3s_node_label.split('=')[0] }}: "{{ sandbox_k3s_node_label.split('=')[1] }}"
+
+- name: Wait for the RuntimeClass to be registered
+  ansible.builtin.command: k3s kubectl get runtimeclass {{ sandbox_k3s_runtime_class }}
+  register: _runtimeclass
+  until: _runtimeclass.rc == 0
+  retries: 12
+  delay: 5
+  changed_when: false
+
+# Proves the whole chain — k3s scheduled it, containerd found the runsc handler,
+# and the kernel the workload sees is gVisor's rather than the host's. A green
+# provisioning run that skipped this would mean nothing.
+- name: Smoke-test that a pod actually runs under gVisor
+  ansible.builtin.shell: |
+    set -o pipefail
+    k3s kubectl delete pod gvisor-smoke --ignore-not-found >/dev/null 2>&1
+    k3s kubectl run gvisor-smoke \
+      --image={{ sandbox_runsc_smoketest_image }} \
+      --restart=Never \
+      --overrides='{"spec":{"runtimeClassName":"{{ sandbox_k3s_runtime_class }}"}}' \
+      --command -- dmesg
+    k3s kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/gvisor-smoke --timeout=120s
+    out=$(k3s kubectl logs gvisor-smoke)
+    k3s kubectl delete pod gvisor-smoke --ignore-not-found >/dev/null 2>&1
+    printf '%s\n' "$out"
+    printf '%s' "$out" | grep -qi 'gvisor'
+  args:
+    executable: /bin/bash
+  changed_when: false
+
+- name: Read the cluster kubeconfig
+  ansible.builtin.slurp:
+    src: /etc/rancher/k3s/k3s.yaml
+  register: _k3s_kubeconfig
+
+# k3s writes 127.0.0.1 because it assumes local use. The control plane is not
+# local, so rewrite the server address to one it can reach before handing the
+# file over.
+- name: Save a kubeconfig the control plane can use
+  ansible.builtin.copy:
+    dest: "{{ sandbox_k3s_kubeconfig_local_path }}"
+    mode: "0600"
+    content: >-
+      {{ _k3s_kubeconfig.content | b64decode
+         | replace('https://127.0.0.1:6443', 'https://' ~ sandbox_k3s_advertise_host ~ ':6443') }}
+  delegate_to: localhost
+  become: false

--- a/deploy/sandbox-host/roles/sandbox_host/tasks/main.yml
+++ b/deploy/sandbox-host/roles/sandbox_host/tasks/main.yml
@@ -22,7 +22,18 @@
   ansible.builtin.import_tasks: hardening.yml
   tags: [hardening]
 
+- name: Make this host a single-node execution cluster
+  ansible.builtin.import_tasks: k3s.yml
+  when: sandbox_k3s_enabled | bool
+  tags: [k3s]
+
+# In Kubernetes mode the sandbox is a pod the control plane schedules, so the
+# standalone executor container has nothing to do. Running both would leave a
+# second, unreferenced execution path on the box — the kind of thing that rots
+# quietly and confuses the next person to debug this.
 - name: Deploy the sandbox executor
   ansible.builtin.import_tasks: executor.yml
-  when: sandbox_executor_enabled | bool
+  when:
+    - sandbox_executor_enabled | bool
+    - not (sandbox_k3s_enabled | bool)
   tags: [executor]


### PR DESCRIPTION
Three changes that together let both untrusted workload types run as gVisor pods on a host you already have, instead of MCP servers running on the control plane's kernel.

## 1. One runtime class for both workloads

The warm-pool DaemonSet hardcoded `runtimeClassName: kata-qemu` behind the `kata_runtime` flag.

**With the flag off — the default — sandbox pods got no `runtimeClassName` at all.** Agent `bash()`, the least trusted thing on the platform, ran on the node's default runtime sharing the host kernel. MCP instance pods meanwhile took their runtime from `mcpManager.runtimeClass` — a different mechanism. Same question, two answers, and the sandbox got the worse one.

With the flag on, the chart pinned every deployment to Kata, which needs KVM that managed clusters rarely expose.

Both now come from `mcpManager.runtimeClass`. Enabling `kata_runtime` without setting it **fails the render** with a message naming the fix, rather than silently substituting a vendor's runtime.

## 2. The operator names the cluster workloads run in

`NewKubernetesBackend` tried `rest.InClusterConfig()` first and consulted a kubeconfig only if that failed. A manager running inside a cluster therefore always created workloads in its own cluster — with no way to point it elsewhere, and no error when it ignored where you meant.

That blocks the whole arrangement: control plane in one cluster, untrusted workloads in another. `KUBERNETES_KUBECONFIG` now names the execution cluster and wins over in-cluster credentials; failing to load it aborts.

Empty still uses the ambient cluster — that is discovery, not a fallback, since nothing was declared.

## 3. Kubernetes mode for the sandbox host

`sandbox_k3s_enabled: true` turns the existing VM into a single-node cluster. Both workload types then run there as pods under gVisor.

Nothing is ported to make this work — the control plane already speaks Kubernetes, with warm pools, task-to-pod pinning and idle reaping implemented against the Kubernetes backend. The substrate starts answering an API it was always talking.

k3s rather than managed, for one concrete reason: registering `runsc` means editing containerd's config, which k3s supports through a documented template, while DigitalOcean documents that worker node changes "are overwritten by the reconciler and do not persist."

Details that matter:

- **The containerd template name and plugin key both changed with containerd 2.x.** The play detects which config k3s generated rather than assuming — writing the wrong one yields a cluster with no runsc runtime and no error.
- The RuntimeClass carries `scheduling.nodeSelector`, so pods declare only `runtimeClassName` and Kubernetes places them. The control plane never learns about nodes.
- The kubeconfig is emitted with k3s's `127.0.0.1` rewritten to a reachable address.
- **Provisioning refuses to finish unless a pod really ran under gVisor** — it schedules one and greps `dmesg` for the gVisor banner.
- The standalone executor is not deployed in this mode; two execution paths, one unreferenced, is how things rot.

## Verification

- Chart rendered in all three paths: default omits the class; `gvisor` reaches both DaemonSets *and* `KUBERNETES_RUNTIME_CLASS` from one value; the legacy flag without an explicit class fails with the migration message. `helm lint` clean.
- Cluster selection **verified by mutation**: making a failed kubeconfig fall through to ambient credentials fails both new tests — and on a developer machine it *succeeds*, silently returning the cluster from `~/.kube/config`. The wrong-cluster outcome demonstrated rather than argued.
- 183 Go tests pass (was 180).
- `ansible-playbook --syntax-check` clean; only `ansible.builtin` modules, so no undeclared collections.

## Not covered

The k3s path is syntax-checked, not run against a real host — I have no inventory or credentials for the VM. The gVisor smoke test inside the play is what proves it on first run.
