### PR TITLE
Answer the MCP container health endpoint, per workspace

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_server_instances.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_server_instances.py
@@ -514,24 +514,73 @@ async def discover_mcp_server_instance_tools(
 @router.get("/health/containers")
 async def get_containers_health(
     user_context: UserContextDep,
+    service: MCPServerInstanceService = Depends(get_mcp_server_instance_service),
 ):
-    """Get health status of all MCP containers by proxying to the Go manager."""
+    """Health of this workspace's MCP workloads.
+
+    The manager also has a route that answers for every workload it runs, which is
+    the wrong thing to hand a caller: its rows carry service names and container
+    ids belonging to other workspaces. The instance list comes from the
+    workspace-scoped service instead, and only those ids are asked about, so the
+    answer cannot name a workload the caller is not entitled to see.
+
+    A workload the manager reports as unhealthy, has never heard of, or cannot be
+    reached about is a fact about that instance, not a failure of the request: each
+    is reported per instance and the endpoint still answers 200.
+    """
+    import asyncio
+
     import httpx
 
-    try:
-        settings = get_settings()
-        async with httpx.AsyncClient() as client:
-            response = await client.get(f"{settings.mcp.MCP_MANAGER_URL}/containers/health")
-            if response.status_code != 200:
-                raise HTTPException(
-                    status_code=response.status_code,
-                    detail=f"Failed to get container health: {response.text}",
-                )
-            return response.json()
-    except httpx.RequestError as e:
-        raise HTTPException(status_code=503, detail="Unable to connect to container manager") from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail="Internal server error") from e
+    settings = get_settings()
+    instances = await service.list()
+
+    async def read_one(client: "httpx.AsyncClient", instance) -> dict:
+        row = {"instance_id": str(instance.id), "name": getattr(instance, "name", None)}
+        url = f"{settings.mcp.MCP_MANAGER_URL}/instances/{instance.id}/health"
+        try:
+            response = await client.get(url)
+        except httpx.RequestError as e:
+            logger.warning("MCP manager unreachable for instance %s: %s", instance.id, e)
+            return {**row, "healthy": False, "status": "manager_unreachable"}
+
+        # The manager answers 200 when healthy and 503 when not, both with the
+        # same body: the second is a report, not a transport failure.
+        if response.status_code in (200, 503):
+            try:
+                body = response.json()
+            except ValueError:
+                logger.error("MCP manager sent unreadable health for %s", instance.id)
+                return {**row, "healthy": False, "status": "unreadable"}
+            if not isinstance(body, dict):
+                return {**row, "healthy": False, "status": "unreadable"}
+            return {
+                **row,
+                "healthy": bool(body.get("healthy")),
+                "status": body.get("status") or ("healthy" if body.get("healthy") else "unhealthy"),
+                "details": body,
+            }
+
+        if response.status_code == 404:
+            # Never started, or already reaped for idleness: not an error.
+            return {**row, "healthy": False, "status": "not_running"}
+
+        logger.error(
+            "MCP manager answered %s for instance %s: %s",
+            response.status_code,
+            instance.id,
+            response.text[:200],
+        )
+        return {**row, "healthy": False, "status": "error"}
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        rows = await asyncio.gather(*(read_one(client, instance) for instance in instances))
+
+    return {
+        "instances": list(rows),
+        "total": len(rows),
+        "healthy": sum(1 for row in rows if row["healthy"]),
+    }
 
 
 @router.post("/{instance_id}/probe")

