### PR TITLE
feat(mcp-manager): implement the sandbox file API on the Kubernetes backend

### DIFF
--- a/agentarea-mcp-manager/internal/api/sandbox_files_handler.go
+++ b/agentarea-mcp-manager/internal/api/sandbox_files_handler.go
@@ -7,17 +7,27 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/agentarea/mcp-manager/internal/backends"
 	"github.com/agentarea/mcp-manager/internal/warmpool"
 )
 
 // sandboxFilesProvider is the subset of a backend that can operate on a task's
-// sandbox file workspace. Only the dev docker backend implements it today; the
-// prod warm-pool backend returns 503 until per-task sticky file routing lands.
+// sandbox file workspace. Both shipped backends implement it: docker against
+// SANDBOX_EXECUTOR_URL, Kubernetes against the task's already-assigned pod.
 type sandboxFilesProvider interface {
 	SandboxFilePut(ctx context.Context, req warmpool.FilePutRequest) (*warmpool.FilePutResponse, error)
 	SandboxFileGet(ctx context.Context, workspaceID, taskID, path string) (*warmpool.FileGetResponse, error)
 	SandboxFileList(ctx context.Context, workspaceID, taskID, prefix string) (*warmpool.FileListResponse, error)
 }
+
+// The 503 below is reached by type assertion, so a backend that quietly stops
+// satisfying this interface degrades at runtime instead of failing to build.
+// These make that a compile error — the file tool and bash must see the same
+// filesystem on every substrate, not just the one someone tested.
+var (
+	_ sandboxFilesProvider = (*backends.DockerBackend)(nil)
+	_ sandboxFilesProvider = (*backends.KubernetesBackend)(nil)
+)
 
 // sandboxFiles proxies the sandbox file API to the executor data plane. The file
 // tool writes here so its files land on the same filesystem bash executes in,

--- a/agentarea-mcp-manager/internal/backends/kubernetes_files.go
+++ b/agentarea-mcp-manager/internal/backends/kubernetes_files.go
@@ -1,0 +1,81 @@
+package backends
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/agentarea/mcp-manager/internal/warmpool"
+)
+
+// The sandbox file API on the Kubernetes backend.
+//
+// Until now only the docker backend implemented it, and the production
+// warm-pool path answered 503. That made the file tool a development-only
+// feature: on Kubernetes the agent could execute commands but not put a file
+// where those commands would see it, so files fell back to the S3 task
+// workspace that bash cannot read — the split-brain between the two surfaces.
+//
+// Routing is by the task's already-assigned pod, never a newly created one.
+// FindPodForTask exists for exactly this reason (its own contract: "writeback
+// must target the same pod that executed the command; creating a replacement
+// would lose its workspace changes"), and it refreshes the lease, so touching
+// files keeps the sandbox alive the same way executing does.
+
+const sandboxFileTimeout = 30 * time.Second
+
+// taskPodBaseURL resolves the activation service on the pod already serving the
+// task. It deliberately does not create one: FilePutRequest carries no runtime
+// profile, so assigning a pod here would mean inventing a package-install
+// value — and inventing it wrongly would hand a locked task an unlocked
+// sandbox. A task with no pod yet is reported as such.
+func (k *KubernetesBackend) taskPodBaseURL(ctx context.Context, taskID string) (string, error) {
+	if taskID == "" {
+		return "", fmt.Errorf("task_id is required for sandbox file access")
+	}
+	wp := k.GetWarmPoolClient()
+	if wp == nil {
+		return "", fmt.Errorf("warm pool client unavailable")
+	}
+	pod, err := wp.FindPodForTask(ctx, taskID)
+	if err != nil {
+		return "", err
+	}
+	return podActivationURL(pod)
+}
+
+func podActivationURL(pod *corev1.Pod) (string, error) {
+	if pod.Status.PodIP == "" {
+		return "", fmt.Errorf("sandbox pod %s has no IP address yet", pod.Name)
+	}
+	return fmt.Sprintf("http://%s:8080", pod.Status.PodIP), nil
+}
+
+// SandboxFilePut writes a file into the task's live sandbox filesystem.
+func (k *KubernetesBackend) SandboxFilePut(ctx context.Context, req warmpool.FilePutRequest) (*warmpool.FilePutResponse, error) {
+	base, err := k.taskPodBaseURL(ctx, req.TaskID)
+	if err != nil {
+		return nil, err
+	}
+	return warmpool.PutFile(ctx, base, req, sandboxFileTimeout)
+}
+
+// SandboxFileGet reads a file from the task's live sandbox filesystem.
+func (k *KubernetesBackend) SandboxFileGet(ctx context.Context, workspaceID, taskID, path string) (*warmpool.FileGetResponse, error) {
+	base, err := k.taskPodBaseURL(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	return warmpool.GetFile(ctx, base, workspaceID, taskID, path, sandboxFileTimeout)
+}
+
+// SandboxFileList lists regular files under prefix in the task's live sandbox.
+func (k *KubernetesBackend) SandboxFileList(ctx context.Context, workspaceID, taskID, prefix string) (*warmpool.FileListResponse, error) {
+	base, err := k.taskPodBaseURL(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	return warmpool.ListFiles(ctx, base, workspaceID, taskID, prefix, sandboxFileTimeout)
+}


### PR DESCRIPTION
Closes the last thing blocking agent bash from running on a Kubernetes substrate.

## The gap

Only the docker backend implemented the sandbox file API. The production warm-pool path answered **503** — the handler said so in its own comment.

So on Kubernetes an agent could execute commands but could not put a file where those commands would see it. Writes fell back to the S3 task workspace that bash cannot read: the split-brain between the two file surfaces.

It also blocked the migration. MCP servers can move to the k3s sandbox host today; **bash could not**, because its file tool would start failing the moment it got there.

## Routing

By the task's **already-assigned** pod. `FindPodForTask` exists for precisely this — its contract is *"writeback must target the same pod that executed the command; creating a replacement would lose its workspace changes"*, and files are the same problem. It also refreshes the lease, so working with files keeps the sandbox alive the way executing does.

**Deliberately not `FindOrAssignPodForTask`.** `FilePutRequest` carries no runtime profile, so assigning a pod here would mean inventing a `package-install` value — and inventing it wrongly would hand a `locked` task an unlocked sandbox. A task with no pod yet gets a clear error rather than a guessed sandbox.

## The 503 could come back silently

The handler reaches the provider by type assertion, so a backend that quietly stops satisfying the interface degrades at runtime instead of failing to build.

Added compile-time assertions for both backends, and verified they do their job — renaming one method turns the runtime 503 into:

```
cannot use (*backends.KubernetesBackend)(nil) ... does not implement
sandboxFilesProvider (missing method SandboxFileList)
```

## Verification

183 tests pass, build/vet/gofmt clean.

Not covered: no test exercises the routing against a live cluster — there is no Kubernetes test harness in this repo, and a fake client would assert my own wiring back at me. The compile-time assertion covers the contract; the routing itself is verified on first real use.
