### PR TITLE
Keep the resource ceiling comparable

### DIFF
--- a/agentarea-mcp-manager/internal/container/cpu_ceiling_test.go
+++ b/agentarea-mcp-manager/internal/container/cpu_ceiling_test.go
@@ -50,3 +50,39 @@ func TestFiniteCPURequestInsideTheCeilingIsStillAdmitted(t *testing.T) {
 		t.Fatalf("refused a request inside the ceiling: %v", err)
 	}
 }
+
+// The same fail-open one field over. A suffix multiplies into int64 and wraps:
+// a negative byte count is below every maximum, so the request the ceiling
+// exists to stop is the one shape that passes it.
+func TestOverflowingMemoryRequestRefusesRatherThanWrappingNegative(t *testing.T) {
+	runtime, _ := stubRuntime(t)
+
+	for _, requested := range []string{"9223372036g", "9007199254741m", "9223372036854775807k"} {
+		manager := &Manager{config: testConfig(runtime), logger: discardLogger(),
+			containers: map[string]*models.Container{}}
+		manager.config.Container.MaxMemoryLimit = "512m"
+		manager.config.Container.MaxCPULimit = "1.0"
+
+		err := manager.enforceResourceCeiling(&models.Container{
+			Name: "c", MemoryLimit: requested, CPULimit: "0.5",
+		})
+		if err == nil {
+			t.Fatalf("a 512m host accepted %s; the byte count wrapped past the ceiling", requested)
+		}
+	}
+}
+
+func TestLargeButRepresentableMemoryRequestIsStillCompared(t *testing.T) {
+	runtime, _ := stubRuntime(t)
+
+	manager := &Manager{config: testConfig(runtime), logger: discardLogger(),
+		containers: map[string]*models.Container{}}
+	manager.config.Container.MaxMemoryLimit = "8g"
+	manager.config.Container.MaxCPULimit = "1.0"
+
+	if err := manager.enforceResourceCeiling(&models.Container{
+		Name: "c", MemoryLimit: "4g", CPULimit: "0.5",
+	}); err != nil {
+		t.Fatalf("refused 4g against an 8g ceiling: %v", err)
+	}
+}

--- a/agentarea-mcp-manager/internal/container/cpu_ceiling_test.go
+++ b/agentarea-mcp-manager/internal/container/cpu_ceiling_test.go
@@ -1,0 +1,52 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/agentarea/mcp-manager/internal/models"
+)
+
+// A ceiling is only a ceiling if it can be compared. ParseFloat accepts NaN and
+// Inf: every comparison with NaN is false, so a NaN maximum admits any request,
+// and an Inf maximum is above every finite one. Either leaves the host's limit
+// nominally configured and actually off, which is the same fail-open the
+// unreadable-maximum case already refuses.
+func TestNonFiniteCPUCeilingRefusesRatherThanAdmittingEverything(t *testing.T) {
+	runtime, _ := stubRuntime(t)
+
+	for name, tc := range map[string]struct{ maxCPU, requested string }{
+		"nan maximum":   {"NaN", "4"},
+		"inf maximum":   {"Inf", "64"},
+		"nan requested": {"1.0", "NaN"},
+		"inf requested": {"1.0", "+Inf"},
+	} {
+		manager := &Manager{config: testConfig(runtime), logger: discardLogger(),
+			containers: map[string]*models.Container{}}
+		manager.config.Container.MaxMemoryLimit = "512m"
+		manager.config.Container.MaxCPULimit = tc.maxCPU
+
+		err := manager.enforceResourceCeiling(&models.Container{
+			Name: "c", MemoryLimit: "256m", CPULimit: tc.requested,
+		})
+		if err == nil {
+			t.Fatalf("%s: max %q accepted %q; a ceiling that cannot be compared must refuse",
+				name, tc.maxCPU, tc.requested)
+		}
+	}
+}
+
+func TestFiniteCPURequestInsideTheCeilingIsStillAdmitted(t *testing.T) {
+	runtime, _ := stubRuntime(t)
+
+	manager := &Manager{config: testConfig(runtime), logger: discardLogger(),
+		containers: map[string]*models.Container{}}
+	manager.config.Container.MaxMemoryLimit = "512m"
+	manager.config.Container.MaxCPULimit = "2"
+
+	err := manager.enforceResourceCeiling(&models.Container{
+		Name: "c", MemoryLimit: "256m", CPULimit: "1.5",
+	})
+	if err != nil {
+		t.Fatalf("refused a request inside the ceiling: %v", err)
+	}
+}

