### PR TITLE
fix(sandbox): preserve POST through HTTPS OpenSandbox proxy

### DIFF
--- a/agentarea-mcp-manager/internal/sandboxruntime/opensandbox.go
+++ b/agentarea-mcp-manager/internal/sandboxruntime/opensandbox.go
@@ -52,6 +52,18 @@ func NewOpenSandboxProvider(cfg OpenSandboxConfig) (*OpenSandboxProvider, error)
 	if endpoint.Scheme != "https" && (endpoint.Scheme != "http" || !cfg.AllowInsecure) {
 		return nil, fmt.Errorf("OpenSandbox domain must use HTTPS unless insecure development mode is explicitly enabled")
 	}
+	if cfg.Connection.Protocol != "" && cfg.Connection.Protocol != endpoint.Scheme {
+		return nil, fmt.Errorf(
+			"OpenSandbox protocol %q does not match domain scheme %q",
+			cfg.Connection.Protocol,
+			endpoint.Scheme,
+		)
+	}
+	// Server-proxy endpoints are intentionally returned without a scheme.
+	// The SDK uses Connection.Protocol to restore it, so it must match the
+	// lifecycle endpoint. Otherwise an HTTPS deployment is contacted over HTTP
+	// and a 301 redirect rewrites streaming POST requests such as /command to GET.
+	cfg.Connection.Protocol = endpoint.Scheme
 	if cfg.LeaseTTL <= 0 {
 		return nil, fmt.Errorf("OpenSandbox task lease TTL must be positive")
 	}

--- a/agentarea-mcp-manager/internal/sandboxruntime/opensandbox_test.go
+++ b/agentarea-mcp-manager/internal/sandboxruntime/opensandbox_test.go
@@ -169,6 +169,31 @@ func TestOpenSandboxProviderRejectsImplicitWeakIsolation(t *testing.T) {
 	}
 }
 
+func TestOpenSandboxProviderDerivesProxyProtocolFromDomain(t *testing.T) {
+	base := OpenSandboxConfig{
+		Connection: opensandbox.ConnectionConfig{
+			Domain:         "https://opensandbox.example.com",
+			UseServerProxy: true,
+		},
+		LeaseTTL:   time.Minute,
+		Isolation:  "gvisor",
+		EgressMode: "host-public",
+	}
+
+	provider, err := NewOpenSandboxProvider(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.cfg.Connection.Protocol != "https" {
+		t.Fatalf("protocol = %q, want https", provider.cfg.Connection.Protocol)
+	}
+
+	base.Connection.Protocol = "http"
+	if _, err := NewOpenSandboxProvider(base); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("mismatched protocol error = %v", err)
+	}
+}
+
 func TestTaskVolumeNameIsScopedByWorkspaceAndTask(t *testing.T) {
 	first := taskVolumeName("agentarea-task", "workspace-1", "task-1")
 	if first == taskVolumeName("agentarea-task", "workspace-2", "task-1") {


### PR DESCRIPTION
## Why
RU OpenSandbox returns a scheme-less server-proxy endpoint. The Go SDK restores it from `Connection.Protocol`, which we left empty, so it defaulted to HTTP. Caddy redirected HTTP to HTTPS with 301 and changed streaming `POST /command` to `GET /command`, causing the sandbox shell call to fail with 404.

## Change
- derive the proxy protocol from the validated lifecycle URL
- reject an explicit conflicting protocol
- add a regression test for HTTPS proxy configuration

## Verification
- `go test ./internal/sandboxruntime`
- `go test ./...`

The task token-budget error was secondary and is intentionally not changed here.