### PR TITLE
fix(helm): stop emitting sandbox execution limits twice

### DIFF
--- a/.github/workflows/validate-helm.yml
+++ b/.github/workflows/validate-helm.yml
@@ -89,6 +89,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # The duplicate-env guard parses rendered manifests with PyYAML; the other
+      # scripts in this job are stdlib-only, so this job has no Python setup yet.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
@@ -113,3 +125,6 @@ jobs:
 
       - name: Verify execution cluster kubeconfig wiring
         run: scripts/test-execution-cluster-helm.sh
+
+      - name: Verify no container declares a duplicate env name
+        run: scripts/test-no-duplicate-env-helm.sh

--- a/charts/agentarea/config.yaml
+++ b/charts/agentarea/config.yaml
@@ -136,10 +136,12 @@ groups:
       SANDBOX_WORKSPACE_MAX_FILES: '{{ .Values.sandboxRuntime.workspace.maxFiles }}'
       SANDBOX_WORKSPACE_MAX_FILE_BYTES: '{{ .Values.sandboxRuntime.workspace.maxFileBytes }}'
       SANDBOX_WORKSPACE_MAX_BYTES: '{{ .Values.sandboxRuntime.workspace.maxBytes }}'
-      SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS: '{{ .Values.sandboxRuntime.maxExecutionTimeoutSeconds }}'
-      SANDBOX_DEFAULT_EXECUTION_TIMEOUT_SECONDS: '{{ .Values.sandboxRuntime.defaultExecutionTimeoutSeconds }}'
-      SANDBOX_EXECUTION_QUEUE_TIMEOUT: '{{ .Values.sandboxRuntime.executionQueueTimeout }}'
-      SANDBOX_EXECUTION_COMPLETION_GRACE: '{{ .Values.sandboxRuntime.executionCompletionGrace }}'
+      # SANDBOX_{MAX,DEFAULT}_EXECUTION_TIMEOUT_SECONDS,
+      # SANDBOX_EXECUTION_QUEUE_TIMEOUT and SANDBOX_EXECUTION_COMPLETION_GRACE
+      # are deliberately absent here. agentarea.sandboxRuntime.envs emits them
+      # from the same sandboxRuntime values to both mcp-manager and
+      # sandbox-runner; declaring them again produced two env entries with one
+      # name, which makes server-side apply reject the Deployment.
       SANDBOX_WORKSPACE_SIGNED_URL_TTL: '{{ .Values.sandboxRuntime.workspace.signedUrlTTL }}'
       SANDBOX_WORKSPACE_S3_FORCE_PATH_STYLE: '{{ .Values.sandboxRuntime.workspace.forcePathStyle }}'
       KUBERNETES_SECURITY_RUN_AS_NON_ROOT: 'true'

--- a/charts/agentarea/templates/configs/mcpManager.env.tpl
+++ b/charts/agentarea/templates/configs/mcpManager.env.tpl
@@ -25,10 +25,6 @@ SANDBOX_WORKSPACE_PROVIDER: "s3"
 SANDBOX_WORKSPACE_MAX_FILES: "{{ .Values.sandboxRuntime.workspace.maxFiles }}"
 SANDBOX_WORKSPACE_MAX_FILE_BYTES: "{{ .Values.sandboxRuntime.workspace.maxFileBytes }}"
 SANDBOX_WORKSPACE_MAX_BYTES: "{{ .Values.sandboxRuntime.workspace.maxBytes }}"
-SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS: "{{ .Values.sandboxRuntime.maxExecutionTimeoutSeconds }}"
-SANDBOX_DEFAULT_EXECUTION_TIMEOUT_SECONDS: "{{ .Values.sandboxRuntime.defaultExecutionTimeoutSeconds }}"
-SANDBOX_EXECUTION_QUEUE_TIMEOUT: "{{ .Values.sandboxRuntime.executionQueueTimeout }}"
-SANDBOX_EXECUTION_COMPLETION_GRACE: "{{ .Values.sandboxRuntime.executionCompletionGrace }}"
 SANDBOX_WORKSPACE_SIGNED_URL_TTL: "{{ .Values.sandboxRuntime.workspace.signedUrlTTL }}"
 SANDBOX_WORKSPACE_S3_FORCE_PATH_STYLE: "{{ .Values.sandboxRuntime.workspace.forcePathStyle }}"
 KUBERNETES_SECURITY_RUN_AS_NON_ROOT: "true"
