### PR TITLE
refactor(governance): typed pydantic validation for policy rule params

### DIFF
--- a/agentarea-platform/libs/governance/agentarea_governance/domain/rules.py
+++ b/agentarea-platform/libs/governance/agentarea_governance/domain/rules.py
@@ -11,12 +11,19 @@ contract is unchanged; only the storage shape changed.
 from __future__ import annotations
 
 import logging
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from agentarea_common.money import to_money
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from .policies import (
     ApprovalPolicy,
@@ -26,6 +33,7 @@ from .policies import (
     PolicyDocument,
     TokenPolicy,
     ToolsPolicy,
+    parse_subject,
 )
 
 logger = logging.getLogger(__name__)
@@ -125,12 +133,127 @@ def parse_target(selector: str) -> tuple[str, str | None]:
     return kind, value
 
 
+class SpendCapParams(BaseModel):
+    """``params`` for a ``cap`` on ``spend`` (per calendar month or per run)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    amount_usd: Decimal = Field(ge=0)
+    period: Literal["month", "run"] = "month"
+
+
+class ServiceCapParams(BaseModel):
+    """``params`` for a ``cap`` on ``service`` spend."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    amount_usd: Decimal = Field(gt=0)
+
+
+class TokenCapParams(BaseModel):
+    """``params`` for a ``cap`` on ``tokens``; at least one ceiling is required."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_tokens: int | None = Field(default=None, gt=0)
+    max_tokens_per_call: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _require_one(self) -> TokenCapParams:
+        if self.max_tokens is None and self.max_tokens_per_call is None:
+            raise ValueError("token cap requires 'max_tokens' or 'max_tokens_per_call'")
+        return self
+
+
+class ExecutionCapParams(BaseModel):
+    """``params`` for a ``cap`` on ``execution``; at least one ceiling is required."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_model_turns: int | None = Field(default=None, gt=0)
+    max_tool_calls_per_turn: int | None = Field(default=None, gt=0)
+    max_tool_calls_total: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _require_one(self) -> ExecutionCapParams:
+        if (
+            self.max_model_turns is None
+            and self.max_tool_calls_per_turn is None
+            and self.max_tool_calls_total is None
+        ):
+            raise ValueError(
+                "execution cap requires 'max_model_turns', 'max_tool_calls_per_turn', "
+                "or 'max_tool_calls_total'"
+            )
+        return self
+
+
+class ApprovalParams(BaseModel):
+    """``params`` for an ``approval`` rule; approvers are Keto-style subject refs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    approvers: list[str] = Field(default_factory=list)
+
+    @field_validator("approvers")
+    @classmethod
+    def _validate_refs(cls, value: list[str]) -> list[str]:
+        for ref in value:
+            parse_subject(ref)  # raises ValueError on a non subject-ref (e.g. a raw id)
+        return value
+
+
+class SafetyParams(BaseModel):
+    """``params`` for a ``safety`` rule on ``content``; at least one toggle required."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_injection: bool | None = None
+    output_sanitizer: bool | None = None
+
+    @model_validator(mode="after")
+    def _require_one(self) -> SafetyParams:
+        if self.prompt_injection is None and self.output_sanitizer is None:
+            raise ValueError("safety on content requires 'prompt_injection' or 'output_sanitizer'")
+        return self
+
+
+# Which typed param model validates a cap for each cap target kind.
+_CAP_PARAM_MODEL: dict[str, type[BaseModel]] = {
+    "spend": SpendCapParams,
+    "service": ServiceCapParams,
+    "tokens": TokenCapParams,
+    "execution": ExecutionCapParams,
+}
+
+
+def _validate_params(rule: PolicyRule, model: type[BaseModel]) -> None:
+    """Validate ``rule.params`` through a typed model at the write boundary.
+
+    Pydantic's ``ValidationError`` does not subclass ``ValueError`` in v2, so the
+    write API's ``except ValueError`` would miss it; translate it into a compact,
+    caller-facing ``ValueError`` instead of surfacing the multi-line pydantic dump.
+    """
+    try:
+        model.model_validate(rule.params or {})
+    except ValidationError as exc:
+        problems = "; ".join(
+            f"{'.'.join(str(loc) for loc in err['loc']) or 'params'}: {err['msg']}"
+            for err in exc.errors()
+        )
+        raise ValueError(
+            f"invalid params for {rule.effect.value} on {rule.target!r}: {problems}"
+        ) from exc
+
+
 def assert_enforceable(rule: PolicyRule) -> None:
     """Reject a rule the engine would silently ignore at runtime.
 
     The compiler debug-skips unenforceable rules, so without this guard the write
     API returns 201 for rules that never take effect (fail-open). Fail loudly at
-    the write boundary instead, mirroring the compiler's skip conditions.
+    the write boundary instead: the effect/target selector is checked structurally,
+    then ``params`` is validated through the matching typed model above. This runs
+    only on create/update — never when loading existing rows from the database.
 
     Raises:
         ValueError: with a caller-facing reason when the rule cannot be enforced.
@@ -144,45 +267,16 @@ def assert_enforceable(rule: PolicyRule) -> None:
         raise ValueError("conditions (CEL) are not evaluated yet; omit 'condition'")
 
     kind, value = parse_target(rule.target)  # raises ValueError on an unknown kind
-    params = rule.params or {}
     effect = rule.effect
 
     if effect == PolicyEffect.CAP:
-        if kind not in ("spend", "service", "tokens", "execution"):
+        model = _CAP_PARAM_MODEL.get(kind)
+        if model is None:
             raise ValueError(
                 f"cap on {rule.target!r} is not enforceable; caps apply to "
                 "spend, service, tokens, or execution"
             )
-        if kind in ("spend", "service"):
-            amount = params.get("amount_usd")
-            if amount is None:
-                raise ValueError(f"cap on {rule.target!r} requires 'amount_usd' in params")
-            # to_money coerces garbage to Decimal('0') instead of raising, so a
-            # non-numeric amount would silently compile to a $0 cap. Parse strictly
-            # here and reject anything Decimal cannot read.
-            try:
-                Decimal(str(amount))
-            except (InvalidOperation, ValueError, TypeError) as exc:
-                raise ValueError(
-                    f"cap on {rule.target!r} has a non-numeric 'amount_usd': {amount!r}"
-                ) from exc
-            if kind == "spend":
-                period = params.get("period", "month")
-                if period not in ("month", "run"):
-                    raise ValueError(f"spend cap period must be 'month' or 'run', got {period!r}")
-        elif kind == "tokens":
-            if "max_tokens" not in params and "max_tokens_per_call" not in params:
-                raise ValueError(
-                    "token cap requires 'max_tokens' or 'max_tokens_per_call' in params"
-                )
-        elif not any(
-            f in params
-            for f in ("max_model_turns", "max_tool_calls_per_turn", "max_tool_calls_total")
-        ):
-            raise ValueError(
-                "execution cap requires 'max_model_turns', 'max_tool_calls_per_turn', or "
-                "'max_tool_calls_total' in params"
-            )
+        _validate_params(rule, model)
         return
 
     if effect in (PolicyEffect.DENY, PolicyEffect.ALLOW):
@@ -199,19 +293,17 @@ def assert_enforceable(rule: PolicyRule) -> None:
         return
 
     if effect == PolicyEffect.APPROVAL:
-        if kind == "all" or (kind == "tool" and (value == "*" or value)):
-            return
-        raise ValueError(
-            f"approval is enforceable on '*' (all tools) or tool:<name>, not {rule.target!r}"
-        )
+        if not (kind == "all" or (kind == "tool" and (value == "*" or value))):
+            raise ValueError(
+                f"approval is enforceable on '*' (all tools) or tool:<name>, not {rule.target!r}"
+            )
+        _validate_params(rule, ApprovalParams)
+        return
 
     if effect == PolicyEffect.SAFETY:
         if kind != "content":
             raise ValueError(f"safety is only enforceable on a content target, not {rule.target!r}")
-        if "prompt_injection" not in params and "output_sanitizer" not in params:
-            raise ValueError(
-                "safety on content requires 'prompt_injection' or 'output_sanitizer' in params"
-            )
+        _validate_params(rule, SafetyParams)
         return
 
     if effect == PolicyEffect.EGRESS:

--- a/agentarea-platform/libs/governance/tests/test_rules.py
+++ b/agentarea-platform/libs/governance/tests/test_rules.py
@@ -304,3 +304,47 @@ class TestAssertEnforceable:
         )
         with pytest.raises(ValueError):
             assert_enforceable(rule)
+
+
+class TestTypedParams:
+    """The write boundary validates params through typed pydantic models, so
+    unknown keys, wrong types, and out-of-range values are rejected instead of
+    silently passing through a dict[str, Any] and compiling to a wrong cap."""
+
+    def test_rejects_unknown_param_key(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("spend", PolicyEffect.CAP, amount_usd=10, bogus="x"))
+
+    def test_rejects_non_numeric_amount(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("spend", PolicyEffect.CAP, amount_usd="abc"))
+
+    def test_rejects_negative_spend_amount(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("spend", PolicyEffect.CAP, amount_usd=-5))
+
+    def test_rejects_zero_service_amount(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("service", PolicyEffect.CAP, amount_usd=0))
+
+    def test_rejects_non_positive_token_ceiling(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("tokens", PolicyEffect.CAP, max_tokens=0))
+
+    def test_rejects_non_integer_execution_ceiling(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("execution", PolicyEffect.CAP, max_model_turns="lots"))
+
+    def test_accepts_string_amount_like_the_yaml_baseline(self):
+        assert_enforceable(_rule("spend", PolicyEffect.CAP, amount_usd="500.00", period="month"))
+
+    def test_rejects_bad_approver_ref(self):
+        with pytest.raises(ValueError):
+            assert_enforceable(_rule("*", PolicyEffect.APPROVAL, approvers=["alice"]))
+
+    def test_accepts_subject_ref_approver(self):
+        assert_enforceable(_rule("*", PolicyEffect.APPROVAL, approvers=["user:alice"]))
+
+    def test_error_message_names_the_offending_rule(self):
+        with pytest.raises(ValueError, match="spend"):
+            assert_enforceable(_rule("spend", PolicyEffect.CAP, amount_usd="abc"))


### PR DESCRIPTION
## What

`PolicyRule.params` is a `dict[str, Any]`, polymorphic by `(effect, target-kind)`. Until now `assert_enforceable` validated it by hand-poking keys (`params.get("amount_usd")`, `"max_tokens" not in params`, a manual `Decimal(str(...))` parse, etc.). That style silently accepted anything it didn't explicitly check — unknown keys, wrong types, negative caps — so a rule could `201` at the write API and then compile to a wrong or dropped runtime effect.

This replaces the hand-rolled checks with **typed pydantic param models**, dispatched by `(effect, target-kind)`:

| effect / target | model | rejects |
|---|---|---|
| `cap` / `spend` | `SpendCapParams` | non-numeric / negative `amount_usd`, `period` ∉ {month, run} |
| `cap` / `service` | `ServiceCapParams` | non-numeric / non-positive `amount_usd` |
| `cap` / `tokens` | `TokenCapParams` | both ceilings absent, non-positive int |
| `cap` / `execution` | `ExecutionCapParams` | all three ceilings absent, non-positive int |
| `approval` | `ApprovalParams` | approvers that aren't Keto-style subject refs |
| `safety` / `content` | `SafetyParams` | both toggles absent |

Every model is `extra="forbid"`, so unknown param keys are now rejected instead of silently ignored.

## Design constraints honored

- **Write-boundary only.** Validation runs in `assert_enforceable` (called from `POST`/`PATCH /v1/policies`), *not* as a `PolicyRule` model validator — existing DB rows must still round-trip through the compiler unchanged.
- **422 preserved.** Pydantic's `ValidationError` is not a `ValueError` subclass in v2, so it's translated to a compact `ValueError`; the route's `except ValueError -> 422` keeps working, with a caller-facing message instead of the multi-line pydantic dump.
- **Egress stays opaque.** No egress param model — core stores/round-trips egress rows for the enterprise `EgressEnforcer` (container network layer) and never validates or enforces them.
- **Compiler path untouched.** `rules_to_document` still reads the raw dict and skip-and-logs, so loading legacy rows never fails closed.
- Every shape in `config/default_policies.yaml` validates cleanly (incl. `amount_usd` as a string).

## Verification

- `libs/governance/tests/test_rules.py`: 78 passed (10 new `TestTypedParams` cases: unknown-key, wrong-type, negative/zero, bad approver ref, string-amount baseline).
- `libs/governance/tests`: 265 passed. `apps/api/tests/test_governance_policy_api.py` + migration: 20 passed.
- `ruff check .` (CI-equivalent, from `agentarea-platform`): All checks passed. `ruff format --check`: clean.
- `pyright libs/.../rules.py`: 0 errors.

Opened for review — not merging.
