### PR TITLE
Keep terminal completion outside governed tool-call quota

### DIFF
--- a/agentarea-platform/apps/api/alembic/versions/20260731_1100_backfill_execution_policy.py
+++ b/agentarea-platform/apps/api/alembic/versions/20260731_1100_backfill_execution_policy.py
@@ -1,0 +1,66 @@
+"""Backfill persisted execution limits for existing workspaces.
+
+Execution limits were added to the baseline policy data after some workspaces
+already existed. New workspaces receive the rule during provisioning, but old
+ones otherwise have no persisted source for the required runtime contract.
+
+This migration inserts the baseline only when the workspace has no
+workspace-scoped execution cap at all. Existing rules, including disabled or
+partially configured rules, are left untouched so a migration cannot silently
+override an operator's governance decision.
+
+Revision ID: 20260731_1100_exec_policy
+Revises: 20260727_0100_mcp_last_used
+Create Date: 2026-07-31 11:00:00.000000
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260731_1100_exec_policy"
+down_revision: str | None = "20260727_0100_mcp_last_used"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_BASELINE_EXECUTION_PARAMS = {
+    "max_model_turns": 100,
+    "max_tool_calls_per_turn": 10,
+    "max_tool_calls_total": 1000,
+}
+
+
+def upgrade() -> None:
+    op.get_bind().execute(
+        sa.text(
+            """
+            INSERT INTO policies
+                (id, workspace_id, created_by, subject_type, subject_id,
+                 target, effect, params, enabled, priority,
+                 created_at, updated_at)
+            SELECT gen_random_uuid(), w.id, w.owner_user_id, 'workspace', w.id,
+                   'execution', 'cap', CAST(:params AS jsonb), true, 0,
+                   now(), now()
+            FROM workspaces AS w
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM policies AS p
+                WHERE p.workspace_id = w.id
+                  AND p.subject_type = 'workspace'
+                  AND p.subject_id = w.id
+                  AND p.target = 'execution'
+                  AND p.effect = 'cap'
+            )
+            """
+        ),
+        {"params": json.dumps(_BASELINE_EXECUTION_PARAMS)},
+    )
+
+
+def downgrade() -> None:
+    # Keep the safety contract. Once inserted, these rows are indistinguishable
+    # from an equivalent rule created through the public governance API; deleting
+    # them on rollback could remove a user's active policy.
+    pass

--- a/agentarea-platform/apps/api/tests/test_execution_policy_backfill_migration.py
+++ b/agentarea-platform/apps/api/tests/test_execution_policy_backfill_migration.py
@@ -1,0 +1,55 @@
+"""Contract tests for the execution-policy backfill migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "alembic/versions/20260731_1100_backfill_execution_policy.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("_execution_policy_backfill", MIGRATION)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_backfill_inserts_only_missing_workspace_execution_caps() -> None:
+    module = _load_migration()
+    bind = MagicMock()
+
+    with patch.object(module.op, "get_bind", return_value=bind):
+        module.upgrade()
+
+    bind.execute.assert_called_once()
+    statement, parameters = bind.execute.call_args.args
+    sql = str(statement)
+
+    assert "INSERT INTO policies" in sql
+    assert "FROM workspaces AS w" in sql
+    assert "WHERE NOT EXISTS" in sql
+    assert "p.subject_type = 'workspace'" in sql
+    assert "p.subject_id = w.id" in sql
+    assert "p.target = 'execution'" in sql
+    assert "p.effect = 'cap'" in sql
+    assert json.loads(parameters["params"]) == {
+        "max_model_turns": 100,
+        "max_tool_calls_per_turn": 10,
+        "max_tool_calls_total": 1000,
+    }
+
+
+def test_backfill_follows_current_migration_head() -> None:
+    module = _load_migration()
+
+    assert module.revision == "20260731_1100_exec_policy"
+    assert module.down_revision == "20260727_0100_mcp_last_used"
+    assert len(module.revision) <= 32

--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -26,6 +26,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from agentarea_common.money import ZERO, Money, serialize_money, to_money
     from agentarea_governance.domain.policies import effective_policy_from_json
