### PR TITLE
feat: activate org-context tool (read_org_file/list_org_files) + expose RustFS for presigned uploads

### DIFF
--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/context_toolset.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/tools/context_toolset.py
@@ -45,8 +45,11 @@ class ContextToolset(Toolset):
         self.workspace_id: str = workspace_id or "_standalone"
 
     @tool_method
-    async def list_context(self, prefix: str = "") -> str:
-        """List files available in the organization context store.
+    async def list_org_files(self, prefix: str = "") -> str:
+        """List files in the organization library (shared, read-only).
+
+        These are the organization's durable shared files, distinct from your
+        own task files (``file_*`` tools).
 
         Args:
             prefix: Optional path prefix to filter by.
@@ -57,7 +60,7 @@ class ContextToolset(Toolset):
         try:
             objects = await self.storage.list(self.workspace_id, prefix=prefix)
         except Exception as e:
-            return f"Error listing context: {e}"
+            return f"Error listing organization files: {e}"
         paths = sorted(
             str(getattr(obj, "path", "")) for obj in objects if getattr(obj, "path", None)
         )
@@ -66,11 +69,11 @@ class ContextToolset(Toolset):
         return "\n".join(paths)
 
     @tool_method
-    async def read_context(self, path: str) -> str:
-        """Read a text file from the organization context store.
+    async def read_org_file(self, path: str) -> str:
+        """Read a text file from the organization library (shared, read-only).
 
         Args:
-            path: Path of the file within the context store.
+            path: Path of the file within the organization library.
 
         Returns:
             The file's text content, or an error message.
@@ -82,7 +85,7 @@ class ContextToolset(Toolset):
         try:
             data, _ = await self.storage.get(self.workspace_id, resolved)
         except FileNotFoundError:
-            return f"Error: context file {path} does not exist"
+            return f"Error: organization file {path} does not exist"
         except Exception as e:
-            return f"Error reading context: {e}"
+            return f"Error reading organization file: {e}"
         return data.decode("utf-8")

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_context_toolset.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_context_toolset.py
@@ -48,7 +48,7 @@ class _FakeOrgStore:
 async def test_read_context_returns_bytes_decoded():
     store = _FakeOrgStore({("ws1", "shared/notes.md"): b"hello org"})
     ct = ContextToolset(storage=store, workspace_id="ws1")
-    result = await ct.read_context("shared/notes.md")
+    result = await ct.read_org_file("shared/notes.md")
     assert result == "hello org"
 
 
@@ -62,7 +62,7 @@ async def test_list_context_returns_paths():
         }
     )
     ct = ContextToolset(storage=store, workspace_id="ws1")
-    result = await ct.list_context()
+    result = await ct.list_org_files()
     assert "shared/a.md" in result
     assert "projects/b.md" in result
     # cross-workspace isolation: ws2 content never appears
@@ -73,7 +73,7 @@ async def test_list_context_returns_paths():
 async def test_read_context_missing_file_is_graceful_error():
     store = _FakeOrgStore({})
     ct = ContextToolset(storage=store, workspace_id="ws1")
-    result = await ct.read_context("nope.md")
+    result = await ct.read_org_file("nope.md")
     assert "does not exist" in result.lower() or "error" in result.lower()
 
 
@@ -82,7 +82,7 @@ async def test_read_context_rejects_path_traversal():
     store = _FakeOrgStore({("ws1", "shared/notes.md"): b"secret"})
     ct = ContextToolset(storage=store, workspace_id="ws1")
     for bad in ("../secret", "/etc/passwd", "a/../../b"):
-        result = await ct.read_context(bad)
+        result = await ct.read_org_file(bad)
         assert "escapes" in result.lower() or "error" in result.lower()
 
 
@@ -90,6 +90,6 @@ def test_context_toolset_is_read_only():
     ct = ContextToolset(workspace_id="ws1")
     method_names = set(ct._tool_methods.keys())
     # only read surface is exposed
-    assert method_names == {"read_context", "list_context"}
-    for forbidden in ("save_context", "write_context", "put", "delete", "save_file"):
+    assert method_names == {"read_org_file", "list_org_files"}
+    for forbidden in ("save_org_file", "write_org_file", "put", "delete", "save_file"):
         assert forbidden not in method_names

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/agent_execution_activities.py
@@ -374,7 +374,14 @@ def make_agent_activities(dependencies: ActivityDependencies):
                 name=agent.name,
                 description=agent.description or "",
                 instruction=(agent.instruction or "")