@@ -150,26 +146,6 @@ MCP_GATEWAY_STARTUP_TIMEOUT: "{{ .Values.mcpManager.serverless.startupTimeout }}
     configMapKeyRef:
       name: {{ include "agentarea.fullname" . }}-env-mcpmanager
       key: SANDBOX_WORKSPACE_MAX_BYTES
-- name: SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS
-  valueFrom:
-    configMapKeyRef:
-      name: {{ include "agentarea.fullname" . }}-env-mcpmanager
-      key: SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS
-- name: SANDBOX_DEFAULT_EXECUTION_TIMEOUT_SECONDS
-  valueFrom:
-    configMapKeyRef:
-      name: {{ include "agentarea.fullname" . }}-env-mcpmanager
-      key: SANDBOX_DEFAULT_EXECUTION_TIMEOUT_SECONDS
-- name: SANDBOX_EXECUTION_QUEUE_TIMEOUT
-  valueFrom:
-    configMapKeyRef:
-      name: {{ include "agentarea.fullname" . }}-env-mcpmanager
-      key: SANDBOX_EXECUTION_QUEUE_TIMEOUT
-- name: SANDBOX_EXECUTION_COMPLETION_GRACE
-  valueFrom:
-    configMapKeyRef:
-      name: {{ include "agentarea.fullname" . }}-env-mcpmanager
-      key: SANDBOX_EXECUTION_COMPLETION_GRACE
 - name: SANDBOX_WORKSPACE_SIGNED_URL_TTL
   valueFrom:
     configMapKeyRef:

