### PR TITLE
fix(governance): restore runnable legacy workspaces

### DIFF
--- a/agentarea-operator/registry_sync.py
+++ b/agentarea-operator/registry_sync.py
@@ -81,13 +81,36 @@ def _parse_mcp_servers(data: dict[str, Any]) -> list[dict[str, Any]]:
     servers = data.get("servers", [])
     if not servers:
         return []
-    first = servers[0]
-    if "server" not in first:
+
+    formats: set[str] = set()
+    for index, entry in enumerate(servers):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                "Unrecognized MCP registry format: each entry of 'servers' must be a mapping "
+                f"(entry {index} is {type(entry).__name__})"
+            )
+        if isinstance(entry.get("server"), dict):
+            formats.add("standard")
+        elif (
+            isinstance(entry.get("registry_id"), str)
+            and isinstance(entry.get("connection_type"), str)
+            and isinstance(entry.get("json_spec"), dict)
+        ):
+            formats.add("agentarea")
+        else:
+            raise ValueError(
+                "Unrecognized MCP registry format: each entry of 'servers' must contain either "
+                "a mapping 'server' key or the AgentArea keys 'registry_id', "
+                f"'connection_type', and 'json_spec' (entry {index} keys: {sorted(entry)})"
+            )
+
+    if len(formats) != 1:
         raise ValueError(
-            "Unrecognized MCP registry format: each entry of 'servers' must contain a "
-            f"'server' key (got keys: {sorted(first)})"
+            "Unrecognized MCP registry format: official and AgentArea entries cannot be mixed"
         )
-    return _parse_standard_mcp(servers)
+    if "standard" in formats:
+        return _parse_standard_mcp(servers)
+    return _parse_agentarea_mcp(servers)
 
 
 def _parse_standard_mcp(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -212,6 +235,44 @@ def _parse_standard_mcp(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "tags": ["command", reg_type],
                 }
             )
