### PR TITLE
feat(mcp): route MCP servers to the remote data plane

### DIFF
--- a/agentarea-mcp-manager/cmd/mcp-manager/main.go
+++ b/agentarea-mcp-manager/cmd/mcp-manager/main.go
@@ -88,7 +88,7 @@ func initBackend(
 	cfg *config.Config,
 	logger *slog.Logger,
 	taskLeaseTTL time.Duration,
-) (string, backends.Backend, *container.Manager) {
+) (string, backends.Backend, *container.Manager, *mcpgateway.RemoteUpstream) {
 	if cfg.Environment != "" {
 		logger.Info("Using forced environment", slog.String("environment", cfg.Environment))
 	}
@@ -102,6 +102,8 @@ func initBackend(
 
 	var backend backends.Backend
 	var containerManager *container.Manager
+	// Non-nil only when MCP workloads live on a separate data plane.
+	var remoteUpstream *mcpgateway.RemoteUpstream
 
 	switch envType {
 	case "kubernetes":
@@ -129,6 +131,9 @@ func initBackend(
 			os.Exit(1)
 		}
 		backend = dataplane.NewClient(agentCfg)
+		// MCP traffic is proxied to the data plane's per-instance path, and this
+		// credential is attached to that outgoing hop only.
+		remoteUpstream = &mcpgateway.RemoteUpstream{BaseURL: agentCfg.BaseURL, Token: agentCfg.Token}
 		logger.Info("Remote data-plane backend configured", slog.String("url", agentCfg.BaseURL))
 
 	default:
@@ -142,7 +147,7 @@ func initBackend(
 		logger.Error("Failed to initialize backend", slog.String("environment", envType), slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	return envType, backend, containerManager
+	return envType, backend, containerManager, remoteUpstream
 }
 
 func initProviderManager(
@@ -157,11 +162,15 @@ func initProviderManager(
 	case envType == "docker" && containerManager != nil:
 		dockerProvider := providers.NewDockerProvider(secretResolver, containerManager, logger)
 		return providers.NewProviderManager(dockerProvider, nil, urlProvider)
-	case envType == "kubernetes":
-		// For Kubernetes, create a Kubernetes provider that uses the backend
+	case envType == "kubernetes" || envType == "dataplane":
+		// Both drive workloads through a Backend rather than a local container
+		// runtime: the Kubernetes API in-cluster, the remote data plane's HTTP
+		// API otherwise. Without this case a data-plane deployment fell through
+		// to the URL-only manager and every container-backed instance failed
+		// with "no container provider available".
 		adapter := &backendAdapter{inner: backend}
-		kubernetesProvider := providers.NewKubernetesProvider(adapter, secretResolver, logger)
-		return providers.NewProviderManager(nil, kubernetesProvider, urlProvider)
+		backendProvider := providers.NewBackendProvider(adapter, secretResolver, logger)
+		return providers.NewProviderManager(nil, backendProvider, urlProvider)
 	default:
 		// Fallback - only URL provider
 		return providers.NewProviderManager(nil, nil, urlProvider)
@@ -211,7 +220,7 @@ func main() {
 	}
 
 	// Detect environment and initialize appropriate backend
-	envType, backend, containerManager := initBackend(ctx, cfg, logger, sandboxPolicy.TaskLeaseTTL)
+	envType, backend, containerManager, remoteUpstream := initBackend(ctx, cfg, logger, sandboxPolicy.TaskLeaseTTL)
 
 	// Data-plane mode stops here: this process is a data plane, and everything
 	// below — secrets, Redis, the event bus, the sandbox runtime — is
@@ -254,12 +263,12 @@ func main() {
 		os.Exit(1)
 	}
 	defer gatewayRepository.Close()
-	gatewayRuntime, err := mcpgateway.NewProviderRuntime(providerManager, backend, cfg, imagePolicy, gatewayPolicy.StartupTimeout)
+	gatewayRuntime, err := mcpgateway.NewProviderRuntime(providerManager, backend, cfg, imagePolicy, gatewayPolicy.StartupTimeout, remoteUpstream)
 	if err != nil {
 		logger.Error("Failed to initialize MCP demand runtime", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	mcpGateway, err := mcpgateway.New(gatewayRepository, gatewayRuntime, gatewayPolicy, logger)
+	mcpGateway, err := mcpgateway.New(gatewayRepository, gatewayRuntime, gatewayPolicy, logger, remoteUpstream)
 	if err != nil {
 		logger.Error("Failed to initialize MCP demand gateway", slog.String("error", err.Error()))
 		os.Exit(1)

--- a/agentarea-mcp-manager/cmd/mcp-manager/provider_wiring_test.go
+++ b/agentarea-mcp-manager/cmd/mcp-manager/provider_wiring_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/agentarea/mcp-manager/internal/backends"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+type wiringBackendStub struct{}
+
+func (wiringBackendStub) Initialize(context.Context) error { return nil }
+func (wiringBackendStub) CreateInstance(context.Context, *backends.InstanceSpec) (*backends.InstanceResult, error) {
+	return &backends.InstanceResult{}, nil
+}
+func (wiringBackendStub) DeleteInstance(context.Context, string) error { return nil }
+func (wiringBackendStub) GetInstanceStatus(context.Context, string) (*backends.InstanceStatus, error) {
+	return nil, backends.ErrInstanceNotFound
+}
+func (wiringBackendStub) ListInstances(context.Context) ([]*backends.InstanceStatus, error) {
+	return nil, nil
+}
+func (wiringBackendStub) UpdateInstance(context.Context, string, *backends.InstanceSpec) error {
+	return nil
+}
+func (wiringBackendStub) PerformHealthCheck(context.Context, string) (*backends.HealthCheckResult, error) {
+	return &backends.HealthCheckResult{}, nil
+}
+func (wiringBackendStub) Cleanup(context.Context) error { return nil }
+
+// A data-plane deployment used to fall through to the URL-only manager, so every
+// container-backed instance failed with "no container provider available
+// (docker, backend)" -- a 502 on the first MCP request and on retirement.
+func TestDataPlaneDeploymentResolvesAContainerProvider(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, envType := range []string{"dataplane", "kubernetes"} {
+		t.Run(envType, func(t *testing.T) {
+			manager := initProviderManager(envType, wiringBackendStub{}, nil, nil, logger)
+			for _, instanceType := range []string{"docker", "command"} {
+				instance := &models.MCPServerInstance{
+					InstanceID: "abc-123",
+					JSONSpec:   map[string]any{"type": instanceType},
+				}
+				provider, err := manager.GetProvider(instance)
+				if err != nil {
+					t.Fatalf("GetProvider(%s) error = %v, want a backend-backed provider", instanceType, err)
+				}
+				if provider == nil {
+					t.Fatalf("GetProvider(%s) = nil", instanceType)
+				}
+			}
+		})
+	}
+}
+
+// URL-type instances stay on the URL provider: they are reached directly and
+// never occupy the data plane.
+func TestDataPlaneDeploymentKeepsURLInstancesOnTheURLProvider(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	manager := initProviderManager("dataplane", wiringBackendStub{}, nil, nil, logger)
+	provider, err := manager.GetProvider(&models.MCPServerInstance{
+		InstanceID: "abc-123",
+		JSONSpec:   map[string]any{"type": "url", "endpoint_url": "https://mcp.example.com"},
+	})
+	if err != nil {
+		t.Fatalf("GetProvider(url) error = %v", err)
+	}
+	if provider == nil {
+		t.Fatal("GetProvider(url) = nil")
+	}
+}
+
+func (wiringBackendStub) Shutdown(context.Context) error { return nil }

--- a/agentarea-mcp-manager/internal/dataplane/client.go
+++ b/agentarea-mcp-manager/internal/dataplane/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -108,7 +109,12 @@ func (c *Client) do(ctx context.Context, method, path string, body any, out any)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("data plane %s %s returned %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(payload)))
+		return &responseError{
+			status: resp.StatusCode,
+			method: method,
+			path:   path,
+			body:   strings.TrimSpace(string(payload)),
+		}
 	}
 	if out == nil || len(payload) == 0 {
 		return nil
@@ -119,6 +125,31 @@ func (c *Client) do(ctx context.Context, method, path string, body any, out any)
 	return nil
 }
 
+// responseError preserves the data plane's HTTP status so callers can act on it.
+// Without it every failure was one opaque string, and the demand gateway could
+// not tell "this instance does not exist yet" -- its signal to create the
+// workload -- from "the data plane is broken".
+type responseError struct {
+	status int
+	method string
+	path   string
+	body   string
+}
+
+func (e *responseError) Error() string {
+	return fmt.Sprintf("data plane %s %s returned %d: %s", e.method, e.path, e.status, e.body)
+}
+
+func (e *responseError) StatusCode() int { return e.status }
+
+func statusCodeOf(err error) int {
+	var responseErr *responseError
+	if errors.As(err, &responseErr) {
+		return responseErr.status
+	}
+	return 0
+}
+
 func (c *Client) CreateInstance(ctx context.Context, spec *backends.InstanceSpec) (*backends.InstanceResult, error) {
 	var result backends.InstanceResult
 	if err := c.do(ctx, http.MethodPost, "/dataplane/v1/instances", spec, &result); err != nil {
@@ -127,13 +158,28 @@ func (c *Client) CreateInstance(ctx context.Context, spec *backends.InstanceSpec
 	return &result, nil
 }
 
+// DeleteInstance treats an unknown instance as already retired. Retirement is
+// driven by the control plane's own records, which can outlive the workload
+// (the data plane reaped it, or the host was replaced); failing here left such
+// an instance permanently undeletable.
 func (c *Client) DeleteInstance(ctx context.Context, instanceID string) error {
-	return c.do(ctx, http.MethodDelete, "/dataplane/v1/instances/"+url.PathEscape(instanceID), nil, nil)
+	err := c.do(ctx, http.MethodDelete, "/dataplane/v1/instances/"+url.PathEscape(instanceID), nil, nil)
+	if statusCodeOf(err) == http.StatusNotFound {
+		return nil
+	}
+	return err
 }
 
+// GetInstanceStatus reports a missing instance as backends.ErrInstanceNotFound,
+// the typed signal the demand gateway uses to decide it must create the
+// workload. Any other failure stays an inspection error so an outage cannot be
+// mistaken for absence and duplicate a running workload.
 func (c *Client) GetInstanceStatus(ctx context.Context, instanceID string) (*backends.InstanceStatus, error) {
 	var status backends.InstanceStatus
 	if err := c.do(ctx, http.MethodGet, "/dataplane/v1/instances/"+url.PathEscape(instanceID), nil, &status); err != nil {
+		if statusCodeOf(err) == http.StatusNotFound {
+			return nil, backends.ErrInstanceNotFound
+		}
 		return nil, err
 	}
 	return &status, nil

--- a/agentarea-mcp-manager/internal/dataplane/client_notfound_test.go
+++ b/agentarea-mcp-manager/internal/dataplane/client_notfound_test.go
@@ -1,0 +1,72 @@
+package dataplane
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentarea/mcp-manager/internal/backends"
+)
+
+func testClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return NewClient(&ClientConfig{BaseURL: server.URL, Token: "0123456789012345678901234567890123456789"})
+}
+
+// The demand gateway decides to create a workload from exactly one signal:
+// backends.ErrInstanceNotFound. While a 404 arrived as an untyped string, a new
+// instance never got created -- EnsureReady stopped at "inspect MCP runtime
+// status" and the caller saw 502.
+func TestGetInstanceStatusReportsMissingInstanceAsNotFound(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"unknown instance"}`, http.StatusNotFound)
+	})
+
+	_, err := client.GetInstanceStatus(context.Background(), "missing")
+	if !errors.Is(err, backends.ErrInstanceNotFound) {
+		t.Fatalf("GetInstanceStatus() error = %v, want backends.ErrInstanceNotFound", err)
+	}
+}
+
+// The opposite mistake is worse: treating an outage as absence would create a
+// second workload for an instance that already has one.
+func TestGetInstanceStatusKeepsServerFailuresDistinct(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	_, err := client.GetInstanceStatus(context.Background(), "instance-1")
+	if err == nil {
+		t.Fatal("GetInstanceStatus() error = nil, want an inspection failure")
+	}
+	if errors.Is(err, backends.ErrInstanceNotFound) {
+		t.Fatalf("a 500 was reported as absence: %v", err)
+	}
+}
+
+// Retirement is driven by control-plane records that can outlive the workload,
+// so a 404 means the goal is already met. Reporting it left the instance
+// permanently undeletable through the API.
+func TestDeleteInstanceTreatsUnknownInstanceAsRetired(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"unknown instance"}`, http.StatusNotFound)
+	})
+
+	if err := client.DeleteInstance(context.Background(), "missing"); err != nil {
+		t.Fatalf("DeleteInstance() error = %v, want nil for an already-absent instance", err)
+	}
+}
+
+func TestDeleteInstanceStillReportsRealFailures(t *testing.T) {
+	client := testClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusBadGateway)
+	})
+
+	if err := client.DeleteInstance(context.Background(), "instance-1"); err == nil {
+		t.Fatal("DeleteInstance() error = nil, want the upstream failure")
+	}
+}

--- a/agentarea-mcp-manager/internal/mcpgateway/gateway.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/gateway.go
@@ -110,16 +110,41 @@ type Gateway struct {
 	runtime    InstanceRuntime
 	policy     Policy
 	logger     *slog.Logger
+	remote     *RemoteUpstream
 }
 
-func New(repository LifecycleRepository, runtime InstanceRuntime, policy Policy, logger *slog.Logger) (*Gateway, error) {
+func New(repository LifecycleRepository, runtime InstanceRuntime, policy Policy, logger *slog.Logger, remote *RemoteUpstream) (*Gateway, error) {
 	if repository == nil || runtime == nil || logger == nil {
 		return nil, fmt.Errorf("MCP gateway repository, runtime, and logger are required")
 	}
 	if err := policy.Validate(); err != nil {
 		return nil, err
 	}
-	return &Gateway{repository: repository, runtime: runtime, policy: policy, logger: logger}, nil
+	if remote != nil && (remote.BaseURL == "" || remote.Token == "") {
+		return nil, fmt.Errorf("a remote MCP upstream requires both a base URL and a token")
+	}
+	return &Gateway{repository: repository, runtime: runtime, policy: policy, logger: logger, remote: remote}, nil
+}
+
+// isRemoteUpstream reports whether this upstream is the configured data plane,
+// which is the only destination allowed to receive the machine credential.
+//
+// Origin and path prefix must both match: an upstream that names any other host,
+// or the right host by some other route, is proxied without the credential
+// rather than handed one it should never see.
+func (g *Gateway) isRemoteUpstream(target *url.URL, parseErr error) bool {
+	if g.remote == nil || parseErr != nil || target == nil {
+		return false
+	}
+	base, err := url.Parse(g.remote.BaseURL)
+	if err != nil || base.Host == "" {
+		return false
+	}
+	if target.Scheme != base.Scheme || target.Host != base.Host {
+		return false
+	}
+	prefix := strings.TrimRight(base.Path, "/") + "/dataplane/v1/instances/"
+	return strings.HasPrefix(target.Path, prefix)
 }
 
 func (g *Gateway) ServeHTTP(response http.ResponseWriter, request *http.Request) {
@@ -186,7 +211,12 @@ func (g *Gateway) ServeHTTP(response http.ResponseWriter, request *http.Request)
 	}
 
 	target, err := url.Parse(upstream)
-	if err != nil || target.Scheme != "http" || target.Host == "" {
+	remoteHop := g.isRemoteUpstream(target, err)
+	// In-cluster workloads are plain http. The data-plane hop leaves this
+	// network, so it must be https unless the operator declared the path
+	// private, which the data-plane client validates at startup.
+	allowedScheme := target != nil && (target.Scheme == "http" || (remoteHop && target.Scheme == "https"))
+	if err != nil || !allowedScheme || target.Host == "" {
 		g.finishRequest(instanceID, requestID)
 		http.Error(response, "MCP runtime returned an invalid internal endpoint", http.StatusBadGateway)
 		return
@@ -205,6 +235,12 @@ func (g *Gateway) ServeHTTP(response http.ResponseWriter, request *http.Request)
 		outbound.URL.Path = target.Path
 		outbound.URL.RawPath = ""
 		outbound.Host = target.Host
+		if remoteHop {
+			// Set, never add: whatever the caller sent is replaced, so a client
+			// can neither read this credential nor smuggle its own to the data
+			// plane. The header exists only on this outgoing request.
+			outbound.Header.Set("Authorization", "Bearer "+g.remote.Token)
+		}
 	}
 	proxy.ErrorHandler = func(writer http.ResponseWriter, _ *http.Request, proxyErr error) {
 		g.logger.Warn("MCP upstream request failed", slog.String("instance_id", instanceID), slog.String("error", proxyErr.Error()))

--- a/agentarea-mcp-manager/internal/mcpgateway/gateway_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/gateway_test.go
@@ -102,7 +102,7 @@ func testGateway(t *testing.T, repository *gatewayRepositoryStub, runtime Instan
 		IdleTimeout:     time.Minute,
 		SweepInterval:   time.Second,
 		AuthSecret:      testGatewaySecret,
-	}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agentarea-mcp-manager/internal/mcpgateway/remote_upstream_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/remote_upstream_test.go
@@ -1,0 +1,150 @@
+package mcpgateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentarea/mcp-manager/internal/config"
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+const testRemoteToken = "0123456789012345678901234567890123456789"
+
+func testRemote(base string) *RemoteUpstream {
+	return &RemoteUpstream{BaseURL: base, Token: testRemoteToken}
+}
+
+// In remote mode the container has no address in this network, so the upstream
+// must be the data plane's per-instance proxy path. Using the local service URL
+// resolved nothing and every MCP request failed.
+func TestInstanceProxyURLAddressesTheDataPlane(t *testing.T) {
+	got := testRemote("https://mcp-dp.example.com/").InstanceProxyURL("abc-123")
+	want := "https://mcp-dp.example.com/dataplane/v1/instances/abc-123/proxy/mcp"
+	if got != want {
+		t.Fatalf("InstanceProxyURL() = %q, want %q", got, want)
+	}
+}
+
+func TestNewProviderRuntimeRejectsHalfConfiguredRemote(t *testing.T) {
+	for name, remote := range map[string]*RemoteUpstream{
+		"no token": {BaseURL: "https://mcp-dp.example.com"},
+		"no url":   {Token: testRemoteToken},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewProviderRuntime(
+				selectorStub{provider: &runtimeProviderStub{}},
+				&runtimeBackendStub{},
+				&config.Config{Environment: "dataplane"},
+				testImagePolicy(t),
+				time.Second,
+				remote,
+			)
+			if err == nil {
+				t.Fatal("NewProviderRuntime() error = nil, want a refusal to start half-configured")
+			}
+		})
+	}
+}
+
+// The machine credential belongs to this control plane: the real proxy attaches
+// it to the outgoing hop, replacing whatever the caller sent, so a caller can
+// neither read it nor smuggle its own credential to the data plane.
+func TestRemoteHopCarriesTheMachineCredential(t *testing.T) {
+	var seen string
+	dataPlane := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		seen = request.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer dataPlane.Close()
+
+	instanceID := "8ca9f331-9cc9-4a51-9933-27d7bb73860b"
+	repository := &gatewayRepositoryStub{instance: &models.MCPServerInstance{
+		InstanceID: instanceID,
+		JSONSpec:   map[string]any{"type": "docker"},
+	}}
+	remote := testRemote(dataPlane.URL)
+	runtime := &runtimeStub{endpoint: remote.InstanceProxyURL(instanceID)}
+	gateway := testGateway(t, repository, runtime)
+	gateway.remote = remote
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/mcp/"+instanceID+"/mcp", strings.NewReader("{}"))
+	request.Header.Set("X-AgentArea-Manager-Authorization", "Bearer "+testGatewaySecret)
+	request.Header.Set("Authorization", "Bearer caller-supplied")
+
+	gateway.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK || recorder.Body.String() != "proxied" {
+		t.Fatalf("response = %d %q", recorder.Code, recorder.Body.String())
+	}
+	if seen != "Bearer "+testRemoteToken {
+		t.Fatalf("data plane saw Authorization %q, want the machine credential", seen)
+	}
+}
+
+// Without a remote upstream the caller's own Authorization passes through
+// untouched: a local MCP server may authenticate its clients itself.
+func TestLocalHopLeavesCallerCredentialAlone(t *testing.T) {
+	var seen string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		seen = request.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	instanceID := "8ca9f331-9cc9-4a51-9933-27d7bb73860b"
+	repository := &gatewayRepositoryStub{instance: &models.MCPServerInstance{
+		InstanceID: instanceID,
+		JSONSpec:   map[string]any{"type": "docker"},
+	}}
+	runtime := &runtimeStub{endpoint: upstream.URL + "/mcp"}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/mcp/"+instanceID+"/mcp", strings.NewReader("{}"))
+	request.Header.Set("X-AgentArea-Manager-Authorization", "Bearer "+testGatewaySecret)
+	request.Header.Set("Authorization", "Bearer caller-supplied")
+
+	testGateway(t, repository, runtime).ServeHTTP(recorder, request)
+
+	if seen != "Bearer caller-supplied" {
+		t.Fatalf("upstream saw Authorization %q, want the caller's own", seen)
+	}
+}
+
+// Anything that is not exactly the configured data plane is proxied without the
+// credential rather than handed one it must never see.
+func TestOtherUpstreamsNeverReceiveTheCredential(t *testing.T) {
+	gateway := &Gateway{remote: testRemote("https://mcp-dp.example.com")}
+	for name, raw := range map[string]string{
+		"another host":   "https://evil.example.com/dataplane/v1/instances/abc-123/proxy/mcp",
+		"another scheme": "http://mcp-dp.example.com/dataplane/v1/instances/abc-123/proxy/mcp",
+		"another path":   "https://mcp-dp.example.com/admin",
+		"in-cluster":     "http://mcp-abc-123.agentarea.svc.cluster.local:8000/mcp",
+	} {
+		t.Run(name, func(t *testing.T) {
+			target, err := url.Parse(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gateway.isRemoteUpstream(target, nil) {
+				t.Fatalf("isRemoteUpstream(%q) = true; the credential would leak", raw)
+			}
+		})
+	}
+}
+
+func TestLocalDeploymentsHaveNoRemoteHop(t *testing.T) {
+	gateway := &Gateway{}
+	target, err := url.Parse("http://mcp-abc.agentarea.svc.cluster.local:8000/mcp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gateway.isRemoteUpstream(target, nil) {
+		t.Fatal("isRemoteUpstream() = true without a configured data plane")
+	}
+}

--- a/agentarea-mcp-manager/internal/mcpgateway/runtime.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/runtime.go
@@ -114,37 +114,21 @@ func (r *ProviderRuntime) EnsureReady(ctx context.Context, instance *models.MCPS
 		}
 	}
 
-	// A declared-but-unusable port is a spec error, not an invitation to guess:
-	// silently falling back to 8000 would proxy the request to whatever happens
-	// to be listening there. Only an absent port takes the documented default.
-	port := 8000
-	if instanceType == "command" {
-		// command instances are wrapped by mcp-bridge, which always listens here
-		// regardless of any port in the spec.
-		port = 8080
-	} else if rawPort, declared := instance.JSONSpec["port"]; declared && rawPort != nil {
-		var parsed int
-		switch value := rawPort.(type) {
-		case float64:
-			parsed = int(value)
-			if float64(parsed) != value {
-				return "", fmt.Errorf("MCP instance port %v is not an integer", value)
-			}
-		case int:
-			parsed = value
-		default:
-			return "", fmt.Errorf("MCP instance port %v is not a number", rawPort)
-		}
-		if parsed <= 0 || parsed > 65535 {
-			return "", fmt.Errorf("MCP instance port %d is outside 1-65535", parsed)
-		}
-		port = parsed
-	}
+	return r.upstreamURL(instance, instanceType)
+}
+
+// upstreamURL is where the gateway proxies this instance's MCP traffic.
+func (r *ProviderRuntime) upstreamURL(instance *models.MCPServerInstance, instanceType string) (string, error) {
 	// A remote data plane exposes one authenticated path per instance and keeps
 	// the container unaddressable from here, so the local service URL -- which
-	// resolves nothing in this mode -- must not be consulted.
+	// resolves nothing in this mode -- must not be consulted, and the port in
+	// the spec is the data plane's business rather than ours.
 	if r.remote != nil {
 		return r.remote.InstanceProxyURL(instance.InstanceID), nil
+	}
+	port, err := instancePort(instance, instanceType)
+	if err != nil {
+		return "", err
 	}
 	var base string
 	if r.config.Environment == "kubernetes" {
@@ -153,6 +137,39 @@ func (r *ProviderRuntime) EnsureReady(ctx context.Context, instance *models.MCPS
 		base = r.config.GetServiceURL(instance.InstanceID, port)
 	}
 	return strings.TrimRight(base, "/") + "/mcp", nil
+}
+
+// instancePort resolves the port the workload listens on.
+//
+// A declared-but-unusable port is a spec error, not an invitation to guess:
+// silently falling back to 8000 would proxy the request to whatever happens to
+// be listening there. Only an absent port takes the documented default.
+func instancePort(instance *models.MCPServerInstance, instanceType string) (int, error) {
+	if instanceType == "command" {
+		// command instances are wrapped by mcp-bridge, which always listens here
+		// regardless of any port in the spec.
+		return 8080, nil
+	}
+	rawPort, declared := instance.JSONSpec["port"]
+	if !declared || rawPort == nil {
+		return 8000, nil
+	}
+	var parsed int
+	switch value := rawPort.(type) {
+	case float64:
+		parsed = int(value)
+		if float64(parsed) != value {
+			return 0, fmt.Errorf("MCP instance port %v is not an integer", value)
+		}
+	case int:
+		parsed = value
+	default:
+		return 0, fmt.Errorf("MCP instance port %v is not a number", rawPort)
+	}
+	if parsed <= 0 || parsed > 65535 {
+		return 0, fmt.Errorf("MCP instance port %d is outside 1-65535", parsed)
+	}
+	return parsed, nil
 }
 
 // authorize admits the instance against the operator's declared lists. The two

--- a/agentarea-mcp-manager/internal/mcpgateway/runtime.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/runtime.go
@@ -20,17 +20,38 @@ type ProviderSelector interface {
 	GetProvider(*models.MCPServerInstance) (providers.Provider, error)
 }
 
+// RemoteUpstream addresses MCP workloads that run on a separate data plane.
+//
+// The token is this control plane's machine credential for that host. It is
+// attached to the outgoing hop by the gateway and never travels to the caller,
+// so an agent speaking MCP to the manager cannot read or replay it.
+type RemoteUpstream struct {
+	BaseURL string
+	Token   string
+}
+
+// InstanceProxyURL is the data plane's authenticated entry point for one
+// instance. The data plane owns the container and starts it on demand behind
+// this path, so the control plane never needs a routable address of its own.
+func (u RemoteUpstream) InstanceProxyURL(instanceID string) string {
+	return strings.TrimRight(u.BaseURL, "/") + "/dataplane/v1/instances/" + instanceID + "/proxy/mcp"
+}
+
 type ProviderRuntime struct {
 	providers      ProviderSelector
 	backend        backends.Backend
 	config         *config.Config
 	imagePolicy    ImagePolicy
 	startupTimeout time.Duration
+	remote         *RemoteUpstream
 }
 
-func NewProviderRuntime(providerManager ProviderSelector, backend backends.Backend, cfg *config.Config, imagePolicy ImagePolicy, startupTimeout time.Duration) (*ProviderRuntime, error) {
+func NewProviderRuntime(providerManager ProviderSelector, backend backends.Backend, cfg *config.Config, imagePolicy ImagePolicy, startupTimeout time.Duration, remote *RemoteUpstream) (*ProviderRuntime, error) {
 	if providerManager == nil || backend == nil || cfg == nil || startupTimeout <= 0 {
 		return nil, fmt.Errorf("MCP provider runtime requires providers, backend, config, and positive startup timeout")
+	}
+	if remote != nil && (remote.BaseURL == "" || remote.Token == "") {
+		return nil, fmt.Errorf("a remote MCP upstream requires both a base URL and a token")
 	}
 	return &ProviderRuntime{
 		providers:      providerManager,
@@ -38,6 +59,7 @@ func NewProviderRuntime(providerManager ProviderSelector, backend backends.Backe
 		config:         cfg,
 		imagePolicy:    imagePolicy,
 		startupTimeout: startupTimeout,
+		remote:         remote,
 	}, nil
 }
 
@@ -117,6 +139,12 @@ func (r *ProviderRuntime) EnsureReady(ctx context.Context, instance *models.MCPS
 			return "", fmt.Errorf("MCP instance port %d is outside 1-65535", parsed)
 		}
 		port = parsed
+	}
+	// A remote data plane exposes one authenticated path per instance and keeps
+	// the container unaddressable from here, so the local service URL -- which
+	// resolves nothing in this mode -- must not be consulted.
+	if r.remote != nil {
+		return r.remote.InstanceProxyURL(instance.InstanceID), nil
 	}
 	var base string
 	if r.config.Environment == "kubernetes" {

--- a/agentarea-mcp-manager/internal/mcpgateway/runtime_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/runtime_test.go
@@ -87,6 +87,7 @@ func testProviderRuntime(t *testing.T, backend backends.Backend, provider provid
 		&config.Config{Environment: "docker"},
 		testImagePolicy(t),
 		startup,
+		nil,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/agentarea-mcp-manager/internal/providers/backend_provider.go
+++ b/agentarea-mcp-manager/internal/providers/backend_provider.go
@@ -50,16 +50,17 @@ type Backend interface {
 	DeleteInstance(ctx context.Context, instanceID string) error
 }
 
-// KubernetesProvider handles Kubernetes-based MCP server instances
-type KubernetesProvider struct {
+// BackendProvider drives MCP workloads through a Backend: an in-cluster
+// Kubernetes API, or a remote data plane reached over HTTP.
+type BackendProvider struct {
 	backend Backend
 	logger  *slog.Logger
 	secrets secrets.SecretResolver
 }
 
-// NewKubernetesProvider creates a new Kubernetes provider
-func NewKubernetesProvider(backend Backend, secretResolver secrets.SecretResolver, logger *slog.Logger) *KubernetesProvider {
-	return &KubernetesProvider{
+// NewBackendProvider creates a provider over any Backend
+func NewBackendProvider(backend Backend, secretResolver secrets.SecretResolver, logger *slog.Logger) *BackendProvider {
+	return &BackendProvider{
 		backend: backend,
 		logger:  logger,
 		secrets: secretResolver,
@@ -67,7 +68,7 @@ func NewKubernetesProvider(backend Backend, secretResolver secrets.SecretResolve
 }
 
 // CreateInstance creates a new Kubernetes deployment/service for the MCP server
-func (p *KubernetesProvider) CreateInstance(ctx context.Context, instance *models.MCPServerInstance) error {
+func (p *BackendProvider) CreateInstance(ctx context.Context, instance *models.MCPServerInstance) error {
 	p.logger.Info("Creating Kubernetes instance via backend",
 		slog.String("instance_id", instance.InstanceID),
 		slog.String("name", instance.Name))
@@ -99,7 +100,7 @@ func (p *KubernetesProvider) CreateInstance(ctx context.Context, instance *model
 }
 
 // DeleteInstance removes the Kubernetes resources for an MCP server
-func (p *KubernetesProvider) DeleteInstance(ctx context.Context, instanceID, name string) error {
+func (p *BackendProvider) DeleteInstance(ctx context.Context, instanceID, name string) error {
 	p.logger.Info("Deleting Kubernetes instance via backend",
 		slog.String("instance_id", instanceID),
 		slog.String("name", name))
@@ -124,7 +125,7 @@ func (p *KubernetesProvider) DeleteInstance(ctx context.Context, instanceID, nam
 // For command-type instances we wrap the stdio command in mcp-bridge (same as
 // the docker-mode handler does). Otherwise deployment would be created with
 // empty image + port=0 and rejected by the K8s apiserver.
-func (p *KubernetesProvider) convertToInstanceSpec(instance *models.MCPServerInstance) *BackendInstanceSpec {
+func (p *BackendProvider) convertToInstanceSpec(instance *models.MCPServerInstance) *BackendInstanceSpec {
 	// The tier is deliberately left empty: the backend then applies the
 	// operator's DEFAULT_ISOLATION_TIER. Pinning "untrusted" here asked every MCP
 	// pod for a syscall-interposing RuntimeClass, so on a cluster without one the

--- a/agentarea-mcp-manager/internal/providers/backend_provider_test.go
+++ b/agentarea-mcp-manager/internal/providers/backend_provider_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/agentarea/mcp-manager/internal/models"
 )
 
-func newTestKubernetesProvider() *KubernetesProvider {
+func newTestBackendProvider() *BackendProvider {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return &KubernetesProvider{backend: nil, logger: logger}
+	return &BackendProvider{backend: nil, logger: logger}
 }
 
 // command-type: image must be the sandbox bridge, port must be 8080, and
 // Command must equal [cmd, ...args] (no filtering needed since stdio is not
 // relevant to the bridge wrapper).
 func TestConvertToInstanceSpec_CommandType_UsesSandboxImageAndPort(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	instance := &models.MCPServerInstance{
 		InstanceID: "inst-1",
@@ -52,7 +52,7 @@ func TestConvertToInstanceSpec_CommandType_UsesSandboxImageAndPort(t *testing.T)
 // command-type: spec.Command is built from json_spec["command"] (a string,
 // not a slice). The field maps to spec.Command directly, not spec.Entrypoint.
 func TestConvertToInstanceSpec_CommandType_CommandFieldIsString(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	instance := &models.MCPServerInstance{
 		InstanceID: "inst-2",
@@ -77,7 +77,7 @@ func TestConvertToInstanceSpec_CommandType_CommandFieldIsString(t *testing.T) {
 // docker-type: --transport=stdio must be stripped from Command; all other
 // flags must be preserved unchanged.
 func TestConvertToInstanceSpec_DockerType_StripTransportStdioFlag(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	instance := &models.MCPServerInstance{
 		InstanceID: "inst-3",
@@ -112,7 +112,7 @@ func TestConvertToInstanceSpec_DockerType_StripTransportStdioFlag(t *testing.T) 
 
 // docker-type without --transport=stdio: command passes through unchanged.
 func TestConvertToInstanceSpec_DockerType_NoStdioFlag_CommandUnchanged(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	instance := &models.MCPServerInstance{
 		InstanceID: "inst-4",
@@ -141,7 +141,7 @@ func TestConvertToInstanceSpec_DockerType_NoStdioFlag_CommandUnchanged(t *testin
 // docker-type: image and port are taken from json_spec, not overridden with
 // the sandbox values.
 func TestConvertToInstanceSpec_DockerType_UsesImageAndPortFromSpec(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	instance := &models.MCPServerInstance{
 		InstanceID: "inst-5",
@@ -169,7 +169,7 @@ func TestConvertToInstanceSpec_DockerType_UsesImageAndPortFromSpec(t *testing.T)
 // docker-type with --transport=stdio as the only command arg results in an
 // empty (nil or zero-length) Command slice.
 func TestConvertToInstanceSpec_DockerType_OnlyStdioFlag_CommandBecomesEmpty(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	instance := &models.MCPServerInstance{
 		InstanceID: "inst-6",
@@ -195,7 +195,7 @@ func TestConvertToInstanceSpec_DockerType_OnlyStdioFlag_CommandBecomesEmpty(t *t
 // the instance was unreachable no matter what it ran. Leaving the field empty
 // hands the decision to the operator's DEFAULT_ISOLATION_TIER.
 func TestConvertToInstanceSpecLeavesTheIsolationTierToTheOperator(t *testing.T) {
-	p := newTestKubernetesProvider()
+	p := newTestBackendProvider()
 
 	for name, jsonSpec := range map[string]map[string]interface{}{
 		"docker":  {"type": "docker", "image": "ghcr.io/vendor/mcp:1.0", "port": 9000},

--- a/agentarea-mcp-manager/internal/providers/provider.go
+++ b/agentarea-mcp-manager/internal/providers/provider.go
@@ -15,17 +15,17 @@ type Provider interface {
 
 // ProviderManager manages different types of MCP providers
 type ProviderManager struct {
-	dockerProvider     *DockerProvider
-	kubernetesProvider *KubernetesProvider
-	urlProvider        *URLProvider
+	dockerProvider  *DockerProvider
+	backendProvider *BackendProvider
+	urlProvider     *URLProvider
 }
 
 // NewProviderManager creates a new provider manager
-func NewProviderManager(dockerProvider *DockerProvider, kubernetesProvider *KubernetesProvider, urlProvider *URLProvider) *ProviderManager {
+func NewProviderManager(dockerProvider *DockerProvider, backendProvider *BackendProvider, urlProvider *URLProvider) *ProviderManager {
 	return &ProviderManager{
-		dockerProvider:     dockerProvider,
-		kubernetesProvider: kubernetesProvider,
-		urlProvider:        urlProvider,
+		dockerProvider:  dockerProvider,
+		backendProvider: backendProvider,
+		urlProvider:     urlProvider,
 	}
 }
 
@@ -42,15 +42,15 @@ func (pm *ProviderManager) GetProvider(instance *models.MCPServerInstance) (Prov
 				if pm.dockerProvider != nil {
 					return pm.dockerProvider, nil
 				}
-				if pm.kubernetesProvider != nil {
-					return pm.kubernetesProvider, nil
+				if pm.backendProvider != nil {
+					return pm.backendProvider, nil
 				}
-				return nil, fmt.Errorf("no container provider available (docker/kubernetes)")
+				return nil, fmt.Errorf("no container provider available (docker, backend)")
 			case "kubernetes":
-				if pm.kubernetesProvider != nil {
-					return pm.kubernetesProvider, nil
+				if pm.backendProvider != nil {
+					return pm.backendProvider, nil
 				}
-				return nil, fmt.Errorf("kubernetes provider not available")
+				return nil, fmt.Errorf("backend provider not available")
 			case "url":
 				if pm.urlProvider != nil {
 					return pm.urlProvider, nil
@@ -58,8 +58,8 @@ func (pm *ProviderManager) GetProvider(instance *models.MCPServerInstance) (Prov
 				return nil, fmt.Errorf("url provider not available")
 			default:
 				// Try providers in order: kubernetes, docker, url
-				if pm.kubernetesProvider != nil {
-					return pm.kubernetesProvider, nil
+				if pm.backendProvider != nil {
+					return pm.backendProvider, nil
 				}
 				if pm.dockerProvider != nil {
 					return pm.dockerProvider, nil
@@ -73,8 +73,8 @@ func (pm *ProviderManager) GetProvider(instance *models.MCPServerInstance) (Prov
 	}
 
 	// Default: try providers in order
-	if pm.kubernetesProvider != nil {
-		return pm.kubernetesProvider, nil
+	if pm.backendProvider != nil {
+		return pm.backendProvider, nil
 	}
 	if pm.dockerProvider != nil {
 		return pm.dockerProvider, nil


### PR DESCRIPTION
A data-plane deployment could not run MCP servers **at all** — reproduced on RU production. Three seams assumed the workload was local:

| Seam | Symptom |
|---|---|
| `initProviderManager` fell through to URL-only | `no container provider available` -> 502 on first request and on retirement |
| `EnsureReady` used the local service URL | resolves nothing in this mode |
| `dataplane.Client` returned 404 as an untyped error | gateway cannot tell "no workload yet" from an outage, so it never creates one |

## Design

Kubernetes and the data plane both drive workloads through a `Backend`, so they share one provider path — the provider was already backend-generic, only its name said Kubernetes.

The credential stays server-side: the proxy sets `Authorization` on the **outgoing** request only, replacing whatever the caller sent, and only when the upstream's origin **and** path prefix match the configured data plane. An agent speaking MCP to the manager can neither read it nor smuggle its own to the VM. No per-instance tokens — that would be a bigger change than this needs.

## Tests

- `TestRemoteHopCarriesTheMachineCredential` drives the **real** proxy into an `httptest` data plane and asserts the server saw the machine token, not the caller's `Bearer caller-supplied`
- `TestLocalHopLeavesCallerCredentialAlone` — no remote upstream, caller's header passes through
- `TestOtherUpstreamsNeverReceiveTheCredential` — wrong host, scheme, path, or in-cluster address gets nothing
- `TestDataPlaneDeploymentResolvesAContainerProvider` — docker/command resolve a provider for both `dataplane` and `kubernetes`
- `client_notfound_test.go` — 404 maps to `ErrInstanceNotFound` on GET, to success on DELETE; 500 stays an error either way