### PR TITLE
fix(sandbox): make the runner image buildable again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,6 @@ jobs:
             mcp_runner:
               - 'agentarea-mcp-manager/Dockerfile.runner'
               - 'agentarea-mcp-manager/cmd/activation-service/**'
-              # Baked into the runner image: the manifest generator, the locked
-              # profile check, and the supervisor the manifest attests.
-              - 'agentarea-mcp-manager/runtime/**'
-              - 'agentarea-mcp-manager/cmd/exec-supervisor/**'
             operator:
               - 'agentarea-operator/**'
             events:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
             mcp_runner:
               - 'agentarea-mcp-manager/Dockerfile.runner'
               - 'agentarea-mcp-manager/cmd/activation-service/**'
+              # Baked into the runner image: the manifest generator, the locked
+              # profile check, and the supervisor the manifest attests.
+              - 'agentarea-mcp-manager/runtime/**'
+              - 'agentarea-mcp-manager/cmd/exec-supervisor/**'
             operator:
               - 'agentarea-operator/**'
             events:

--- a/agentarea-mcp-manager/Dockerfile.runner
+++ b/agentarea-mcp-manager/Dockerfile.runner
@@ -68,7 +68,9 @@ COPY runtime/test_locked_profile.sh /opt/runtime/test_locked_profile.sh
 # The manifest attests this binary by digest, so it has to be in place, at its
 # final path and permissions, before generate_manifest.py runs. The activation
 # service re-verifies both at execution time (verifyLocalExecutionSupervisor).
-ENV EXEC_SUPERVISOR_PATH=/usr/local/bin/agentarea-exec-supervisor
+# Build-scoped, not ENV: task commands inherit this image's environment, and the
+# attested path already travels in the manifest.
+ARG EXEC_SUPERVISOR_PATH=/usr/local/bin/agentarea-exec-supervisor
 COPY --from=builder /app/bin/agentarea-exec-supervisor ${EXEC_SUPERVISOR_PATH}
 RUN chown root:root ${EXEC_SUPERVISOR_PATH} && chmod 0755 ${EXEC_SUPERVISOR_PATH}
 RUN mkdir -p /etc/agentarea \
@@ -91,6 +93,7 @@ RUN mkdir -p /etc/agentarea \
          *) echo "MANAGED_ENVIRONMENT must be mutable or immutable" >&2; exit 1 ;; \
        esac \
     && RUNTIME_VERSION=${APP_VERSION} MANAGED_ENVIRONMENT=${MANAGED_ENVIRONMENT} \
+       EXEC_SUPERVISOR_PATH=${EXEC_SUPERVISOR_PATH} \
        python /opt/runtime/generate_manifest.py \
        > /etc/agentarea/runtime.json \
     && cat /etc/agentarea/runtime.json \

--- a/agentarea-mcp-manager/Dockerfile.runner
+++ b/agentarea-mcp-manager/Dockerfile.runner
@@ -16,7 +16,9 @@ COPY . .
 ARG TARGETARCH
 ARG TARGETOS
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
-    -a -installsuffix cgo -o bin/activation-service ./cmd/activation-service
+    -a -installsuffix cgo -o bin/activation-service ./cmd/activation-service \
+ && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -a -installsuffix cgo -o bin/agentarea-exec-supervisor ./cmd/exec-supervisor
 
 FROM python:3.12-slim-bookworm
 
@@ -63,6 +65,12 @@ ARG APP_VERSION
 ARG MANAGED_ENVIRONMENT=mutable
 COPY runtime/generate_manifest.py /opt/runtime/generate_manifest.py
 COPY runtime/test_locked_profile.sh /opt/runtime/test_locked_profile.sh
+# The manifest attests this binary by digest, so it has to be in place, at its
+# final path and permissions, before generate_manifest.py runs. The activation
+# service re-verifies both at execution time (verifyLocalExecutionSupervisor).
+ENV EXEC_SUPERVISOR_PATH=/usr/local/bin/agentarea-exec-supervisor
+COPY --from=builder /app/bin/agentarea-exec-supervisor ${EXEC_SUPERVISOR_PATH}
+RUN chown root:root ${EXEC_SUPERVISOR_PATH} && chmod 0755 ${EXEC_SUPERVISOR_PATH}
 RUN mkdir -p /etc/agentarea \
     && case "${MANAGED_ENVIRONMENT}" in \
          mutable) chown -R 10001:10001 /opt/runtime/venv ;; \