+    return items
+
+
+def _parse_agentarea_mcp(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Parse the normalized format published by the AgentArea catalog pipeline."""
+    items: list[dict[str, Any]] = []
+    for entry in servers:
+        external_id = entry["registry_id"]
+        connection_type = entry["connection_type"]
+        json_spec = entry["json_spec"]
+
+        item_external_id = (
+            f"{external_id}/{connection_type}" if connection_type != "url" else external_id
+        )
+
+        tags: list[str] = []
+        if entry.get("package_registry"):
+            tags.append(entry["package_registry"])
+        if entry.get("requires_auth"):
+            tags.append("requires-auth")
+        transport = entry.get("transport") or json_spec.get("transport", "")
+        if transport:
+            tags.append(transport)
+
+        spec = {**json_spec, "connection_type": connection_type}
+        if entry.get("env_schema"):
+            spec["env_schema"] = entry["env_schema"]
+
+        items.append(
+            {
+                "external_id": item_external_id,
+                "name": entry.get("name") or external_id,
+                "description": (entry.get("description") or "")[:500],
+                "version": entry.get("version") or "latest",
+                "spec": spec,
+                "tags": tags,
+            }
+        )
     return items
 
 
@@ -882,5 +943,4 @@ def _unique_mcp_slug(conn, workspace_id: str, name: str) -> str:
         if not _taken(candidate):
             return candidate
     raise ValueError(f"Exhausted collision suffixes (-2..-999) for slug base '{base}'")
-
 

--- a/agentarea-operator/tests/test_registry_sync_parsers.py
+++ b/agentarea-operator/tests/test_registry_sync_parsers.py
@@ -122,11 +122,67 @@ class TestAgentParser:
 
 
 class TestMCPServerParser:
+    def test_agentarea_flattened_format_parses(self):
+        items = parse_source(
+            "mcp_servers",
+            {
+                "servers": [
+                    {
+                        "registry_id": "agency.lona/trading",
+                        "name": "Lona Trading",
+                        "description": "Trading tools",
+                        "version": "2.0.0",
+                        "connection_type": "url",
+                        "transport": "streamable-http",
+                        "package_registry": "remote",
+                        "requires_auth": False,
+                        "json_spec": {
+                            "url": "https://mcp.lona.agency/mcp",
+                            "transport": "streamable-http",
+                            "raw_spec": {"name": "agency.lona/trading"},
+                        },
+                    }
+                ]
+            },
+        )
+
+        assert items == [
+            {
+                "external_id": "agency.lona/trading",
+                "name": "Lona Trading",
+                "description": "Trading tools",
+                "version": "2.0.0",
+                "spec": {
+                    "url": "https://mcp.lona.agency/mcp",
+                    "transport": "streamable-http",
+                    "raw_spec": {"name": "agency.lona/trading"},
+                    "connection_type": "url",
+                },
+                "tags": ["remote", "streamable-http"],
+            }
+        ]
+
     def test_unrecognized_format_raises(self):
-        with pytest.raises(ValueError, match="'server' key"):
+        with pytest.raises(ValueError, match="AgentArea keys"):
             parse_source(
                 "mcp_servers",
                 {"servers": [{"registry_id": "io.example/echo", "connection_type": "url"}]},
+            )
+
+    def test_mixed_formats_raise(self):
+        with pytest.raises(ValueError, match="cannot be mixed"):
+            parse_source(
+                "mcp_servers",
+                {
+                    "servers": [
+                        {"server": {"name": "io.example/remote", "remotes": []}},
+                        {
+                            "registry_id": "io.example/echo",
+                            "connection_type": "url",
+                            "json_spec": {"url": "https://example.com/mcp"},
+                        },
+                    ]
+                },
             )
 
     def test_standard_format_preserves_raw_spec_icons(self):

--- a/agentarea-platform/apps/api/alembic/versions/20260731_1200_backfill_workspace_policy_baseline.py
+++ b/agentarea-platform/apps/api/alembic/versions/20260731_1200_backfill_workspace_policy_baseline.py
@@ -1,0 +1,141 @@
+"""Backfill the complete persisted policy baseline for legacy workspaces.
+
+The first execution-policy backfill only enumerated the reified ``workspaces``
+table. Older installations can still have valid workspace-scoped resources and
+API keys whose workspace has not been reified, so those tenants were skipped.
+They consequently had no persisted runtime budget, token, or execution limits
+after implicit runtime defaults were removed.
+
+This follow-up discovers both reified and active legacy workspaces, then inserts
+each missing baseline dimension independently. Existing dimensions, including
+disabled or partially configured rules, are preserved exactly; such an explicit
+configuration remains fail-closed until an operator completes it.
+
+Revision ID: 20260731_1200_policy_baseline
+Revises: 20260731_1100_exec_policy
+Create Date: 2026-07-31 12:00:00.000000
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260731_1200_policy_baseline"
+down_revision: str | None = "20260731_1100_exec_policy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_BASELINE_RULES = (
+    (
+        "spend",
+        "cap",
+        {"amount_usd": "500.00", "period": "month"},
+        "month",
+    ),
+    (
+        "spend",
+        "cap",
+        {"amount_usd": "50.00", "period": "run"},
+        "run",
+    ),
+    (
+        "tokens",
+        "cap",
+        {"max_tokens": 20_000_000, "max_tokens_per_call": 100_000},
+        None,
+    ),
+    (
+        "execution",
+        "cap",
+        {
+            "max_model_turns": 100,
+            "max_tool_calls_per_turn": 10,
+            "max_tool_calls_total": 1000,
+        },
+        None,
+    ),
+    (
+        "content",
+        "safety",
+        {"prompt_injection": True, "output_sanitizer": True},
+        None,
+    ),
+)
+
+_INSERT_MISSING_DIMENSION = sa.text(
+    """
+    WITH workspace_sources AS (
+        SELECT id AS workspace_id, owner_user_id AS created_by
+        FROM workspaces
+
+        UNION ALL
+
+        SELECT workspace_id, created_by
+        FROM api_keys
+
+        UNION ALL
+
+        SELECT workspace_id, user_id AS created_by
+        FROM workspace_memberships
+
+        UNION ALL
+
+        SELECT workspace_id, created_by
+        FROM agents
+
+        UNION ALL
+
+        SELECT workspace_id, COALESCE(created_by, user_id) AS created_by
+        FROM tasks
+    ),
+    workspace_targets AS (
+        SELECT
+            workspace_id,
+            COALESCE(MIN(NULLIF(created_by, '')), workspace_id) AS created_by
+        FROM workspace_sources
+        WHERE workspace_id IS NOT NULL
+          AND workspace_id <> ''
+        GROUP BY workspace_id
+    )
+    INSERT INTO policies
+        (id, workspace_id, created_by, subject_type, subject_id,
+         target, effect, params, enabled, priority, created_at, updated_at)
+    SELECT
+        gen_random_uuid(), targets.workspace_id, targets.created_by,
+        'workspace', targets.workspace_id,
+        :target, :effect, CAST(:params AS jsonb), true, 0, now(), now()
+    FROM workspace_targets AS targets
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM policies AS policy
+        WHERE policy.workspace_id = targets.workspace_id
+          AND policy.subject_type = 'workspace'
+          AND policy.subject_id = targets.workspace_id
+          AND policy.target = :target
+          AND policy.effect = :effect
+          AND COALESCE(policy.params->>'period', '') = COALESCE(:period, '')
+    )
+    """
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for target, effect, params, period in _BASELINE_RULES:
+        bind.execute(
+            _INSERT_MISSING_DIMENSION,
+            {
+                "target": target,
+                "effect": effect,
+                "params": json.dumps(params),
+                "period": period,
+            },
+        )
+
+
+def downgrade() -> None:
+    # Rows are indistinguishable from equivalent rules created through the
+    # governance API. Removing them could delete an operator-owned safety rule.
+    pass

--- a/agentarea-platform/apps/api/tests/test_workspace_policy_baseline_backfill_migration.py
+++ b/agentarea-platform/apps/api/tests/test_workspace_policy_baseline_backfill_migration.py
@@ -1,0 +1,107 @@
+"""Contract tests for the legacy-workspace policy baseline backfill."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "alembic/versions/20260731_1200_backfill_workspace_policy_baseline.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("_workspace_policy_baseline", MIGRATION)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_backfill_discovers_reified_and_legacy_workspaces() -> None:
+    module = _load_migration()
+    bind = MagicMock()
+
+    with patch.object(module.op, "get_bind", return_value=bind):
+        module.upgrade()
+
+    assert bind.execute.call_count == 5
+    sql = str(bind.execute.call_args_list[0].args[0])
+
+    assert "FROM workspaces" in sql
+    assert "FROM api_keys" in sql
+    assert "FROM workspace_memberships" in sql
+    assert "FROM agents" in sql
+    assert "FROM tasks" in sql
+    assert "workspace_id <> ''" in sql
+    assert "WHERE NOT EXISTS" in sql
+    assert "policy.subject_type = 'workspace'" in sql
+    assert "policy.subject_id = targets.workspace_id" in sql
+    assert "policy.params->>'period'" in sql
+
+
+def test_backfill_inserts_the_complete_persisted_baseline() -> None:
+    module = _load_migration()
+    bind = MagicMock()
+
+    with patch.object(module.op, "get_bind", return_value=bind):
+        module.upgrade()
+
+    inserted = [
+        {
+            "target": call.args[1]["target"],
+            "effect": call.args[1]["effect"],
+            "params": json.loads(call.args[1]["params"]),
+            "period": call.args[1]["period"],
+        }
+        for call in bind.execute.call_args_list
+    ]
+
+    assert inserted == [
+        {
+            "target": "spend",
+            "effect": "cap",
+            "params": {"amount_usd": "500.00", "period": "month"},
+            "period": "month",
+        },
+        {
+            "target": "spend",
+            "effect": "cap",
+            "params": {"amount_usd": "50.00", "period": "run"},
+            "period": "run",
+        },
+        {
+            "target": "tokens",
+            "effect": "cap",
+            "params": {"max_tokens": 20_000_000, "max_tokens_per_call": 100_000},
+            "period": None,
+        },
+        {
+            "target": "execution",
+            "effect": "cap",
+            "params": {
+                "max_model_turns": 100,
+                "max_tool_calls_per_turn": 10,
+                "max_tool_calls_total": 1000,
+            },
+            "period": None,
+        },
+        {
+            "target": "content",
+            "effect": "safety",
+            "params": {"prompt_injection": True, "output_sanitizer": True},
+            "period": None,
+        },
+    ]
+
+
+def test_backfill_follows_current_migration_head() -> None:
+    module = _load_migration()
+
+    assert module.revision == "20260731_1200_policy_baseline"
+    assert module.down_revision == "20260731_1100_exec_policy"
+    assert len(module.revision) <= 32

--- a/agentarea-platform/libs/registry/agentarea_registry/application/service.py
+++ b/agentarea-platform/libs/registry/agentarea_registry/application/service.py
@@ -597,22 +597,47 @@ class RegistryService:
 
     @staticmethod
     def _parse_mcp_servers(data: dict[str, Any]) -> list[dict[str, Any]]:
-        """Parse MCP servers from the standard registry format.
+        """Parse MCP servers from an official or AgentArea registry artifact.
 
         Standard format (registry.modelcontextprotocol.io):
             {"servers": [{"server": {"name": ..., "remotes": [...], "packages": [...]}, "_meta": {...}}]}
+
+        AgentArea flattened format (published system catalog):
+            {"servers": [{"registry_id": ..., "connection_type": ..., "json_spec": {...}}]}
         """
         servers = data.get("servers", [])
         if not servers:
             return []
 
-        first = servers[0]
-        if "server" not in first:
+        formats: set[str] = set()
+        for index, entry in enumerate(servers):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    "Unrecognized MCP registry format: each entry of 'servers' must be a mapping "
+                    f"(entry {index} is {type(entry).__name__})"
+                )
+            if isinstance(entry.get("server"), dict):
+                formats.add("standard")
+            elif (
+                isinstance(entry.get("registry_id"), str)
+                and isinstance(entry.get("connection_type"), str)
+                and isinstance(entry.get("json_spec"), dict)
+            ):
+                formats.add("agentarea")
+            else:
+                raise ValueError(
+                    "Unrecognized MCP registry format: each entry of 'servers' must contain either "
+                    "a mapping 'server' key or the AgentArea keys 'registry_id', "
+                    f"'connection_type', and 'json_spec' (entry {index} keys: {sorted(entry)})"
+                )
+
+        if len(formats) != 1:
             raise ValueError(
-                "Unrecognized MCP registry format: each entry of 'servers' must contain a "
-                f"'server' key (got keys: {sorted(first)})"
+                "Unrecognized MCP registry format: official and AgentArea entries cannot be mixed"
             )
