### PR TITLE
fix(mcp): stop 500ing on an instance whose spec is JSON null

### DIFF
--- a/agentarea-mcp-manager/internal/mcpgateway/repository.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/repository.go
@@ -94,16 +94,9 @@ WHERE i.id = $1::uuid
 	if err != nil {
 		return nil, fmt.Errorf("load MCP instance: %w", err)
 	}
-	serverSpec := map[string]any{}
-	instanceSpec := map[string]any{}
-	if err := json.Unmarshal(serverJSON, &serverSpec); err != nil {
-		return nil, fmt.Errorf("decode MCP server spec: %w", err)
-	}
-	if err := json.Unmarshal(instanceJSON, &instanceSpec); err != nil {
-		return nil, fmt.Errorf("decode MCP instance spec: %w", err)
-	}
-	for key, value := range instanceSpec {
-		serverSpec[key] = value
+	serverSpec, err := decodeSpecs(serverJSON, instanceJSON)
+	if err != nil {
+		return nil, err
 	}
 	if remoteURL.Valid && remoteURL.String != "" {
 		serverSpec["type"] = "url"
@@ -135,6 +128,32 @@ WHERE i.id = $1::uuid
 	// Runtime object names are identity-derived. The user-facing display name
 	// remains in Postgres and never participates in data-plane addressing.
 	return &models.MCPServerInstance{InstanceID: id, Name: id, JSONSpec: serverSpec}, nil
+}
+
+// decodeSpecs merges the instance spec over the server spec.
+//
+// Both columns can hold the JSON literal `null` rather than SQL NULL -- the
+// control plane writes it whenever a spec field was omitted -- and COALESCE
+// only defends against the SQL flavour. Unmarshalling `null` into a map yields
+// a nil map, not an empty one, so writing into it panicked with "assignment to
+// entry in nil map" and the gateway answered 500 for every request to that
+// instance.
+func decodeSpecs(serverJSON, instanceJSON []byte) (map[string]any, error) {
+	serverSpec := map[string]any{}
+	instanceSpec := map[string]any{}
+	if err := json.Unmarshal(serverJSON, &serverSpec); err != nil {
+		return nil, fmt.Errorf("decode MCP server spec: %w", err)
+	}
+	if err := json.Unmarshal(instanceJSON, &instanceSpec); err != nil {
+		return nil, fmt.Errorf("decode MCP instance spec: %w", err)
+	}
+	if serverSpec == nil {
+		serverSpec = map[string]any{}
+	}
+	for key, value := range instanceSpec {
+		serverSpec[key] = value
+	}
+	return serverSpec, nil
 }
 
 // MarkStarting opens an activation. An instance that is already ready stays

--- a/agentarea-mcp-manager/internal/mcpgateway/repository_specs_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/repository_specs_test.go
@@ -1,0 +1,60 @@
+package mcpgateway
+
+import "testing"
+
+// Either json_spec column can hold the JSON literal `null` instead of SQL NULL:
+// the control plane writes it whenever the field was omitted, and the query's
+// COALESCE only substitutes for the SQL flavour. Unmarshalling `null` into a map
+// yields nil, so merging the instance spec over it used to panic with
+// "assignment to entry in nil map" -- gin recovered, and the platform saw a 500
+// for every request to that instance.
+func TestDecodeSpecsAcceptsNullServerSpec(t *testing.T) {
+	spec, err := decodeSpecs([]byte("null"), []byte(`{"type":"docker","port":8000}`))
+	if err != nil {
+		t.Fatalf("decodeSpecs() error = %v, want nil", err)
+	}
+	if spec == nil {
+		t.Fatal("decodeSpecs() returned a nil map; callers write into it")
+	}
+	if got := spec["type"]; got != "docker" {
+		t.Fatalf("spec[type] = %v, want docker", got)
+	}
+	if got := spec["port"]; got != float64(8000) {
+		t.Fatalf("spec[port] = %v, want 8000", got)
+	}
+}
+
+func TestDecodeSpecsAcceptsNullInstanceSpec(t *testing.T) {
+	spec, err := decodeSpecs([]byte(`{"type":"docker","image":"example:1"}`), []byte("null"))
+	if err != nil {
+		t.Fatalf("decodeSpecs() error = %v, want nil", err)
+	}
+	if got := spec["image"]; got != "example:1" {
+		t.Fatalf("spec[image] = %v, want example:1", got)
+	}
+}
+
+func TestDecodeSpecsInstanceOverridesServer(t *testing.T) {
+	spec, err := decodeSpecs(
+		[]byte(`{"type":"docker","image":"example:1","port":9000}`),
+		[]byte(`{"port":8000}`),
+	)
+	if err != nil {
+		t.Fatalf("decodeSpecs() error = %v, want nil", err)
+	}
+	if got := spec["port"]; got != float64(8000) {
+		t.Fatalf("spec[port] = %v, want the instance value 8000", got)
+	}
+	if got := spec["image"]; got != "example:1" {
+		t.Fatalf("spec[image] = %v, want the server value example:1", got)
+	}
+}
+
+func TestDecodeSpecsRejectsMalformedJSON(t *testing.T) {
+	if _, err := decodeSpecs([]byte("{"), []byte("{}")); err == nil {
+		t.Fatal("decodeSpecs() error = nil, want a decode failure for malformed server spec")
+	}
+	if _, err := decodeSpecs([]byte("{}"), []byte("{")); err == nil {
+		t.Fatal("decodeSpecs() error = nil, want a decode failure for malformed instance spec")
+	}
+}


### PR DESCRIPTION
Every request to an MCP instance created through `POST /v1/mcp-server-instances/with-spec` returns **500**. Reproduced on RU production:

```
panic recovered: assignment to entry in nil map
  internal/mcpgateway/repository.go:106
```

`LoadInstance` merges the instance spec over the server spec. The query does `COALESCE(s.json_spec, '{}'::jsonb)`, which only defends against **SQL** NULL — the control plane stores the **JSON literal** `null` when a spec field is omitted, and `json.Unmarshal("null", &m)` leaves `m` nil rather than empty. Writing into it panics; gin recovers into a 500, and the platform records `verification: failed`.

## Fix

The merge moves into `decodeSpecs`, which normalises either side being `null`.

## Test

`repository_specs_test.go` — no migrated database needed, unlike the rest of this package. Verified both directions: removing the guard makes `TestDecodeSpecsAcceptsNullServerSpec` panic with the exact production message; with it, all four cases pass.