### PR TITLE
Keep OpenSandbox runners healthy under execd

### DIFF
--- a/agentarea-mcp-manager/Dockerfile.runner
+++ b/agentarea-mcp-manager/Dockerfile.runner
@@ -103,8 +103,11 @@ COPY --from=builder /app/bin/activation-service /usr/local/bin/activation-servic
 # 8080 - Activation API, 3000 - MCP protocol (configurable)
 EXPOSE 8080 3000
 
+# The image has two entrypoint modes: the native activation API and OpenSandbox's
+# injected execd bootstrap.  Check the process OpenSandbox actually supervises
+# instead of marking every otherwise-runnable sandbox unhealthy.
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -fsS http://localhost:8080/health || exit 1
+    CMD curl -fsS http://localhost:8080/health || grep -qsx execd /proc/[0-9]*/comm
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/activation-service"]


### PR DESCRIPTION
## Summary
- keep the existing activation-service HTTP health probe
- accept OpenSandbox execd as the supervised process when OpenSandbox replaces the image entrypoint
- prevent successfully runnable gVisor sandboxes from being reported as Docker-unhealthy

## Validation
- `docker build --check -f agentarea-mcp-manager/Dockerfile.runner .`
- ran the exact health command inside the RU runsc sandbox created for task `58c91468-f724-4c4d-aa03-a2a392c5b5cd`; activation endpoint was absent, execd probe returned exit 0