-        return RegistryService._parse_standard_mcp_registry(servers)
+        if "standard" in formats:
+            return RegistryService._parse_standard_mcp_registry(servers)
+        return RegistryService._parse_agentarea_mcp_registry(servers)
 
     @staticmethod
     def _parse_standard_mcp_registry(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -756,6 +781,44 @@ class RegistryService:
                     }
                 )
 
+        return items
+
+    @staticmethod
+    def _parse_agentarea_mcp_registry(servers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Parse the normalized format published by the AgentArea catalog pipeline."""
+        items = []
+        for entry in servers:
+            external_id = entry["registry_id"]
+            connection_type = entry["connection_type"]
+            json_spec = entry["json_spec"]
+
+            item_external_id = (
+                f"{external_id}/{connection_type}" if connection_type != "url" else external_id
+            )
+
+            tags = []
+            if entry.get("package_registry"):
+                tags.append(entry["package_registry"])
+            if entry.get("requires_auth"):
+                tags.append("requires-auth")
+            transport = entry.get("transport") or json_spec.get("transport", "")
+            if transport:
+                tags.append(transport)
+
+            spec = {**json_spec, "connection_type": connection_type}
+            if entry.get("env_schema"):
+                spec["env_schema"] = entry["env_schema"]
+
+            items.append(
+                {
+                    "external_id": item_external_id,
+                    "name": entry.get("name") or external_id,
+                    "description": (entry.get("description") or "")[:500],
+                    "version": entry.get("version") or "latest",
+                    "spec": spec,
+                    "tags": tags,
+                }
+            )
         return items
 
     @staticmethod

--- a/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
+++ b/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
@@ -126,10 +126,64 @@ class TestParseMCPServers:
             ]
         }
 
+    def test_agentarea_flattened_format_parses(self):
+        items = RegistryService._parse_mcp_servers(
+            {
+                "servers": [
+                    {
+                        "registry_id": "agency.lona/trading",
+                        "name": "Lona Trading",
+                        "description": "Trading tools",
+                        "version": "2.0.0",
+                        "connection_type": "url",
+                        "transport": "streamable-http",
+                        "package_registry": "remote",
+                        "requires_auth": False,
+                        "json_spec": {
+                            "url": "https://mcp.lona.agency/mcp",
+                            "transport": "streamable-http",
+                            "raw_spec": {"name": "agency.lona/trading"},
+                        },
+                    }
+                ]
+            }
+        )
+
+        assert items == [
+            {
+                "external_id": "agency.lona/trading",
+                "name": "Lona Trading",
+                "description": "Trading tools",
+                "version": "2.0.0",
+                "spec": {
+                    "url": "https://mcp.lona.agency/mcp",
+                    "transport": "streamable-http",
+                    "raw_spec": {"name": "agency.lona/trading"},
+                    "connection_type": "url",
+                },
+                "tags": ["remote", "streamable-http"],
+            }
+        ]
+
     def test_unrecognized_format_raises(self):
-        with pytest.raises(ValueError, match="'server' key"):
+        with pytest.raises(ValueError, match="AgentArea keys"):
             RegistryService._parse_mcp_servers(
                 {"servers": [{"registry_id": "io.example/echo", "connection_type": "url"}]}
+            )
+
+    def test_mixed_formats_raise(self):
+        with pytest.raises(ValueError, match="cannot be mixed"):
+            RegistryService._parse_mcp_servers(
+                {
+                    "servers": [
+                        {"server": {"name": "io.example/remote", "remotes": []}},
+                        {
+                            "registry_id": "io.example/echo",
+                            "connection_type": "url",
+                            "json_spec": {"url": "https://example.com/mcp"},
+                        },
+                    ]
+                }
             )
 
     def test_pypi_package_parses_to_uvx_command(self):


### PR DESCRIPTION
## Outcome

- backfills the complete persisted governance baseline for legacy workspace IDs that predate the `workspaces` table
- preserves existing partial/disabled rules as fail-closed operator decisions
- restores strict support for the currently published AgentArea MCP catalog schema in API and operator reconciliation

## Verification

- 274 platform tests passed
- 16 operator parser tests passed
- Ruff/format passed
- Pyright: 0 errors
- single Alembic head
- real PostgreSQL 18 migration with an API-key-only legacy workspace produced exactly five baseline rules
- current 4317-entry MCP catalog parsed 4317/4317

## Rollout reason

The first RU smoke after the previous release correctly failed closed because the legacy workspace had no persisted runtime budget/token/execution policy. The current registry hook also exposes an active catalog schema that the strict parser had incorrectly classified as dead.