+    from agentarea_governance.domain.tool_calls import metered_tool_call_count
 
     from .context_manager import (
         ContextWindowManager,
@@ -2196,13 +2197,17 @@ class AgentExecutionWorkflow:
                 type="InvalidExecutionSnapshot",
                 non_retryable=True,
             )
-        if len(tool_calls) > max_per_turn:
+        metered_calls_this_turn = metered_tool_call_count(
+            tool_call.function["name"] for tool_call in tool_calls
+        )
+        if metered_calls_this_turn > max_per_turn:
             raise ApplicationError(
-                f"model requested {len(tool_calls)} tool calls; policy allows {max_per_turn} per turn",
+                f"model requested {metered_calls_this_turn} metered tool calls; "
+                f"policy allows {max_per_turn} per turn",
                 type="ToolCallLimitExceeded",
                 non_retryable=True,
             )
-        attempted_total = self.state.tool_calls_used + len(tool_calls)
+        attempted_total = self.state.tool_calls_used + metered_calls_this_turn
         if attempted_total > max_total:
             raise ApplicationError(
                 f"tool-call budget exceeded: {attempted_total}/{max_total}",

--- a/agentarea-platform/libs/execution/tests/integration/test_flow_tool_use.py
+++ b/agentarea-platform/libs/execution/tests/integration/test_flow_tool_use.py
@@ -236,8 +236,8 @@ class TestAgentToolUseFlow:
                             },
                             "execution": {
                                 "max_model_turns": 5,
-                                "max_tool_calls_per_turn": 10,
-                                "max_tool_calls_total": 100,
+                                "max_tool_calls_per_turn": 1,
+                                "max_tool_calls_total": 1,
                             },
                             "tools": {"allowed": ["*"]},
                         },
@@ -284,3 +284,4 @@ class TestAgentToolUseFlow:
                     assert _FAKE_TOOL_RESULT in result.final_response, (
                         f"Final response should contain tool result. Got: {result.final_response!r}"
                     )
+                    assert result.total_tool_calls == 1

