### PR TITLE
fix(governance): close fail-open policy-write + fail-loud policy resolution

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/policies.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/policies.py
@@ -11,6 +11,7 @@ from agentarea_governance.domain.rules import (
     PolicyEffect,
     PolicyRule,
     PolicySubjectType,
+    assert_enforceable,
 )
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, ConfigDict, Field
@@ -119,6 +120,10 @@ async def create_policy_rule(
         enabled=payload.enabled,
         priority=payload.priority,
     )
+    try:
+        assert_enforceable(rule)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     created = await service.create_rule(rule=rule, subject_id=payload.subject_id)
     return _rule_response(created)
 
@@ -147,6 +152,13 @@ async def update_policy_rule(
     """Partially update a policy rule."""
     service = GovernancePolicyService(RepositoryFactory(db_session, user_context))
     fields = payload.model_dump(exclude_unset=True)
+    existing = await service.get_rule(rule_id=rule_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Policy rule not found")
+    try:
+        assert_enforceable(existing.model_copy(update=fields))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     updated = await service.update_rule(rule_id=rule_id, **fields)
     if updated is None:
         raise HTTPException(status_code=404, detail="Policy rule not found")

--- a/agentarea-platform/apps/api/tests/test_governance_policy_api.py
+++ b/agentarea-platform/apps/api/tests/test_governance_policy_api.py
@@ -8,6 +8,7 @@ import pytest
 from agentarea_api.api.v1 import governance, policies
 from agentarea_api.api.v1.policies import (
     PolicyRuleCreateRequest,
+    PolicyRuleUpdateRequest,
     create_policy_rule,
     delete_policy_rule,
     get_policy_rule,
@@ -139,6 +140,84 @@ async def test_create_get_list_update_delete(session_factory):
         with pytest.raises(HTTPException) as exc:
             await get_policy_rule(created.id, context, session)
         assert exc.value.status_code == 404
+
+
+# ---- fail-closed write boundary: unenforceable rules must be rejected ----
+
+
+async def test_create_rejects_group_subject(session_factory):
+    async with session_factory() as session:
+        context = _context()
+        request = PolicyRuleCreateRequest(
+            subject_type=PolicySubjectType.GROUP,
+            subject_id="group:eng",
+            target="tool:send_email",
+            effect=PolicyEffect.DENY,
+        )
+        with pytest.raises(HTTPException) as exc:
+            await create_policy_rule(request, context, session)
+        assert exc.value.status_code == 422
+        assert "group" in exc.value.detail.lower()
+
+
+async def test_create_rejects_condition(session_factory):
+    async with session_factory() as session:
+        context = _context()
+        request = PolicyRuleCreateRequest(
+            subject_type=PolicySubjectType.WORKSPACE,
+            subject_id="workspace-a",
+            target="tool:send_email",
+            effect=PolicyEffect.DENY,
+            condition="resource.env == 'prod'",
+        )
+        with pytest.raises(HTTPException) as exc:
+            await create_policy_rule(request, context, session)
+        assert exc.value.status_code == 422
+        assert "condition" in exc.value.detail.lower()
+
+
+async def test_create_rejects_invalid_target(session_factory):
+    async with session_factory() as session:
+        context = _context()
+        request = PolicyRuleCreateRequest(
+            subject_type=PolicySubjectType.WORKSPACE,
+            subject_id="workspace-a",
+            target="tool_send_email",  # missing ':' -> unknown selector kind
+            effect=PolicyEffect.DENY,
+        )
+        with pytest.raises(HTTPException) as exc:
+            await create_policy_rule(request, context, session)
+        assert exc.value.status_code == 422
+
+
+async def test_create_rejects_cap_without_amount(session_factory):
+    async with session_factory() as session:
+        context = _context()
+        request = PolicyRuleCreateRequest(
+            subject_type=PolicySubjectType.WORKSPACE,
+            subject_id="workspace-a",
+            target="spend",
+            effect=PolicyEffect.CAP,
+            params={"period": "month"},  # no amount_usd -> silently dropped by compiler
+        )
+        with pytest.raises(HTTPException) as exc:
+            await create_policy_rule(request, context, session)
+        assert exc.value.status_code == 422
+        assert "amount_usd" in exc.value.detail
+
+
+async def test_update_rejects_condition(session_factory):
+    async with session_factory() as session:
+        context = _context()
+        created = await create_policy_rule(_cap_request("25.00"), context, session)
+        with pytest.raises(HTTPException) as exc:
+            await update_policy_rule(
+                created.id,
+                PolicyRuleUpdateRequest(condition="x == 1"),
+                context,
+                session,
+            )
+        assert exc.value.status_code == 422
 
 
 async def test_list_is_workspace_scoped(session_factory):

--- a/agentarea-platform/libs/governance/agentarea_governance/application/resolver_adapter.py
+++ b/agentarea-platform/libs/governance/agentarea_governance/application/resolver_adapter.py
@@ -41,7 +41,10 @@ class GovernancePolicyResolver:
         user_id: str | None = None,
     ) -> EffectivePolicy:
         if not workspace_id:
-            return EffectivePolicy()
+            raise ValueError(
+                "workspace_id is required to resolve an effective policy; "
+                "refusing to default to an allow-all policy"
+            )
 
         layers: list[PolicyDocument | None] = []
         source_ids: list[str] = []

--- a/agentarea-platform/libs/governance/agentarea_governance/domain/rules.py
+++ b/agentarea-platform/libs/governance/agentarea_governance/domain/rules.py
@@ -11,6 +11,7 @@ contract is unchanged; only the storage shape changed.
 from __future__ import annotations
 
 import logging
+from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from typing import Any
 
@@ -122,6 +123,104 @@ def parse_target(selector: str) -> tuple[str, str | None]:
         raise ValueError(f"invalid target selector {selector!r}: unknown kind {kind!r}")
 
     return kind, value
+
+
+def assert_enforceable(rule: PolicyRule) -> None:
+    """Reject a rule the engine would silently ignore at runtime.
+
+    The compiler debug-skips unenforceable rules, so without this guard the write
+    API returns 201 for rules that never take effect (fail-open). Fail loudly at
+    the write boundary instead, mirroring the compiler's skip conditions.
+
+    Raises:
+        ValueError: with a caller-facing reason when the rule cannot be enforced.
+    """
+    if rule.subject_type == PolicySubjectType.GROUP:
+        raise ValueError(
+            "group subjects are not resolved yet (issue #198); bind the rule to a "
+            "workspace, agent, or user"
+        )
+    if rule.condition is not None:
+        raise ValueError("conditions (CEL) are not evaluated yet; omit 'condition'")
+
+    kind, value = parse_target(rule.target)  # raises ValueError on an unknown kind
+    params = rule.params or {}
+    effect = rule.effect
+
+    if effect == PolicyEffect.CAP:
+        if kind not in ("spend", "service", "tokens", "execution"):
+            raise ValueError(
+                f"cap on {rule.target!r} is not enforceable; caps apply to "
+                "spend, service, tokens, or execution"
+            )
+        if kind in ("spend", "service"):
+            amount = params.get("amount_usd")
+            if amount is None:
+                raise ValueError(f"cap on {rule.target!r} requires 'amount_usd' in params")
+            # to_money coerces garbage to Decimal('0') instead of raising, so a
+            # non-numeric amount would silently compile to a $0 cap. Parse strictly
+            # here and reject anything Decimal cannot read.
+            try:
+                Decimal(str(amount))
+            except (InvalidOperation, ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"cap on {rule.target!r} has a non-numeric 'amount_usd': {amount!r}"
+                ) from exc
+            if kind == "spend":
+                period = params.get("period", "month")
+                if period not in ("month", "run"):
+                    raise ValueError(f"spend cap period must be 'month' or 'run', got {period!r}")
+        elif kind == "tokens":
+            if "max_tokens" not in params and "max_tokens_per_call" not in params:
+                raise ValueError(
+                    "token cap requires 'max_tokens' or 'max_tokens_per_call' in params"
+                )
+        elif not any(
+            f in params
+            for f in ("max_model_turns", "max_tool_calls_per_turn", "max_tool_calls_total")
+        ):
+            raise ValueError(
+                "execution cap requires 'max_model_turns', 'max_tool_calls_per_turn', or "
+                "'max_tool_calls_total' in params"
+            )
+        return
+
+    if effect in (PolicyEffect.DENY, PolicyEffect.ALLOW):
+        if kind != "tool":
+            raise ValueError(
+                f"{effect.value} is only enforceable on a tool target (tool:<name>), "
+                f"not {rule.target!r}"
+            )
+        if value in (None, "*"):
+            raise ValueError(
+                f"{effect.value} requires a specific tool (tool:<name>), not a wildcard "
+                f"{rule.target!r}"
+            )
+        return
+
+    if effect == PolicyEffect.APPROVAL:
+        if kind == "all" or (kind == "tool" and (value == "*" or value)):
+            return
+        raise ValueError(
+            f"approval is enforceable on '*' (all tools) or tool:<name>, not {rule.target!r}"
+        )
+
+    if effect == PolicyEffect.SAFETY:
+        if kind != "content":
+            raise ValueError(f"safety is only enforceable on a content target, not {rule.target!r}")
+        if "prompt_injection" not in params and "output_sanitizer" not in params:
+            raise ValueError(
+                "safety on content requires 'prompt_injection' or 'output_sanitizer' in params"
+            )
+        return
+
+    if effect == PolicyEffect.EGRESS:
+        # Accepted as opaque data — core neither validates nor enforces egress.
+        # Enforcement is the enterprise EgressEnforcer at the container network
+        # boundary; core only stores and round-trips the rows for it to consume.
+        return
+
+    raise ValueError(f"effect {effect.value!r} on {rule.target!r} is not enforceable")
 
 
 class _DocumentAccumulator:

--- a/agentarea-platform/libs/governance/tests/test_resolver_from_rules.py
+++ b/agentarea-platform/libs/governance/tests/test_resolver_from_rules.py
@@ -83,6 +83,16 @@ async def test_resolve_workspace_budget_cap(session_factory):
         assert len(effective.source_policy_ids) == 1
 
 
+async def test_resolve_rejects_empty_workspace_id(session_factory):
+    # A missing workspace_id must fail loudly, not silently resolve to an empty
+    # (allow-all) policy — that would be fail-open.
+    async with session_factory() as session:
+        context = _context()
+        resolver = GovernancePolicyResolver(RepositoryFactory(session, context))
+        with pytest.raises(ValueError):
+            await resolver.resolve(workspace_id="")
+
+
 async def test_resolve_merges_workspace_and_agent_tighter_wins(session_factory):
     async with session_factory() as session:
         context = _context()

--- a/agentarea-platform/libs/governance/tests/test_rules.py
+++ b/agentarea-platform/libs/governance/tests/test_rules.py
@@ -8,6 +8,7 @@ from agentarea_governance.domain.rules import (
     PolicyEffect,
     PolicyRule,
     PolicySubjectType,
+    assert_enforceable,
     egress_allowlist_from_rules,
     parse_target,
     rules_to_document,
@@ -224,3 +225,82 @@ class TestEgressRules:
             )
             == {}
         )
+
+
+class TestAssertEnforceable:
+    """assert_enforceable must mirror the compiler: accept exactly what compiles
+    to a runtime effect (plus egress as opaque data core stores for enterprise),
+    and reject everything the compiler would silently skip — so the write API can
+    never 201 a rule that then never enforces (fail-open)."""
+
+    @pytest.mark.parametrize(
+        "target,effect,params",
+        [
+            ("tool:send_email", PolicyEffect.DENY, {}),
+            ("tool:web_fetch", PolicyEffect.ALLOW, {}),
+            ("spend", PolicyEffect.CAP, {"amount_usd": 10}),
+            ("spend", PolicyEffect.CAP, {"amount_usd": 5, "period": "run"}),
+            ("service", PolicyEffect.CAP, {"amount_usd": 3}),
+            ("tokens", PolicyEffect.CAP, {"max_tokens": 1000}),
+            ("tokens", PolicyEffect.CAP, {"max_tokens_per_call": 100}),
+            ("execution", PolicyEffect.CAP, {"max_model_turns": 10}),
+            ("*", PolicyEffect.APPROVAL, {}),
+            ("tool:*", PolicyEffect.APPROVAL, {}),
+            ("tool:send_email", PolicyEffect.APPROVAL, {}),
+            ("content", PolicyEffect.SAFETY, {"prompt_injection": True}),
+            ("content", PolicyEffect.SAFETY, {"output_sanitizer": True}),
+            ("mcp:github", PolicyEffect.EGRESS, {"allowed_hosts": ["*.github.com"]}),
+            ("mcp:github", PolicyEffect.EGRESS, {}),
+        ],
+    )
+    def test_accepts_enforceable_rules(self, target, effect, params):
+        assert_enforceable(_rule(target, effect, **params))
+
+    @pytest.mark.parametrize(
+        "target,effect,params",
+        [
+            ("tool:*", PolicyEffect.DENY, {}),
+            ("tool", PolicyEffect.DENY, {}),
+            ("tool:*", PolicyEffect.ALLOW, {}),
+            ("model:gpt-4", PolicyEffect.DENY, {}),
+            ("mcp:x", PolicyEffect.DENY, {}),
+            ("skill:x", PolicyEffect.ALLOW, {}),
+            ("tool:send_email", PolicyEffect.CAP, {}),
+            ("tokens", PolicyEffect.CAP, {}),
+            ("execution", PolicyEffect.CAP, {}),
+            ("spend", PolicyEffect.CAP, {}),
+            ("spend", PolicyEffect.CAP, {"amount_usd": "abc"}),
+            ("spend", PolicyEffect.CAP, {"amount_usd": 1, "period": "week"}),
+            ("model:x", PolicyEffect.APPROVAL, {}),
+            ("content", PolicyEffect.SAFETY, {}),
+            ("tool:x", PolicyEffect.SAFETY, {}),
+        ],
+    )
+    def test_rejects_unenforceable_rules(self, target, effect, params):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule(target, effect, **params))
+
+    def test_rejects_unknown_target_kind(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("bogus:x", PolicyEffect.DENY))
+
+    def test_rejects_group_subject(self):
+        rule = PolicyRule(
+            subject_type=PolicySubjectType.GROUP,
+            subject_id="grp-a",
+            target="tool:send_email",
+            effect=PolicyEffect.DENY,
+        )
+        with pytest.raises(ValueError):
+            assert_enforceable(rule)
+
+    def test_rejects_condition(self):
+        rule = PolicyRule(
+            subject_type=PolicySubjectType.WORKSPACE,
+            subject_id="ws-a",
+            target="tool:send_email",
+            effect=PolicyEffect.DENY,
+            condition="request.time < 17",
+        )
+        with pytest.raises(ValueError):
+            assert_enforceable(rule)