--- a/scripts/test-no-duplicate-env-helm.sh
+++ b/scripts/test-no-duplicate-env-helm.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# No container may declare the same env name twice. Helm renders such a template
+# happily, kubectl accepts it, and only server-side apply refuses it — with an
+# error on the diff, not the apply, so Argo CD reports "Unknown" sync state and
+# silently stops reconciling that Application while the old pods keep serving.
+# The generated config groups and agentarea.sandboxRuntime.envs both emit
+# SANDBOX_* variables, so this is a live collision risk on every chart change.
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+chart="$repository_root/charts/agentarea"
+default_render="$(mktemp)"
+external_render="$(mktemp)"
+trap 'rm -f "$default_render" "$external_render"' EXIT
+
+helm template dup-env "$chart" >"$default_render"
+
+# The external-provider path renders the sandbox env helper into mcp-manager and
+# sandbox-runner, which is where the collision appeared.
+helm template dup-env "$chart" \
+  --set sandboxRuntime.provider=opensandbox \
+  --set sandboxRuntime.opensandbox.url=https://sandbox.example.com \
+  --set sandboxRuntime.opensandbox.isolation=gvisor \
+  --set sandboxRuntime.opensandbox.runtimeIdentity=test-runtime \
+  --set sandboxRuntime.allowInternet=true \
+  --set sandboxRuntime.opensandbox.egressMode=host-public \
+  --set sandboxRuntime.opensandbox.image=example/runner@sha256:0000000000000000000000000000000000000000000000000000000000000000 \
+  --set sandboxRuntime.opensandbox.apiKeySecretRef.name=sandbox-key \
+  --set sandboxRuntime.opensandbox.apiKeySecretRef.key=api-key \
+  --set sandboxRuntime.manifest.allowed.image_version=0.0.0 \
+  --set sandboxRuntime.manifest.allowed.managed_environment=mutable \
+  --set sandboxRuntime.manifest.allowed.python.version=3.12.13 \
+  --set sandboxRuntime.manifest.allowed.python.executable=/usr/bin/python3 \
+  --set sandboxRuntime.manifest.allowed.node.version=v22.23.2 \
+  --set sandboxRuntime.manifest.allowed.features.browser=none \
+  --set sandboxRuntime.manifest.allowed.features.managed_environment_mutation=true \
+  --set sandboxRuntime.manifest.allowed.features.arbitrary_workspace_code=true \
+  --set sandboxRuntime.manifest.allowed.execution_supervisor.path=/usr/local/bin/agentarea-exec-supervisor \
+  --set sandboxRuntime.manifest.allowed.execution_supervisor.sha256=0000000000000000000000000000000000000000000000000000000000000000 \
+  --set sandboxRuntime.manifest.allowed.execution_supervisor.protocol_version=1 \
+  --set sandboxRuntime.manifest.allowed.execution_supervisor.command_uid=10001 \
+  --set sandboxRuntime.manifest.allowed.execution_supervisor.command_gid=10001 \
+  >"$external_render"
+
+python3 - "$default_render" "$external_render" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+WORKLOADS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"}
+failures = []
+
+for path in sys.argv[1:]:
+    label = pathlib.Path(path).name
+    for doc in yaml.safe_load_all(pathlib.Path(path).read_text()):
+        if not doc or doc.get("kind") not in WORKLOADS:
+            continue
+        spec = doc["spec"]
+        # CronJob nests one more template than the rest.
+        while "template" in spec:
+            spec = spec["template"].get("spec", {})
+        containers = spec.get("containers", []) + spec.get("initContainers", [])
+        for container in containers:
+            names = [entry["name"] for entry in container.get("env", []) or []]
+            duplicates = sorted({name for name in names if names.count(name) > 1})
+            if duplicates:
+                failures.append(
+                    f"{doc['kind']}/{doc['metadata']['name']} [{container['name']}]"
+                    f" declares {', '.join(duplicates)} more than once"
+                )
+
+if failures:
+    print("duplicate env names would be rejected by server-side apply:", file=sys.stderr)
+    for failure in failures:
+        print(f"  {failure}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+echo "OK: no container declares a duplicate env name"

--- a/scripts/test-sandbox-cleanup-helm.sh
+++ b/scripts/test-sandbox-cleanup-helm.sh
@@ -78,11 +78,15 @@ for document in documents:
 
 # Command admission and the activation data plane must render from one policy
 # value. A control-plane maximum larger than the executor maximum would accept
-# work that the data plane later shortens or rejects.
-manager_config = find_document("ConfigMap", "cleanup-auth-agentarea-env-mcpmanager")
+# work that the data plane later shortens or rejects. The manager reads it from
+# agentarea.sandboxRuntime.envs, the one place that emits it: declaring it in the
+# manager config group as well produced two env entries with the same name,
+# which server-side apply rejects.
+manager = find_document("Deployment", "cleanup-auth-agentarea-mcp-manager")
 assert re.search(
-    r'(?m)^\s*SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS:\s*"1800"\s*$',
-    manager_config,
+    r'(?m)^\s*- name:\s*SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS\s*$\n'
+    r'^\s*value:\s*"1800"\s*$',
+    manager,
 ), "manager timeout policy was not rendered from sandboxRuntime.maxExecutionTimeoutSeconds"
 warm_pool = find_document("DaemonSet", "cleanup-auth-agentarea-warm-pool")
 assert re.search(


### PR DESCRIPTION
## What breaks

`mcp-manager` and `sandbox-runner` each render **two env entries with the same name** for four variables, because both the generated manager config group and `agentarea.sandboxRuntime.envs` declare them:

```
SANDBOX_MAX_EXECUTION_TIMEOUT_SECONDS
SANDBOX_DEFAULT_EXECUTION_TIMEOUT_SECONDS
SANDBOX_EXECUTION_QUEUE_TIMEOUT
SANDBOX_EXECUTION_COMPLETION_GRACE
```

Helm renders it, `kubectl` accepts it, and only server-side apply refuses — on the **diff**, not the apply:

```
Failed to compare desired state to live state: error calculating structured merge diff:
  .spec.template.spec.containers[name="mcp-manager"].env: duplicate entries for key [...]
```

Observed in production RU: the Application reported the new revision as observed, sync state `Unknown`, and quietly kept serving pods from the previous manifest.

## Fix

The shared helper stays authoritative — it also feeds `sandbox-runner`, which has no manager ConfigMap. The four entries are removed from the manager config group and the generated template is regenerated.

## Guard

`scripts/test-no-duplicate-env-helm.sh` renders the default **and** the external-provider path and fails on any container declaring a repeated env name. Verified both directions: it fails on the current `main` chart, passes with this fix. The `helm-lint` job gains the Python setup it needs, since the other scripts there are stdlib-only.

`test-sandbox-cleanup-helm.sh` now asserts the manager's admission limit on the Deployment instead of the ConfigMap key — same one-policy-value contract, new delivery path.

## Next

Publish a chart patch (`Release Helm Chart`, bump `patch`) so `k8s-apps` can move off `0.0.17`.