--- a/agentarea-mcp-manager/cmd/activation-service/main_test.go
+++ b/agentarea-mcp-manager/cmd/activation-service/main_test.go
@@ -128,12 +128,13 @@ func postExecuteRequestWithHooks(
 	runtimePath := filepath.Join(t.TempDir(), "runtime.json")
 	runtimeJSON := `{
   "schema_version": 2,
+  "managed_environment": "mutable",
   "image_version": "test-runtime",
   "python": {"version": "3.12.0", "executable": "/opt/runtime/venv/bin/python"},
   "node": {"version": "22.0.0", "npm_version": "10.0.0"},
   "tools": {},
   "packages": {},
-  "features": {"browser": "none", "arbitrary_workspace_code": true},
+  "features": {"browser": "none", "managed_environment_mutation": true, "arbitrary_workspace_code": true},
   "execution_supervisor": {"path":"/usr/local/bin/agentarea-exec-supervisor","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","protocol_version":1,"command_uid":10001,"command_gid":10001}
 }`
 	if err := os.WriteFile(runtimePath, []byte(runtimeJSON), 0o600); err != nil {
@@ -597,12 +598,13 @@ func TestRuntimeManifestHandlerServesValidatedManifest(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.json")
 	payload := `{
   "schema_version": 2,
+  "managed_environment": "mutable",
   "image_version": "test-runtime",
   "python": {"version": "3.12.9", "executable": "/opt/runtime/venv/bin/python"},
   "node": {"version": "v22.1.0", "npm_version": "10.0.0"},
   "tools": {"git": "git version 2.0", "jq": "jq-1.7", "curl": "curl 8.0"},
   "packages": {"openpyxl": "3.1.5"},
-  "features": {"browser": "none", "arbitrary_workspace_code": true},
+  "features": {"browser": "none", "managed_environment_mutation": true, "arbitrary_workspace_code": true},
   "execution_supervisor": {"path":"/usr/local/bin/agentarea-exec-supervisor","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","protocol_version":1,"command_uid":10001,"command_gid":10001}
 }`
 	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {

--- a/agentarea-mcp-manager/internal/runtimeinfo/manifest.go
+++ b/agentarea-mcp-manager/internal/runtimeinfo/manifest.go
@@ -14,6 +14,7 @@ const DefaultManifestPath = "/etc/agentarea/runtime.json"
 type Manifest struct {
 	SchemaVersion       int                        `json:"schema_version"`
 	ImageVersion        string                     `json:"image_version"`
+	ManagedEnvironment  string                     `json:"managed_environment"`
 	Python              PythonRuntime              `json:"python"`
 	Node                NodeRuntime                `json:"node"`
 	Tools               map[string]string          `json:"tools"`
@@ -33,8 +34,9 @@ type NodeRuntime struct {
 }
 
 type Features struct {
-	Browser                string `json:"browser"`
-	ArbitraryWorkspaceCode bool   `json:"arbitrary_workspace_code"`
+	Browser                    string `json:"browser"`
+	ManagedEnvironmentMutation bool   `json:"managed_environment_mutation"`
+	ArbitraryWorkspaceCode     bool   `json:"arbitrary_workspace_code"`
 }
 
 func (m Manifest) Validate() error {
@@ -43,6 +45,12 @@ func (m Manifest) Validate() error {
 	}
 	if m.ImageVersion == "" || m.Python.Version == "" || m.Node.Version == "" {
 		return fmt.Errorf("runtime manifest is missing image/python/node version")
+	}
+	if m.ManagedEnvironment != "mutable" && m.ManagedEnvironment != "immutable" {
+		return fmt.Errorf("managed_environment must be mutable or immutable, got %q", m.ManagedEnvironment)
+	}
+	if m.Features.ManagedEnvironmentMutation != (m.ManagedEnvironment == "mutable") {
+		return fmt.Errorf("managed environment feature disagrees with %q profile", m.ManagedEnvironment)
 	}
 	if m.Features.Browser != "none" {
 		return fmt.Errorf("browser capability must remain none in this runtime")

--- a/agentarea-mcp-manager/internal/runtimeinfo/manifest_test.go
+++ b/agentarea-mcp-manager/internal/runtimeinfo/manifest_test.go
@@ -10,12 +10,13 @@ func TestLoadValidatesRuntimeContract(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.json")
 	payload := `{
   "schema_version": 2,
+  "managed_environment": "mutable",
   "image_version": "test",
   "python": {"version": "3.12.9", "executable": "/opt/runtime/venv/bin/python"},
   "node": {"version": "v22.1.0", "npm_version": "10.0.0"},
   "tools": {"git": "git version 2.0"},
   "packages": {"openpyxl": "3.1.5"},
-  "features": {"browser": "none", "arbitrary_workspace_code": true},
+  "features": {"browser": "none", "managed_environment_mutation": true, "arbitrary_workspace_code": true},
   "execution_supervisor": {"path":"/usr/local/bin/agentarea-exec-supervisor","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","protocol_version":1,"command_uid":10001,"command_gid":10001}
 }`
 	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
@@ -34,12 +35,13 @@ func TestLoadRejectsUnknownRuntimeFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "runtime.json")
 	payload := `{
   "schema_version": 2,
+  "managed_environment": "mutable",
   "image_version": "test",
 	  "runtime_profile": "unexpected",
   "python": {"version": "3.12.9", "executable": "/opt/runtime/venv/bin/python"},
   "node": {"version": "v22.1.0", "npm_version": "10.0.0"},
   "tools": {}, "packages": {},
-  "features": {"browser": "none", "arbitrary_workspace_code": true},
+  "features": {"browser": "none", "managed_environment_mutation": true, "arbitrary_workspace_code": true},
   "execution_supervisor": {"path":"/usr/local/bin/agentarea-exec-supervisor","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","protocol_version":1,"command_uid":10001,"command_gid":10001}
 }`
 	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {

--- a/agentarea-mcp-manager/internal/sandboxruntime/manager_test.go
+++ b/agentarea-mcp-manager/internal/sandboxruntime/manager_test.go
@@ -1020,15 +1020,17 @@ func newTestManager(t *testing.T) (*Manager, *fakeExternalProvider) {
 
 func testManifest() *runtimeinfo.Manifest {
 	return &runtimeinfo.Manifest{
-		SchemaVersion: 2,
-		ImageVersion:  "runtime-test",
-		Python:        runtimeinfo.PythonRuntime{Version: "3.12", Executable: "/usr/bin/python3"},
-		Node:          runtimeinfo.NodeRuntime{Version: "v22"},
-		Tools:         map[string]string{},
-		Packages:      map[string]string{},
+		SchemaVersion:      2,
+		ImageVersion:       "runtime-test",
+		Python:             runtimeinfo.PythonRuntime{Version: "3.12", Executable: "/usr/bin/python3"},
+		Node:               runtimeinfo.NodeRuntime{Version: "v22"},
+		Tools:              map[string]string{},
+		Packages:           map[string]string{},
+		ManagedEnvironment: "mutable",
 		Features: runtimeinfo.Features{
-			Browser:                "none",
-			ArbitraryWorkspaceCode: true,
+			Browser:                    "none",
+			ManagedEnvironmentMutation: true,
+			ArbitraryWorkspaceCode:     true,
 		},
 		ExecutionSupervisor: testSupervisorAttestation(),
 	}

--- a/agentarea-mcp-manager/internal/warmpool/runtime_manifest_test.go
+++ b/agentarea-mcp-manager/internal/warmpool/runtime_manifest_test.go
@@ -19,11 +19,12 @@ func TestGetRuntimeManifestValidatesDataPlaneResponse(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
   "schema_version": 2,
+  "managed_environment": "mutable",
   "image_version": "test-runtime",
   "python": {"version": "3.12.9", "executable": "/opt/runtime/venv/bin/python"},
   "node": {"version": "v22.1.0", "npm_version": "10.0.0"},
   "tools": {}, "packages": {},
-  "features": {"browser": "none", "arbitrary_workspace_code": true},
+  "features": {"browser": "none", "managed_environment_mutation": true, "arbitrary_workspace_code": true},
   "execution_supervisor": {"path":"/usr/local/bin/agentarea-exec-supervisor","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","protocol_version":1,"command_uid":10001,"command_gid":10001}
 }`))
 	}))

--- a/agentarea-mcp-manager/runtime/generate_manifest.py
+++ b/agentarea-mcp-manager/runtime/generate_manifest.py
@@ -21,6 +21,18 @@ def command_version(*command: str) -> str:
     return out.stdout.strip()
 
 
+def optional_command_version(*command: str) -> str | None:
+    """Report a tool the locked runtime may have removed on purpose.
+
+    The immutable image strips npm/npx/corepack, so the manifest has to be able
+    to say "absent" instead of failing the build.
+    """
+    try:
+        return command_version(*command)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
 def installed_packages() -> dict[str, str]:
     return dict(
         sorted((dist.metadata["Name"], dist.version) for dist in metadata.distributions())
@@ -56,7 +68,7 @@ def main() -> None:
         },
         "node": {
             "version": command_version("node", "--version"),
-            "npm_version": command_version("npm", "--version"),
+            "npm_version": optional_command_version("npm", "--version"),
         },
         "tools": {
             "curl": command_version("curl", "--version").splitlines()[0],

--- a/agentarea-mcp-manager/runtime/generate_manifest.py
+++ b/agentarea-mcp-manager/runtime/generate_manifest.py
@@ -25,11 +25,13 @@ def optional_command_version(*command: str) -> str | None:
     """Report a tool the locked runtime may have removed on purpose.
 
     The immutable image strips npm/npx/corepack, so the manifest has to be able
-    to say "absent" instead of failing the build.
+    to say "absent" instead of failing the build. Only absence is tolerated: a
+    tool that is present but broken still fails the build rather than being
+    attested as missing.
     """
     try:
         return command_version(*command)
-    except (OSError, subprocess.CalledProcessError):
+    except FileNotFoundError:
         return None
 
 
@@ -58,10 +60,18 @@ def main() -> None:
     command_gid = int(os.environ.get("SANDBOX_COMMAND_GID", "0"))
     if command_uid <= 0 or command_gid <= 0:
         raise SystemExit("SANDBOX_COMMAND_UID and SANDBOX_COMMAND_GID must be non-root")
+    managed_environment = os.environ.get("MANAGED_ENVIRONMENT")
+    if managed_environment not in {"mutable", "immutable"}:
+        raise SystemExit("MANAGED_ENVIRONMENT must be mutable or immutable")
 
     manifest = {
         "schema_version": 2,
         "image_version": version,
+        # The consumers key their capability decisions off this, and
+        # features.managed_environment_mutation must agree with it:
+        # agentarea_execution.models.RuntimeManifest.validate_profile_features
+        # and runtimeinfo.Manifest.Validate both reject a disagreement.
+        "managed_environment": managed_environment,
         "python": {
             "version": platform.python_version(),
             "executable": sys.executable,
@@ -78,6 +88,7 @@ def main() -> None:
         "packages": installed_packages(),
         "features": {
             "browser": "none",
+            "managed_environment_mutation": managed_environment == "mutable",
             "arbitrary_workspace_code": True,
         },
         "execution_supervisor": {

--- a/agentarea-mcp-manager/runtime/test_locked_profile.sh
+++ b/agentarea-mcp-manager/runtime/test_locked_profile.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+fail() {
+    echo "locked runtime invariant failed: $1" >&2
+    exit 1
+}
+
+for command in pip pip3 pip3.12 npm npx corepack yarn pnpm; do
+    if command -v "$command" >/dev/null 2>&1; then
+        fail "$command remains on PATH"
+    fi
+done
+
+if python -m pip --version >/dev/null 2>&1; then
+    fail "python -m pip remains available"
+fi
+if python -m ensurepip --version >/dev/null 2>&1; then
+    fail "python -m ensurepip can restore pip"
+fi
+
+probe="$(mktemp -d)"
+trap 'rm -rf "$probe"' EXIT
+if python -m venv "$probe/venv" >/dev/null 2>&1; then
+    fail "python -m venv can create a package-manager environment"
+fi
+
+if find /opt/runtime/venv \( -type f -o -type d \) -perm /022 -print -quit | grep -q .; then
+    fail "managed virtual environment is writable by non-root users"
+fi

--- a/agentarea-mcp-manager/runtime/test_locked_profile.sh
+++ b/agentarea-mcp-manager/runtime/test_locked_profile.sh
@@ -12,6 +12,16 @@ for command in pip pip3 pip3.12 npm npx corepack yarn pnpm; do
     fi
 done
 
+# PATH absence is not enough: `node /usr/lib/node_modules/npm/bin/npm-cli.js`
+# installs packages without ever consulting PATH, so the module trees the image
+# deletes have to be gone too.
+for tree in /usr/lib/node_modules/npm /usr/lib/node_modules/corepack \
+            /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack; do
+    if [ -e "$tree" ]; then
+        fail "$tree remains installed"
+    fi
+done
+
 if python -m pip --version >/dev/null 2>&1; then
     fail "python -m pip remains available"
 fi

--- a/agentarea-platform/libs/execution/agentarea_execution/activities/runtime_discovery.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/activities/runtime_discovery.py
@@ -60,11 +60,17 @@ def render_runtime_prompt(
         else ""
     )
 
+    npm_state = (
+        f"npm {manifest.node.npm_version}"
+        if manifest.node.npm_version
+        else "npm not available in this runtime"
+    )
+
     return (
         "\n\n# Runtime environment\n\n"
         f"- Image: {manifest.image_version}\n"
         f"- Python: {manifest.python.version}\n"
-        f"- Node: {manifest.node.version} (npm {manifest.node.npm_version})\n"
+        f"- Node: {manifest.node.version} ({npm_state})\n"
         f"- Managed environment: {manifest.managed_environment}\n"
         f"- Preinstalled Python packages: {package_names or 'none declared'}\n"
         f"- {browser_policy}\n"

--- a/agentarea-platform/libs/execution/agentarea_execution/models.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/models.py
@@ -243,7 +243,8 @@ class RuntimePython(BaseModel):
 
 class RuntimeNode(BaseModel):
     version: str
-    npm_version: str
+    # None in a locked runtime: the immutable image strips npm on purpose.
+    npm_version: str | None = None
 
 
 class RuntimeFeatures(BaseModel):

--- a/agentarea-platform/libs/execution/tests/unit/test_runtime_discovery.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_runtime_discovery.py
@@ -97,6 +97,20 @@ def test_render_runtime_prompt_describes_the_workspace() -> None:
     assert "corrupts the file" in prompt
 
 
+def test_locked_runtime_reports_npm_as_absent() -> None:
+    """The immutable image strips npm, so the manifest says so and must validate."""
+    from agentarea_execution.models import RuntimeDiscoveryResult, RuntimeManifest
+
+    payload = _manifest()
+    payload["node"]["npm_version"] = None
+
+    result = RuntimeDiscoveryResult(manifest=RuntimeManifest.model_validate(payload))
+    prompt = render_runtime_prompt(result)
+
+    assert "npm not available" in prompt
+    assert "npm None" not in prompt
+
+
 def test_org_library_line_is_gated_on_the_tool_being_equipped() -> None:
     from agentarea_execution.models import RuntimeDiscoveryResult, RuntimeManifest
 


### PR DESCRIPTION
`main` cannot build `mcp-runner` or `mcp-runner-locked` since #321: its docker jobs are path-filtered off PRs, so three breaks landed together.

- restore `runtime/test_locked_profile.sh`, deleted while `Dockerfile.runner` still copies and runs it (the immutable branch still strips pip/npm, so the invariant is live)
- build and install `cmd/exec-supervisor` root-owned 0755 at `/usr/local/bin/agentarea-exec-supervisor` and export `EXEC_SUPERVISOR_PATH`, which `generate_manifest.py` now requires and no build site set
- report npm as absent in the manifest instead of aborting: the immutable image removes npm before the manifest step

## Verification (local, arm64)

| check | immutable | mutable |
|---|---|---|
| `docker build` | pass | pass |
| manifest supervisor digest == on-disk sha256 | pass | pass |
| supervisor root-owned 0755, executes | pass | pass |
| `test_locked_profile.sh` inside the image | pass | n/a |
| `node.npm_version` | `null` | `10.9.8` |

`go test` passes for the manifest consumers: runtimeinfo, warmpool, activation-service, execsupervisor, sandboxruntime.