-                + render_runtime_prompt(runtime, package_install=package_install),
+                + render_runtime_prompt(
+                    runtime,
+                    package_install=package_install,
+                    has_org_context=any(
+                        t.get("name") == "agentarea/context"
+                        for t in _as_tool_config_list(agent.tools)
+                    ),
+                ),
                 agent_type=getattr(agent, "agent_type", "stateless") or "stateless",
                 model_id=model_id_str or "",
                 context_window=context_window,

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/runtime_discovery.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/runtime_discovery.py
@@ -38,6 +38,7 @@ def render_runtime_prompt(
     result: RuntimeDiscoveryResult,
     *,
     package_install: str = "allowed",
+    has_org_context: bool = False,
 ) -> str:
     manifest = result.manifest
     if manifest is None:
@@ -75,6 +76,14 @@ def render_runtime_prompt(
     else:
         browser_policy = "Browser automation: Playwright is available."
 
+    org_context_line = (
+        "- Organization library: read the organization's shared files with the "
+        "`list_org_files` and `read_org_file` tools (read-only). It is never changed by "
+        "anything you do in the sandbox.\n"
+        if has_org_context
+        else ""
+    )
+
     return (
         "\n\n# Runtime environment\n\n"
         f"- Image: {manifest.image_version}\n"
@@ -87,9 +96,8 @@ def render_runtime_prompt(
         f"- {compatibility_policy}\n"
         "- Arbitrary code can still be downloaded and run inside the writable task workspace; "
         "the managed-environment profile is not an egress or workspace-code restriction."
-        "\n\n# Workspace and context\n\n"
-        "- Organization context store: read shared organization files with the context tool "
-        "(read-only). It is never changed by anything you do in the sandbox.\n"
+        "\n\n# Files and workspace\n\n"
+        f"{org_context_line}"
         "- Your working directory IS your task workspace. Files you create there — with the "
         "file tool or by running a program in the shell — are captured durably and stay "
         "visible to the user for this task. Use plain relative paths (e.g. `report.xlsx`); a "

--- a/agentarea-platform/libs/execution/tests/unit/test_runtime_discovery.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_runtime_discovery.py
@@ -79,15 +79,12 @@ async def test_invalid_manifest_fails_discovery_closed() -> None:
     assert "Do not assume a browser" in render_runtime_prompt(result)
 
 
-def test_render_runtime_prompt_describes_the_three_surfaces() -> None:
+def test_render_runtime_prompt_describes_the_workspace() -> None:
     from agentarea_execution.models import RuntimeDiscoveryResult, RuntimeManifest
 
     result = RuntimeDiscoveryResult(manifest=RuntimeManifest.model_validate(_manifest()))
     prompt = render_runtime_prompt(result, package_install="locked")
 
-    # tier 1: org context store, read-only via a tool
-    assert "Organization context store" in prompt
-    assert "context tool" in prompt
     # tier 2/3 unified for the agent: its working directory IS the durable task
     # workspace — files created there (relative paths) are captured, and an
     # absolute path outside it is scratch that is not delivered.
@@ -98,6 +95,24 @@ def test_render_runtime_prompt_describes_the_three_surfaces() -> None:
     # binary deliverables must be produced via the shell, not the text file tool
     assert "Binary deliverables" in prompt
     assert "corrupts the file" in prompt
+
+
+def test_org_library_line_is_gated_on_the_tool_being_equipped() -> None:
+    from agentarea_execution.models import RuntimeDiscoveryResult, RuntimeManifest
+
+    result = RuntimeDiscoveryResult(manifest=RuntimeManifest.model_validate(_manifest()))
+
+    # Default: the agent is NOT equipped with the org-context tool, so the prompt
+    # must not advertise it (advertising a tool the agent lacks is a fail-loud lie).
+    without = render_runtime_prompt(result, package_install="locked")
+    assert "Organization library" not in without
+    assert "read_org_file" not in without
+
+    # Equipped: the org-library line appears and names the real tools.
+    with_ctx = render_runtime_prompt(result, package_install="locked", has_org_context=True)
+    assert "Organization library" in with_ctx
+    assert "list_org_files" in with_ctx
+    assert "read_org_file" in with_ctx
 
 
 def test_browser_requirement_is_structured_blocked_result() -> None:

--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -171,6 +171,9 @@ The following table lists configurable parameters of the chart and their default
 | ingress.hosts.kratos.host | string | `""` |  |
 | ingress.hosts.kratos.paths[0].path | string | `"/"` |  |
 | ingress.hosts.kratos.paths[0].pathType | string | `"Prefix"` |  |
+| ingress.hosts.rustfs.host | string | `""` |  |
+| ingress.hosts.rustfs.paths[0].path | string | `"/"` |  |
+| ingress.hosts.rustfs.paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | backend.enabled | bool | `true` |  |
 | backend.replicaCount | int | `1` |  |

--- a/charts/agentarea/templates/rustfs/ingress.yaml
+++ b/charts/agentarea/templates/rustfs/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.ingress.enabled .Values.rustfs.enabled .Values.ingress.hosts.rustfs.host }}
+{{- $fullName := include "agentarea.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-rustfs
+  labels:
+    {{- include "agentarea.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rustfs
+    {{- with .Values.global.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.hosts.rustfs.host | quote }}
+      http:
+        paths:
+          {{- range .Values.ingress.hosts.rustfs.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $.Release.Name }}-rustfs
+                port:
+                  name: rustfs
+          {{- end }}
+{{- end }}

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -289,6 +289,16 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+    # S3 API endpoint of the bundled object store, exposed for browser-direct
+    # presigned uploads/downloads. Only the S3 API port (9000) is routed; the
+    # admin console (9001) is never exposed. Set the host to enable, and point
+    # global.storage.publicEndpoint at the same host so presigned URLs are signed
+    # against it. Leave host empty to keep the store cluster-internal.
+    rustfs:
+      host: ""  # e.g., storage.example.com
+      paths:
+        - path: /
+          pathType: Prefix
   # TLS configuration
   tls: []
     # - secretName: agentarea-tls


### PR DESCRIPTION
## Summary
Activate the read-only **organization-context tool** so agents can read the org's shared files, and add an optional ingress to **expose the bundled RustFS S3 API** so the already-shipped browser-direct presigned uploads work in prod.

### Org-context tool (agents)
The `agentarea/context` toolset already existed and was already grantable (it's in the code-tools registry), but it was rough:
- **Renamed** its methods `read_context` / `list_context` → **`read_org_file` / `list_org_files`**. "context" is vague for an LLM (memory? conversation? RAG?) and stuttered with the toolset prefix; the LLM now sees `context_read_org_file` / `context_list_org_files`, which reads as "a shared org file", clearly distinct from its own task files (`file_*`).
- **Fixed a fail-loud bug in the runtime prompt.** `render_runtime_prompt` unconditionally told *every* agent "read shared org files with the context tool" — even agents that were never granted the tool. It now emits the org-library line only when the agent is actually equipped with `agentarea/context` (`has_org_context`, derived from the agent's tools in `build_agent_config_activity`).
- Stays **opt-in per agent** (`enabled_by_default: false`) — grant it via the agent's tools; it is read-only and workspace-scoped. Humans add files to the org library through the existing `/files` page (`POST /v1/files` `purpose=workspace`, audited); the agent reads exactly those files.

### RustFS ingress (charts)
Browser-direct presigned uploads (already merged) sign a URL against a client-reachable endpoint and PUT bytes straight to the object store. The bundled RustFS was cluster-internal only, so that path can't work in prod. Adds an `Ingress` for the **S3 API port (9000)** gated on `ingress.hosts.rustfs.host`; the **admin console (9001) is never exposed**. Deployers point `global.storage.publicEndpoint` at the same host. No chart version bump (release pipeline owns that). A deployer using their own cloud S3 needs zero changes here.

## Verification
- `test_context_toolset.py` + `test_runtime_discovery.py` — **12 passed** against current `main`.
- New test asserts the org-library prompt line is **present only when the tool is equipped**, absent otherwise (locks the fail-loud fix).
- `ruff check` + `ruff format --check` clean on the touched source.
- `helm template` renders the rustfs ingress with a host set; the gate keeps it out when no host is set. `helm lint` clean.
- Deterministic check: `get_code_tools_metadata()` includes `agentarea/context` (grantable), emitting `context_read_org_file` / `context_list_org_files`, `enabled_by_default=false`.

## Not yet done (flagging honestly)
- **Live real-agent read** (grant the tool to a real agent, upload an org file, confirm it reads it under policy — deny + allow) has NOT been run; no eval harness was found in this repo. Recommend that as the final acceptance before/after merge.
- Deferred (tracked, out of scope here): pluggable `BaseArtifactService`; org-write propose-and-approve (ChangeRequest + policy); `grep_context`.