--- a/agentarea-platform/apps/api/tests/test_mcp_containers_health.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_containers_health.py
@@ -1,0 +1,167 @@
+"""The MCP container-health endpoint must only speak about its own workspace.
+
+The manager exposes a route that answers for every workload on the host, and
+proxying it straight through would have handed one workspace the service names and
+container ids of another. These tests pin the two properties that keep that from
+happening again: the endpoint asks only about ids the workspace-scoped service
+returned, and an unhealthy or unknown workload is reported rather than turned into
+a failure of the whole request.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from uuid import uuid4
+
+import httpx
+import pytest
+from agentarea_api.api.v1 import mcp_server_instances as module
+
+
+class _Response:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no body")
+        return self._payload
+
+
+class _Client:
+    """Records every URL asked about and answers from a fixed table."""
+
+    def __init__(self, answers, asked):
+        self._answers = answers
+        self._asked = asked
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        self._asked.append(url)
+        answer = self._answers.get(url)
+        if answer is None:
+            return _Response(404, text="unknown instance")
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+def _service(instances):
+    async def _list():
+        return instances
+
+    return SimpleNamespace(list=_list)
+
+
+def _context():
+    return SimpleNamespace(user_id="u", workspace_id="w")
+
+
+def _health_url(instance_id):
+    return f"http://manager/instances/{instance_id}/health"
+
+
+def _install(monkeypatch, answers, asked):
+    monkeypatch.setattr(
+        module,
+        "get_settings",
+        lambda: SimpleNamespace(mcp=SimpleNamespace(MCP_MANAGER_URL="http://manager")),
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: _Client(answers, asked))
+
+
+def test_only_workspace_instances_are_asked_about(monkeypatch):
+    mine, theirs = uuid4(), uuid4()
+    asked = []
+    answers = {_health_url(mine): _Response(200, {"healthy": True, "status": "running"})}
+    _install(monkeypatch, answers, asked)
+
+    result = asyncio.run(
+        module.get_containers_health(
+            user_context=_context(),
+            service=_service([SimpleNamespace(id=mine, name="mine")]),
+        )
+    )
+
+    assert asked == [_health_url(mine)]
+    assert str(theirs) not in str(result)
+    assert result["total"] == 1
+    assert result["healthy"] == 1
+    assert result["instances"][0]["instance_id"] == str(mine)
+
+
+def test_unhealthy_workload_is_reported_not_raised(monkeypatch):
+    iid = uuid4()
+    asked = []
+    answers = {_health_url(iid): _Response(503, {"healthy": False, "status": "exited"})}
+    _install(monkeypatch, answers, asked)
+
+    result = asyncio.run(
+        module.get_containers_health(
+            user_context=_context(),
+            service=_service([SimpleNamespace(id=iid, name="sick")]),
+        )
+    )
+
+    row = result["instances"][0]
+    assert row["healthy"] is False
+    assert row["status"] == "exited"
+    assert result["healthy"] == 0
+    assert result["total"] == 1
+
+
+def test_unknown_and_unreachable_are_distinguished(monkeypatch):
+    known, gone = uuid4(), uuid4()
+    asked = []
+    answers = {_health_url(known): httpx.RequestError("connection refused")}
+    _install(monkeypatch, answers, asked)
+
+    result = asyncio.run(
+        module.get_containers_health(
+            user_context=_context(),
+            service=_service(
+                [SimpleNamespace(id=known, name="a"), SimpleNamespace(id=gone, name="b")]
+            ),
+        )
+    )
+
+    by_id = {row["instance_id"]: row["status"] for row in result["instances"]}
+    assert by_id[str(known)] == "manager_unreachable"
+    assert by_id[str(gone)] == "not_running"
+    assert result["healthy"] == 0
+    assert result["total"] == 2
+
+
+def test_no_instances_is_an_empty_report(monkeypatch):
+    asked = []
+    _install(monkeypatch, {}, asked)
+
+    result = asyncio.run(
+        module.get_containers_health(user_context=_context(), service=_service([]))
+    )
+
+    assert result == {"instances": [], "total": 0, "healthy": 0}
+    assert asked == []
+
+
+@pytest.mark.parametrize("status", [500, 502])
+def test_manager_error_status_becomes_a_per_instance_error(monkeypatch, status):
+    iid = uuid4()
+    asked = []
+    answers = {_health_url(iid): _Response(status, text="boom")}
+    _install(monkeypatch, answers, asked)
+
+    result = asyncio.run(
+        module.get_containers_health(
+            user_context=_context(),
+            service=_service([SimpleNamespace(id=iid, name="x")]),
+        )
+    )
+
+    assert result["instances"][0]["status"] == "error"

--- a/agentarea-webapp/packages/api-client/src/generated/sdk.gen.ts
+++ b/agentarea-webapp/packages/api-client/src/generated/sdk.gen.ts
@@ -1718,7 +1718,17 @@ export const checkMcpServerInstanceConfigurationV1McpServerInstancesCheckPost = 
 /**
  * Get Containers Health
  *
- * Get health status of all MCP containers by proxying to the Go manager.
+ * Health of this workspace's MCP workloads.
+ *
+ * The manager also has a route that answers for every workload it runs, which is
+ * the wrong thing to hand a caller: its rows carry service names and container
+ * ids belonging to other workspaces. The instance list comes from the
+ * workspace-scoped service instead, and only those ids are asked about, so the
+ * answer cannot name a workload the caller is not entitled to see.
+ *
+ * A workload the manager reports as unhealthy, has never heard of, or cannot be
+ * reached about is a fact about that instance, not a failure of the request: each
+ * is reported per instance and the endpoint still answers 200.
  */
 export const getContainersHealthV1McpServerInstancesHealthContainersGet = <ThrowOnError extends boolean = false>(options?: Options<GetContainersHealthV1McpServerInstancesHealthContainersGetData, ThrowOnError>): RequestResult<GetContainersHealthV1McpServerInstancesHealthContainersGetResponses, unknown, ThrowOnError> => (options?.client ?? client).get<GetContainersHealthV1McpServerInstancesHealthContainersGetResponses, unknown, ThrowOnError>({
     security: [{

--- a/agentarea-webapp/packages/api-client/types/generated/sdk.gen.d.ts
+++ b/agentarea-webapp/packages/api-client/types/generated/sdk.gen.d.ts
@@ -693,7 +693,17 @@ export declare const checkMcpServerInstanceConfigurationV1McpServerInstancesChec
 /**
  * Get Containers Health
  *
- * Get health status of all MCP containers by proxying to the Go manager.
+ * Health of this workspace's MCP workloads.
+ *
+ * The manager also has a route that answers for every workload it runs, which is
+ * the wrong thing to hand a caller: its rows carry service names and container
+ * ids belonging to other workspaces. The instance list comes from the
+ * workspace-scoped service instead, and only those ids are asked about, so the
+ * answer cannot name a workload the caller is not entitled to see.
+ *
+ * A workload the manager reports as unhealthy, has never heard of, or cannot be
+ * reached about is a fact about that instance, not a failure of the request: each
+ * is reported per instance and the endpoint still answers 200.
  */
 export declare const getContainersHealthV1McpServerInstancesHealthContainersGet: <ThrowOnError extends boolean = false>(options?: Options<GetContainersHealthV1McpServerInstancesHealthContainersGetData, ThrowOnError>) => RequestResult<GetContainersHealthV1McpServerInstancesHealthContainersGetResponses, unknown, ThrowOnError>;
 /**

--- a/agentarea-webapp/src/api/client/sdk.gen.ts
+++ b/agentarea-webapp/src/api/client/sdk.gen.ts
@@ -1611,7 +1611,7 @@ export const getAgentWellKnownIndexV1AgentsAgentIdWellKnownGet = <
   >({
     security: [
       {
-        key: "HTTPBearer",
+        key: "bearer",
         scheme: "bearer",
         type: "http",
       },
@@ -1646,7 +1646,7 @@ export const getAgentA2aInfoV1AgentsAgentIdWellKnownA2aInfoJsonGet = <
   >({
     security: [
       {
-        key: "HTTPBearer",
+        key: "bearer",
         scheme: "bearer",
         type: "http",
       },
@@ -1686,7 +1686,7 @@ export const getAgentWellKnownCardV1AgentsAgentIdWellKnownAgentCardJsonGet = <
   >({
     security: [
       {
-        key: "HTTPBearer",
+        key: "bearer",
         scheme: "bearer",
         type: "http",
       },

--- a/agentarea-webapp/src/api/client/sdk.gen.ts
+++ b/agentarea-webapp/src/api/client/sdk.gen.ts
@@ -4040,7 +4040,17 @@ export const checkMcpServerInstanceConfigurationV1McpServerInstancesCheckPost =
 /**
  * Get Containers Health
  *
- * Get health status of all MCP containers by proxying to the Go manager.
+ * Health of this workspace's MCP workloads.
+ *
+ * The manager also has a route that answers for every workload it runs, which is
+ * the wrong thing to hand a caller: its rows carry service names and container
+ * ids belonging to other workspaces. The instance list comes from the
+ * workspace-scoped service instead, and only those ids are asked about, so the
+ * answer cannot name a workload the caller is not entitled to see.
+ *
+ * A workload the manager reports as unhealthy, has never heard of, or cannot be
+ * reached about is a fact about that instance, not a failure of the request: each
+ * is reported per instance and the endpoint still answers 200.
  */
 export const getContainersHealthV1McpServerInstancesHealthContainersGet = <
   ThrowOnError extends boolean = false,

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -13026,15 +13026,13 @@
         },
         "security": [
           {
-            "HTTPBearer": []
+            "bearer": []
           }
         ],
         "summary": "Get Agent Well Known Index",
         "tags": [
           "v1",
-          "protected",
-          "agents",
-          "agents-well-known"
+          "public"
         ]
       }
     },
@@ -13080,15 +13078,13 @@
         },
         "security": [
           {
-            "HTTPBearer": []
+            "bearer": []
           }
         ],
         "summary": "Get Agent A2A Info",
         "tags": [
           "v1",
-          "protected",
-          "agents",
-          "agents-well-known"
+          "public"
         ]
       }
     },
@@ -13132,15 +13128,13 @@
         },
         "security": [
           {
-            "HTTPBearer": []
+            "bearer": []
           }
         ],
         "summary": "Get Agent Well Known Card",
         "tags": [
           "v1",
-          "protected",
-          "agents",
-          "agents-well-known"
+          "public"
         ]
       }
     },

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -17324,7 +17324,7 @@
     },
     "/v1/mcp-server-instances/health/containers": {
       "get": {
-        "description": "Get health status of all MCP containers by proxying to the Go manager.",
+        "description": "Health of this workspace's MCP workloads.\n\nThe manager also has a route that answers for every workload it runs, which is\nthe wrong thing to hand a caller: its rows carry service names and container\nids belonging to other workspaces. The instance list comes from the\nworkspace-scoped service instead, and only those ids are asked about, so the\nanswer cannot name a workload the caller is not entitled to see.\n\nA workload the manager reports as unhealthy, has never heard of, or cannot be\nreached about is a fact about that instance, not a failure of the request: each\nis reported per instance and the endpoint still answers 200.",
         "operationId": "get_containers_health_v1_mcp_server_instances_health_containers_get",
         "responses": {
           "200": {

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -13026,15 +13026,13 @@
         },
         "security": [
           {
-            "HTTPBearer": []
+            "bearer": []
           }
         ],
         "summary": "Get Agent Well Known Index",
         "tags": [
           "v1",
-          "protected",
-          "agents",
-          "agents-well-known"
+          "public"
         ]
       }
     },
@@ -13080,15 +13078,13 @@
         },
         "security": [
           {
-            "HTTPBearer": []
+            "bearer": []
           }
         ],
         "summary": "Get Agent A2A Info",
         "tags": [
           "v1",
-          "protected",
-          "agents",
-          "agents-well-known"
+          "public"
         ]
       }
     },
@@ -13132,15 +13128,13 @@
         },
         "security": [
           {
-            "HTTPBearer": []
+            "bearer": []
           }
         ],
         "summary": "Get Agent Well Known Card",
         "tags": [
           "v1",
-          "protected",
-          "agents",
-          "agents-well-known"
+          "public"
         ]
       }
     },

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -17324,7 +17324,7 @@
     },
     "/v1/mcp-server-instances/health/containers": {
       "get": {
-        "description": "Get health status of all MCP containers by proxying to the Go manager.",
+        "description": "Health of this workspace's MCP workloads.\n\nThe manager also has a route that answers for every workload it runs, which is\nthe wrong thing to hand a caller: its rows carry service names and container\nids belonging to other workspaces. The instance list comes from the\nworkspace-scoped service instead, and only those ids are asked about, so the\nanswer cannot name a workload the caller is not entitled to see.\n\nA workload the manager reports as unhealthy, has never heard of, or cannot be\nreached about is a fact about that instance, not a failure of the request: each\nis reported per instance and the endpoint still answers 200.",
         "operationId": "get_containers_health_v1_mcp_server_instances_health_containers_get",
         "responses": {
           "200": {


### PR DESCRIPTION
Found by knocking on production over the API: `GET /v1/mcp-server-instances/health/containers` answered **500 for every caller**.

Two causes, one on top of the other:

1. It proxied `{MCP_MANAGER_URL}/containers/health`, a route the Go manager has never served — the manager exposes `/instances/health` and `/instances/{id}/health`. The upstream answered 404.
2. The route wrapped its own `raise HTTPException(...)` in a blanket `except Exception`, so that 404 was re-raised as `500 Internal server error` with `response.text` discarded. Nothing reached the log except the generic message, which is why the endpoint looked like an unexplained crash.

The straightforward repair — point at `/instances/health` — would have been worse than the bug: that route runs a global `ListInstances()` with no workspace filter and returns `service_name` and `container_id` for every workload on the host, so one workspace would receive another workspace's runtime identifiers. The endpoint now takes its instance list from the workspace-scoped `MCPServerInstanceService` and asks the manager only about those ids, so the answer cannot name a workload the caller is not entitled to see.

A workload that is unhealthy, was never started, or cannot be reached about is a fact about that instance rather than a failure of the request: each is reported per instance (`unhealthy` / `not_running` / `manager_unreachable` / `error`) and the endpoint still answers 200 with a count. Genuine upstream failures are logged with the status and body an operator needs.

Tests pin the workspace scoping (only the returned ids are asked about) and every status mapping; each was checked against a deliberately broken implementation to confirm it fails without the fix.

Verification: `pytest apps/api/tests/test_mcp_containers_health.py apps/api/tests/test_mcp_instance_consumers.py` — 11 passed; `ruff check` and `ruff format --check` clean on both touched files.