### PR TITLE
Prevent agent workflow retries from replaying tool side effects

### DIFF
--- a/agentarea-platform/libs/tasks/agentarea_tasks/temporal_task_manager.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/temporal_task_manager.py
@@ -160,9 +160,12 @@ class TemporalTaskManager(BaseTaskManager):
                 "effective_policy": execution_request.effective_policy,
             }
 
-            # Create workflow config with task queue
+            # Activity retries handle transient failures at the side-effect boundary.
+            # Retrying the whole agent workflow would replay a fresh run after a
+            # terminal failure and can execute shell/MCP side effects again.
             config = WorkflowConfig(
-                task_queue="agent-tasks"  # Use the same task queue as the worker
+                task_queue="agent-tasks",
+                retry_attempts=1,
             )
 
             # Debug: Log args_dict to verify workspace_id is present

--- a/agentarea-platform/libs/tasks/tests/unit/test_temporal_task_manager.py
+++ b/agentarea-platform/libs/tasks/tests/unit/test_temporal_task_manager.py
@@ -1,0 +1,38 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from agentarea_tasks.domain.models import AgentTask
+from agentarea_tasks.temporal_task_manager import TemporalTaskManager
+
+
+@pytest.mark.asyncio
+async def test_agent_workflow_disables_whole_workflow_retries() -> None:
+    task = AgentTask(
+        id=uuid4(),
+        title="side-effecting task",
+        description="run a shell command",
+        query="run a shell command",
+        user_id="user-1",
+        workspace_id="workspace-1",
+        agent_id=uuid4(),
+        status="pending",
+        created_at=datetime.now(UTC),
+        task_parameters={},
+        metadata={},
+    )
+    manager = TemporalTaskManager.__new__(TemporalTaskManager)
+    domain_task = manager._agent_task_to_task(task)
+    repository = MagicMock()
+    repository.update_status = AsyncMock(return_value=domain_task)
+    repository.update_task = AsyncMock(return_value=domain_task)
+    executor = MagicMock()
+    executor.start_workflow = AsyncMock(return_value=f"task-{task.id}")
+    manager.task_repository = repository
+    manager.temporal_executor = executor
+
+    await manager.submit_task(task)
+
+    config = executor.start_workflow.await_args.kwargs["config"]
+    assert config.retry_attempts == 1


### PR DESCRIPTION
## Summary
- set root `AgentExecutionWorkflow` maximum attempts to one
- retain existing activity-level retry policies
- add regression coverage for the Temporal start configuration

## Production evidence
During RU sandbox cold-restore validation, a follow-up Kimi request returned HTTP 400 after prior shell work had succeeded. Temporal retried the complete workflow 30 seconds later and executed the original shell call again. Shell and MCP calls are not generally idempotent, so whole-workflow retry is unsafe.

## Validation
- 54 task unit tests passed
- targeted Ruff and format checks passed
- targeted Pyright: 0 errors