### PR TITLE
fix(ci): keep Temporal flow gates fail-closed

### DIFF
--- a/agentarea-platform/libs/execution/tests/integration/test_flow_tool_use.py
+++ b/agentarea-platform/libs/execution/tests/integration/test_flow_tool_use.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from agentarea_common.testing.flows import MainFlow
+from agentarea_common.workflow.sandbox import create_workflow_runner
 from agentarea_execution.models import (
     AgentConfigRequest,
     AgentExecutionRequest,
@@ -45,6 +46,7 @@ async def _mock_build_config(request: AgentConfigRequest) -> dict[str, Any]:
         "description": "Agent that calls a tool",
         "instruction": "You are a helpful assistant.",
         "tools_config": {"mcp_servers": []},
+        "context_window": 128000,
         "events_config": {},
         "planning": False,
     }
@@ -213,6 +215,7 @@ class TestAgentToolUseFlow:
                     workflows=[AgentExecutionWorkflow],
                     activities=_ALL_ACTIVITIES,
                     activity_executor=executor,
+                    workflow_runner=create_workflow_runner(),
                 )
 
                 async with worker:
@@ -223,11 +226,21 @@ class TestAgentToolUseFlow:
                         workspace_id="test-workspace",
                         task_query="What is the weather in Berlin?",
                         timeout_seconds=30,
-                        max_reasoning_iterations=5,
-                        budget_usd=1.0,
                         # Tool authorization is zero-trust/default-deny: the task
                         # policy must explicitly grant tools for this round-trip.
-                        effective_policy={"tools": {"allowed": ["*"]}},
+                        effective_policy={
+                            "budget": {"run_budget_usd": "1.00"},
+                            "tokens": {
+                                "max_tokens": 20_000,
+                                "max_tokens_per_call": 2_000,
+                            },
+                            "execution": {
+                                "max_model_turns": 5,
+                                "max_tool_calls_per_turn": 10,
+                                "max_tool_calls_total": 100,
+                            },
+                            "tools": {"allowed": ["*"]},
+                        },
                     )
 
                     handle = await env.client.start_workflow(

--- a/agentarea-platform/libs/execution/tests/integration/test_task_complete_smoke.py
+++ b/agentarea-platform/libs/execution/tests/integration/test_task_complete_smoke.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from agentarea_common.testing.flows import MainFlow
+from agentarea_common.workflow.sandbox import create_workflow_runner
 from agentarea_execution.models import (
     AgentConfigRequest,
     AgentExecutionRequest,
@@ -42,6 +43,7 @@ async def mock_build_config(request: AgentConfigRequest) -> dict[str, Any]:
         "description": "Test agent",
         "instruction": "You are a helpful assistant.",
         "tools_config": {"mcp_servers": []},
+        "context_window": 128000,
         "events_config": {},
         "planning": False,
     }
@@ -177,6 +179,7 @@ class TestTaskCompleteSmokeTest:
                     workflows=[AgentExecutionWorkflow],
                     activities=ALL_ACTIVITIES,
                     activity_executor=executor,
+                    workflow_runner=create_workflow_runner(),
                 )
 
                 async with worker:
@@ -187,8 +190,18 @@ class TestTaskCompleteSmokeTest:
                         workspace_id="test-workspace",
                         task_query="Привет",
                         timeout_seconds=30,
-                        max_reasoning_iterations=5,
-                        budget_usd=1.0,
+                        effective_policy={
+                            "budget": {"run_budget_usd": "1.00"},
+                            "tokens": {
+                                "max_tokens": 20_000,
+                                "max_tokens_per_call": 2_000,
+                            },
+                            "execution": {
+                                "max_model_turns": 5,
+                                "max_tool_calls_per_turn": 10,
+                                "max_tool_calls_total": 100,
+                            },
+                        },
                     )
 
                     handle = await env.client.start_workflow(

--- a/agentarea-platform/libs/execution/tests/integration/test_workflow_signals.py
+++ b/agentarea-platform/libs/execution/tests/integration/test_workflow_signals.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pytest
 from agentarea_common.testing.flows import MainFlow
+from agentarea_common.workflow.sandbox import create_workflow_runner
 from agentarea_execution.models import (
     AgentConfigRequest,
     AgentExecutionRequest,
@@ -67,6 +68,7 @@ async def _mock_build_config(request: AgentConfigRequest) -> dict[str, Any]:
         "description": "Test agent",
         "instruction": "Be helpful.",
         "tools_config": {"mcp_servers": []},
+        "context_window": 128000,
         "events_config": {},
         "planning": False,
     }
@@ -245,8 +247,18 @@ def _make_request() -> AgentExecutionRequest:
         workspace_id="test-workspace",
         task_query="signal test",
         timeout_seconds=30,
-        max_reasoning_iterations=5,
-        budget_usd=1.0,
+        effective_policy={
+            "budget": {"run_budget_usd": "1.00"},
+            "tokens": {
+                "max_tokens": 20_000,
+                "max_tokens_per_call": 2_000,
+            },
+            "execution": {
+                "max_model_turns": 5,
+                "max_tool_calls_per_turn": 10,
+                "max_tool_calls_total": 100,
+            },
+        },
     )
 
 
@@ -329,6 +341,7 @@ async def test_request_user_input_waits_for_queued_reply_then_continues():
                 workflows=[AgentExecutionWorkflow],
                 activities=activities,
                 activity_executor=executor,
+                workflow_runner=create_workflow_runner(),
             )
             async with worker:
                 handle = await env.client.start_workflow(
@@ -402,6 +415,7 @@ async def test_pause_resume_signals_flip_queryable_state():
                 workflows=[AgentExecutionWorkflow],
                 activities=_ALL_ACTIVITIES,
                 activity_executor=executor,
+                workflow_runner=create_workflow_runner(),
             )
             async with worker:
                 handle = await env.client.start_workflow(
@@ -464,6 +478,7 @@ async def test_workflow_command_queue_message_publishes_event():
                 workflows=[AgentExecutionWorkflow],
                 activities=_ALL_ACTIVITIES,
                 activity_executor=executor,
+                workflow_runner=create_workflow_runner(),
             )
             async with worker:
                 handle = await env.client.start_workflow(
@@ -516,6 +531,7 @@ async def test_workflow_command_change_model_swaps_model_and_publishes_event():
                 workflows=[AgentExecutionWorkflow],
                 activities=_ALL_ACTIVITIES,
                 activity_executor=executor,
+                workflow_runner=create_workflow_runner(),
             )
             async with worker:
                 handle = await env.client.start_workflow(
@@ -581,6 +597,7 @@ async def test_unknown_workflow_command_is_ignored_no_event():
                 workflows=[AgentExecutionWorkflow],
                 activities=_ALL_ACTIVITIES,
                 activity_executor=executor,
+                workflow_runner=create_workflow_runner(),
             )
             async with worker:
                 handle = await env.client.start_workflow(


### PR DESCRIPTION
## Summary

- run CI Temporal flow workers through the production workflow sandbox configuration
- provide explicit effective policy limits after hidden runtime defaults were removed
- include the required ModelSpec context window in activity fixtures

## Verification

- `make test` — 826 passed, 8 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright` — 0 errors

This unblocks API/worker image publication for the sandbox runtime rollout.