### PR TITLE
fix(api): stable OpenAPI operation-ids for multi-method routes; drop duplicate agent subrouter mounts

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents.py
@@ -30,7 +30,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from . import agents_a2a, agents_well_known
 from ._access_control_grants import grant_resource_owner
 from ._approval_policy_sync import (
     apply_approval_targets,
@@ -394,10 +393,3 @@ async def delete_agent(
     if not success:
         raise HTTPException(status_code=404, detail="Agent not found")
     return {"status": "success"}
-
-
-# Include A2A protocol subroutes
-router.include_router(agents_a2a.router, prefix="/{agent_id}", tags=["agents-a2a"])
-
-# Include agent-specific well-known subroutes
-router.include_router(agents_well_known.router, prefix="/{agent_id}", tags=["agents-well-known"])

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
@@ -222,9 +222,25 @@ async def hydra_dcr_proxy(request: Request) -> Response:
     )
 
 
-@oauth_as_router.api_route(
+@oauth_as_router.get(
     "/oauth2/{path:path}",
-    methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
+    operation_id="hydra_oauth2_proxy_oauth2__path__get",
+)
+@oauth_as_router.post(
+    "/oauth2/{path:path}",
+    operation_id="hydra_oauth2_proxy_oauth2__path__post",
+)
+@oauth_as_router.put(
+    "/oauth2/{path:path}",
+    operation_id="hydra_oauth2_proxy_oauth2__path__put",
+)
+@oauth_as_router.delete(
+    "/oauth2/{path:path}",
+    operation_id="hydra_oauth2_proxy_oauth2__path__delete",
+)
+@oauth_as_router.patch(
+    "/oauth2/{path:path}",
+    operation_id="hydra_oauth2_proxy_oauth2__path__patch",
 )
 async def hydra_oauth2_proxy(path: str, request: Request) -> Response:
     """Proxy all /oauth2/* requests through to Hydra (excluding /register handled above)."""

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
@@ -206,9 +206,17 @@ def _guard_and_pin_upstream(
     return request_target, target.original_host, extensions
 
 
-@router.api_route(
+@router.get(
     "/{instance_id}/mcp",
-    methods=["GET", "POST", "DELETE"],
+    operation_id="proxy_instance_v1_mcp__instance_id__mcp_get",
+)
+@router.post(
+    "/{instance_id}/mcp",
+    operation_id="proxy_instance_v1_mcp__instance_id__mcp_post",
+)
+@router.delete(
+    "/{instance_id}/mcp",
+    operation_id="proxy_instance_v1_mcp__instance_id__mcp_delete",
 )
 async def proxy_instance(
     instance_id: UUID,

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/webhooks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/webhooks.py
@@ -26,9 +26,45 @@ async def webhook_health_check(
         return {"status": "unhealthy", "service": "webhook-manager"}
 
 
-@router.api_route(
+@router.get(
     "/{webhook_id}",
-    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+    operation_id="handle_webhook_webhooks__webhook_id__get",
+    summary="Handle webhook requests",
+    description="Process incoming webhook requests for registered triggers",
+)
+@router.post(
+    "/{webhook_id}",
+    operation_id="handle_webhook_webhooks__webhook_id__post",
+    summary="Handle webhook requests",
+    description="Process incoming webhook requests for registered triggers",
+)
+@router.put(
+    "/{webhook_id}",
+    operation_id="handle_webhook_webhooks__webhook_id__put",
+    summary="Handle webhook requests",
+    description="Process incoming webhook requests for registered triggers",
+)
+@router.patch(
+    "/{webhook_id}",
+    operation_id="handle_webhook_webhooks__webhook_id__patch",
+    summary="Handle webhook requests",
+    description="Process incoming webhook requests for registered triggers",
+)
+@router.delete(
+    "/{webhook_id}",
+    operation_id="handle_webhook_webhooks__webhook_id__delete",
+    summary="Handle webhook requests",
+    description="Process incoming webhook requests for registered triggers",
+)
+@router.head(
+    "/{webhook_id}",
+    operation_id="handle_webhook_webhooks__webhook_id__head",
+    summary="Handle webhook requests",
+    description="Process incoming webhook requests for registered triggers",
+)
+@router.options(
+    "/{webhook_id}",
+    operation_id="handle_webhook_webhooks__webhook_id__options",
     summary="Handle webhook requests",
     description="Process incoming webhook requests for registered triggers",
 )

--- a/agentarea-platform/apps/api/tests/test_openapi_operation_ids.py
+++ b/agentarea-platform/apps/api/tests/test_openapi_operation_ids.py
@@ -1,0 +1,88 @@
+"""Regression tests for stable, unique public OpenAPI operation IDs."""
+
+from collections import defaultdict
+
+from agentarea_api.api.v1 import webhooks
+from agentarea_api.api.v1.mcp_oauth_as import oauth_as_router
+from agentarea_api.api.v1.router import protected_v1_router, public_v1_router
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
+
+def _application() -> FastAPI:
+    app = FastAPI()
+    app.include_router(oauth_as_router)
+    app.include_router(webhooks.router)
+    app.include_router(public_v1_router)
+    app.include_router(protected_v1_router)
+    return app
+
+
+def _application_schema() -> dict:
+    return _application().openapi()
+
+
+def test_main_router_has_no_duplicate_method_path_identities() -> None:
+    routes_by_identity: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    for route in _application().routes:
+        if not isinstance(route, APIRoute):
+            continue
+        for method in route.methods:
+            routes_by_identity[(method, route.path)].append(route.name)
+
+    duplicates = {
+        identity: route_names
+        for identity, route_names in routes_by_identity.items()
+        if len(route_names) > 1
+    }
+    assert duplicates == {}
+
+
+def test_openapi_operation_ids_are_unique() -> None:
+    operations_by_id: dict[str, list[str]] = defaultdict(list)
+
+    for path, path_item in _application_schema()["paths"].items():
+        for method, operation in path_item.items():
+            if isinstance(operation, dict) and "operationId" in operation:
+                operations_by_id[operation["operationId"]].append(f"{method.upper()} {path}")
+
+    duplicates = {
+        operation_id: operations
+        for operation_id, operations in operations_by_id.items()
+        if len(operations) > 1
+    }
+    assert duplicates == {}
+
+
+def test_multi_method_proxy_operation_ids_remain_stable() -> None:
+    schema = _application_schema()
+    expected = {
+        "/oauth2/{path}": {
+            "get": "hydra_oauth2_proxy_oauth2__path__get",
+            "post": "hydra_oauth2_proxy_oauth2__path__post",
+            "put": "hydra_oauth2_proxy_oauth2__path__put",
+            "patch": "hydra_oauth2_proxy_oauth2__path__patch",
+            "delete": "hydra_oauth2_proxy_oauth2__path__delete",
+        },
+        "/webhooks/{webhook_id}": {
+            "get": "handle_webhook_webhooks__webhook_id__get",
+            "post": "handle_webhook_webhooks__webhook_id__post",
+            "put": "handle_webhook_webhooks__webhook_id__put",
+            "patch": "handle_webhook_webhooks__webhook_id__patch",
+            "delete": "handle_webhook_webhooks__webhook_id__delete",
+            "head": "handle_webhook_webhooks__webhook_id__head",
+            "options": "handle_webhook_webhooks__webhook_id__options",
+        },
+        "/v1/mcp/{instance_id}/mcp": {
+            "get": "proxy_instance_v1_mcp__instance_id__mcp_get",
+            "post": "proxy_instance_v1_mcp__instance_id__mcp_post",
+            "delete": "proxy_instance_v1_mcp__instance_id__mcp_delete",
+        },
+    }
+
+    actual = {
+        path: {method: schema["paths"][path][method]["operationId"] for method in operation_ids}
+        for path, operation_ids in expected.items()
+    }
+    assert actual == expected


### PR DESCRIPTION
## What

FastAPI's `@router.api_route(..., methods=[...])` registers a multi-method route under a **single** operation-id, which collides in the generated OpenAPI spec and produces ambiguous/duplicated names in downstream clients. This splits the three multi-method routes into per-method routes with explicit, stable `operation_id`s:

- `mcp_proxy` — `GET/POST/DELETE /v1/mcp/{instance_id}/mcp`
- Hydra OAuth proxy (`mcp_oauth_as`) — `GET/POST/PUT/DELETE/PATCH /oauth2/{path}`
- `webhooks`

Adds `test_openapi_operation_ids.py` to lock the invariant: operation-ids are unique, the proxy ids stay stable, and no `(method, path)` identity is registered twice.

## Bug this surfaced

The no-duplicate-identity check caught a real double-mount on `main`: `agents_a2a.router` and `agents_well_known.router` were each included **twice** —

- canonically in `router.py`: a2a on the **protected** v1 router, well-known on the **public** v1 router (with the documented A2A-auth rationale), and
- again in `agents.py` via `router.include_router(...)`.

So every A2A endpoint (`/rpc`, `/well-known`) and every `.well-known/*` discovery endpoint was registered twice at the same path (the well-known ones additionally landed on the protected router, which is wrong for unauthenticated discovery). Removed the redundant `agents.py` includes and their now-unused imports; the canonical `router.py` mounts remain untouched.

## Verification

- `apps/api/tests/test_openapi_operation_ids.py`: 3 passed (unique ids, stable proxy ids, no duplicate identities).
- `ruff check` + `ruff format --check` on changed source: clean.
- `pyright` on changed source: 0 errors.

Scope note: this is the OpenAPI-hygiene slice split out of a larger in-flight branch; the generated api-client + CLI regeneration and the tool-governance/web-search work land separately. Opened for review — not merging.