### PR DESCRIPTION
## Summary
Security hardening of the governance write/resolve boundary.

- **Close fail-open on policy writes.** `assert_enforceable` is now a complete mirror of the rule compiler, so `POST /v1/policies` can no longer return 201 for a rule that then silently never enforces. Newly rejected: wildcard/bare tool `DENY`|`ALLOW` (`tool:*`, `tool`), `DENY`|`ALLOW` on non-tool kinds (model/mcp/skill/…), `CAP` on a non-cap kind, `CAP tokens` with no limit, `APPROVAL` not on `*`/`tool:<name>`, `SAFETY` not on content or with no flag.
- **Fix a silent $0-cap.** `to_money()` coerces garbage to `Decimal('0')`, so a non-numeric `amount_usd` used to compile to a $0 spend cap (and the old `to_money` try/except was dead code). Now parsed strictly with `Decimal`.
- **Fail-loud policy resolution.** An empty `workspace_id` no longer resolves to an empty (allow-all) `EffectivePolicy` — both the task service and the resolver raise instead of silently allowing everything.
- `EGRESS` stays accepted as opaque data; core neither validates nor enforces it (enforcement is the enterprise `EgressEnforcer` at the k8s network boundary).

Builds on the in-flight `assert_enforceable` + `policies.py` wiring.

## Tests
`libs/governance` + `apps/api/tests/test_governance_policy_api.py` + `libs/tasks` → **305 passed**. New: `TestAssertEnforceable` accept/reject matrix + resolver empty-workspace test.

## Not included (deliberately, your call)
- Self-approval-by-default (empty `approvers` lets the task initiator approve their own escalation) — a product default, left as-is pending a decision.
- Durable per-task policy audit (the resolved snapshot lives only in Temporal state) — deferred; not an active enforcement hole.