--- a/agentarea-platform/libs/governance/agentarea_governance/domain/tool_calls.py
+++ b/agentarea-platform/libs/governance/agentarea_governance/domain/tool_calls.py
@@ -1,0 +1,14 @@
+"""Canonical tool-call metering semantics shared by execution runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# Terminal control flow does not execute a capability and therefore must not
+# consume the quota reserved for agent/tool work.
+UNMETERED_TOOL_CALL_NAMES = frozenset({"completion", "task_complete"})
+
+
+def metered_tool_call_count(tool_names: Iterable[str]) -> int:
+    """Count calls that consume the governed tool-call quota."""
+    return sum(name not in UNMETERED_TOOL_CALL_NAMES for name in tool_names)

--- a/agentarea-platform/libs/tasks/agentarea_tasks/direct_task_manager.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/direct_task_manager.py
@@ -14,6 +14,7 @@ from uuid import UUID, uuid4
 
 from agentarea_common.money import ZERO, serialize_money, to_money
 from agentarea_governance.domain.policies import effective_policy_from_json
+from agentarea_governance.domain.tool_calls import metered_tool_call_count
 
 from .domain.interfaces import BaseTaskManager
 from .domain.models import AgentTask
@@ -171,12 +172,15 @@ class DirectTaskManager(BaseTaskManager):
                         break
                     continue
 
-                if len(response.tool_calls) > max_tool_calls_per_turn:
+                metered_calls_this_turn = metered_tool_call_count(
+                    tc["function"]["name"] for tc in response.tool_calls
+                )
+                if metered_calls_this_turn > max_tool_calls_per_turn:
                     raise RuntimeError(
                         "tool-call limit exceeded: "
-                        f"{len(response.tool_calls)}/{max_tool_calls_per_turn} in one turn"
+                        f"{metered_calls_this_turn}/{max_tool_calls_per_turn} in one turn"
                     )
-                tool_calls_used += len(response.tool_calls)
+                tool_calls_used += metered_calls_this_turn
                 if tool_calls_used > max_tool_calls_total:
                     raise RuntimeError(
                         f"tool-call budget exceeded: {tool_calls_used}/{max_tool_calls_total}"

--- a/agentarea-platform/libs/tasks/tests/unit/test_direct_task_outcome.py
+++ b/agentarea-platform/libs/tasks/tests/unit/test_direct_task_outcome.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from agentarea_common.money import to_money
 from agentarea_governance.domain.policies import (
     BudgetPolicy,
     EffectivePolicy,
@@ -48,7 +49,7 @@ async def test_iteration_limit_is_failed_in_direct_execution():
         status="running",
         created_at=datetime.now(UTC),
         effective_policy=EffectivePolicy(
-            budget=BudgetPolicy(run_budget_usd="1.00"),
+            budget=BudgetPolicy(run_budget_usd=to_money("1.00")),
             tokens=TokenPolicy(max_tokens=1000, max_tokens_per_call=100),
             execution=ExecutionLimitsPolicy(
                 max_model_turns=10,
@@ -78,4 +79,79 @@ async def test_iteration_limit_is_failed_in_direct_execution():
         "failed",
         result=task.result,
         error="Maximum iterations reached (10)",
+    )
+
+
+@pytest.mark.asyncio
+async def test_completion_does_not_consume_direct_tool_call_quota():
+    repository = AsyncMock()
+    manager = DirectTaskManager(repository)
+    usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    llm = SimpleNamespace(
+        complete=AsyncMock(
+            side_effect=[
+                SimpleNamespace(
+                    content="",
+                    cost=0,
+                    usage=usage,
+                    tool_calls=[
+                        {
+                            "id": "call-tool",
+                            "function": {"name": "unknown", "arguments": "{}"},
+                        }
+                    ],
+                ),
+                SimpleNamespace(
+                    content="",
+                    cost=0,
+                    usage=usage,
+                    tool_calls=[
+                        {
+                            "id": "call-completion",
+                            "function": {
+                                "name": "completion",
+                                "arguments": '{"result":"done"}',
+                            },
+                        }
+                    ],
+                ),
+            ]
+        )
+    )
+    manager._resolve_agent = AsyncMock(return_value=(llm, "", []))
+    task = AgentTask(
+        title="Task",
+        description="Task",
+        query="Task",
+        user_id=str(uuid4()),
+        workspace_id=str(uuid4()),
+        agent_id=uuid4(),
+        status="running",
+        created_at=datetime.now(UTC),
+        effective_policy=EffectivePolicy(
+            budget=BudgetPolicy(run_budget_usd=to_money("1.00")),
+            tokens=TokenPolicy(max_tokens=1000, max_tokens_per_call=100),
+            execution=ExecutionLimitsPolicy(
+                max_model_turns=3,
+                max_tool_calls_per_turn=1,
+                max_tool_calls_total=1,
+            ),
+        ).to_json_dict(),
+    )
+
+    await manager._execute(task)
+
+    assert task.status == "completed"
+    assert task.result == {
+        "response": "done",
+        "total_cost": "0",
+        "own_cost": "0",
+        "total_tokens": 4,
+        "total_tool_calls": 1,
+    }
+    assert llm.complete.await_count == 2
+    repository.update_status.assert_awaited_once_with(
+        task.id,
+        "completed",
+        result=task.result,
     )


### PR DESCRIPTION
## What
- meter only capability-bearing tool calls in Temporal and direct execution
- persist baseline execution limits for pre-existing workspaces through an idempotent migration
- cover completion quota and migration contracts with regression tests

## Verification
- 231 focused pytest cases passed
- Ruff passed
- Pyright: 0 errors
- local Kimi -> Temporal -> Go manager -> RU OpenSandbox E2E returned RU_SANDBOX_LOCAL_E2E, uid=0(root), Linux
- created RU sandbox container used Docker runtime runsc

## Rollout note
The local Docker exec subsystem became unhealthy before a live Alembic upgrade could be exercised. The migration unit contract passed; the GitOps migration Job must be observed before RU smoke.