--- a/agentarea-mcp-manager/internal/container/manager.go
+++ b/agentarea-mcp-manager/internal/container/manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"os"
 	"os/exec"
@@ -809,12 +810,12 @@ func (m *Manager) enforceResourceCeiling(container *models.Container) error {
 	}
 
 	if container.CPULimit != "" {
-		requested, err := strconv.ParseFloat(container.CPULimit, 64)
-		if err != nil || requested <= 0 {
+		requested, err := parseCPULimit(container.CPULimit)
+		if err != nil {
 			return fmt.Errorf("cpu limit %q is not a positive number", container.CPULimit)
 		}
-		maximum, err := strconv.ParseFloat(m.config.Container.MaxCPULimit, 64)
-		if err != nil || maximum <= 0 {
+		maximum, err := parseCPULimit(m.config.Container.MaxCPULimit)
+		if err != nil {
 			return fmt.Errorf("MAX_CPU_LIMIT %q is unusable, refusing the requested %s",
 				m.config.Container.MaxCPULimit, container.CPULimit)
 		}
@@ -825,6 +826,25 @@ func (m *Manager) enforceResourceCeiling(container *models.Container) error {
 	}
 
 	return nil
+}
+
+// parseCPULimit reads a core count. Positivity alone is not enough: ParseFloat
+// accepts NaN and Inf, and neither survives being compared. A NaN maximum leaves
+// "requested > maximum" false for every request, and an Inf maximum is above
+// every finite one, so either would quietly turn the host's ceiling off. Both
+// sides of the comparison go through here so neither can.
+func parseCPULimit(value string) (float64, error) {
+	parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("%q is not a finite number", value)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("%q is not a positive number", value)
+	}
+	return parsed, nil
 }
 
 // parseMemoryLimit reads the runtime's own memory syntax: a byte count with an

--- a/agentarea-mcp-manager/internal/container/manager.go
+++ b/agentarea-mcp-manager/internal/container/manager.go
@@ -869,6 +869,12 @@ func parseMemoryLimit(value string) (int64, error) {
 	if err != nil || amount <= 0 {
 		return 0, fmt.Errorf("not a positive byte count")
 	}
+	// The suffix multiplies, and int64 wraps: "9223372036g" parses cleanly and
+	// then overflows into a negative byte count, which sits below every maximum
+	// and would walk straight through the ceiling it was supposed to hit.
+	if amount > math.MaxInt64/multiplier {
+		return 0, fmt.Errorf("byte count %s does not fit in int64", value)
+	}
 	return amount * multiplier, nil
 }
 


### PR DESCRIPTION
Follow-up to #329, found by an adversarial review of its head.

The per-instance limits travel with the instance spec, which is caller input from the platform API, so the data plane compares them against a host maximum before running anything. Two arithmetic holes let a request walk through that comparison.

**Non-finite CPU.** `strconv.ParseFloat` accepts `NaN` and `Inf`, and a `<= 0` check catches neither. Every comparison with `NaN` is false, so `MAX_CPU_LIMIT=NaN` admitted any requested value; `Inf` sits above every finite one. The ceiling stayed nominally configured and was in fact off.

**Wrapping memory.** Suffixes multiply into `int64` without a range check, so `9223372036g` parsed cleanly, overflowed to a negative byte count, and landed below every maximum. The one request shape the ceiling exists to stop was the shape that passed it.

Both parsers now refuse values that cannot be compared, which is the fail-closed reading the unreadable-maximum case in #329 already had. Tests cover NaN/Inf on both sides of the CPU comparison, three overflowing memory strings, and that ordinary requests inside the ceiling are still admitted; each was checked against a neutered guard to confirm it fails without the fix.

Verification: `go test ./internal/...` in `agentarea-mcp-manager` — 21 packages ok, 0 failures; `gofmt -l` clean.