### PR TITLE
feat(webapp): wire the workspace switcher to real workspaces

### DIFF
--- a/agentarea-webapp/src/api/client-runtime.ts
+++ b/agentarea-webapp/src/api/client-runtime.ts
@@ -2,12 +2,22 @@ import type { CreateClientConfig } from "./client/client";
 import { env } from "@/env";
 import { getAuthToken } from "@/lib/getAuthToken";
 import { SERVER_API_TIMEOUT_MS } from "@/lib/server-timeouts";
+import { WORKSPACE_SLUG_HEADER } from "@/lib/workspaces";
 
 async function addWorkspaceSlug(request: Request) {
   try {
+    // Imported lazily: this module is also pulled into the browser bundle via
+    // the generated client, and next/headers cannot be statically imported
+    // there.
     const { headers } = await import("next/headers");
+    const { getActiveWorkspaceSlug } = await import("@/lib/workspace-context");
     const requestHeaders = await headers();
-    const workspaceSlug = requestHeaders.get("x-workspace-slug");
+    // An explicit header wins so a caller can pin one request to a workspace;
+    // otherwise the switcher decides, via a slug validated against the user's
+    // memberships rather than read straight off the cookie.
+    const workspaceSlug =
+      requestHeaders.get(WORKSPACE_SLUG_HEADER) ??
+      (await getActiveWorkspaceSlug());
     if (workspaceSlug) {
       request.headers.set("X-Workspace-Slug", workspaceSlug);
     }

--- a/agentarea-webapp/src/app/api/agents/[agentId]/tasks/create/route.ts
+++ b/agentarea-webapp/src/app/api/agents/[agentId]/tasks/create/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { env } from "@/env";
 import { getAuthToken } from "@/lib/getAuthToken";
+import { resolveRequestWorkspaceSlug } from "@/lib/workspace-request";
 
 export async function POST(
   request: NextRequest,
@@ -22,12 +23,7 @@ export async function POST(
       backendHeaders["Authorization"] = `Bearer ${token}`;
     }
 
-    let workspaceSlug = request.headers.get("x-workspace-slug");
-    if (!workspaceSlug) {
-      const referer = request.headers.get("referer");
-      const match = referer?.match(/\/w\/([^/?#]+)/);
-      if (match) workspaceSlug = decodeURIComponent(match[1]);
-    }
+    const workspaceSlug = await resolveRequestWorkspaceSlug(request);
     if (workspaceSlug) {
       backendHeaders["X-Workspace-Slug"] = workspaceSlug;
     }

--- a/agentarea-webapp/src/app/api/files/upload-url/route.ts
+++ b/agentarea-webapp/src/app/api/files/upload-url/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { env } from "@/env";
 import { getAuthToken } from "@/lib/getAuthToken";
+import { resolveRequestWorkspaceSlug } from "@/lib/workspace-request";
 
 // Mint a presigned PUT for a task attachment. The client uploads the file
 // bytes directly to the object store with the returned `upload_url`, then
@@ -16,12 +17,7 @@ export async function POST(request: NextRequest) {
       backendHeaders["Authorization"] = `Bearer ${token}`;
     }
 
-    let workspaceSlug = request.headers.get("x-workspace-slug");
-    if (!workspaceSlug) {
-      const referer = request.headers.get("referer");
-      const match = referer?.match(/\/w\/([^/?#]+)/);
-      if (match) workspaceSlug = decodeURIComponent(match[1]);
-    }
+    const workspaceSlug = await resolveRequestWorkspaceSlug(request);
     if (workspaceSlug) {
       backendHeaders["X-Workspace-Slug"] = workspaceSlug;
     }

--- a/agentarea-webapp/src/app/api/proxy/[...path]/route.ts
+++ b/agentarea-webapp/src/app/api/proxy/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { getAuthToken } from "@/lib/getAuthToken";
+import { resolveRequestWorkspaceSlug } from "@/lib/workspace-request";
 
 /**
  * API Proxy Route Handler
@@ -43,18 +44,7 @@ async function handleRequest(
       headers.set("Authorization", `Bearer ${authToken}`);
     }
 
-    // Forward the active workspace. The proxy middleware does not run on /api
-    // routes, so the slug isn't injected as a header here — derive it from the
-    // caller's page URL (Referer = /w/{slug}/...), or honor an explicit header
-    // if a client sent one. Transport only; the backend authorizes membership.
-    let workspaceSlug = request.headers.get("x-workspace-slug");
-    if (!workspaceSlug) {
-      const referer = request.headers.get("referer");
-      const match = referer?.match(/\/w\/([^/?#]+)/);
-      if (match) {
-        workspaceSlug = decodeURIComponent(match[1]);
-      }
-    }
+    const workspaceSlug = await resolveRequestWorkspaceSlug(request);
     if (workspaceSlug) {
       headers.set("X-Workspace-Slug", workspaceSlug);
     }

--- a/agentarea-webapp/src/app/layout.tsx
+++ b/agentarea-webapp/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import ConditionalLayout from "@/components/ConditionalLayout";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { getWorkspaceContext } from "@/lib/workspace-context";
 
 const sharedMetadata: Omit<Metadata, "metadataBase"> = {
   title: {
@@ -105,6 +106,11 @@ export default async function RootLayout({
     sidebarCookie !== undefined ? sidebarCookie === "true" : true;
   const session = await getServerSession();
   const runtimeConfig = getRuntimeConfig();
+  // Anonymous visitors (landing, auth) have no workspaces to switch between,
+  // and listing them would provision a personal workspace for nobody.
+  const { workspaces, active } = session
+    ? await getWorkspaceContext()
+    : { workspaces: [], active: null };
 
   return (
     <html lang={locale} suppressHydrationWarning className={inter.variable}>
@@ -120,7 +126,11 @@ export default async function RootLayout({
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <NextIntlClientProvider>
               <NuqsAdapter>
-                <ConditionalLayout sidebarDefaultOpen={sidebarDefaultOpen}>
+                <ConditionalLayout
+                  sidebarDefaultOpen={sidebarDefaultOpen}
+                  workspaces={workspaces}
+                  activeWorkspaceSlug={active?.slug ?? null}
+                >
                   {children}
                 </ConditionalLayout>
               </NuqsAdapter>

--- a/agentarea-webapp/src/components/ConditionalLayout.tsx
+++ b/agentarea-webapp/src/components/ConditionalLayout.tsx
@@ -9,10 +9,13 @@ import { SettingsSidebarContent } from "@/components/SettingsLayout/SettingsSide
 import { Sidebar, SidebarProvider, SidebarRail } from "@/components/ui/sidebar";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { navData } from "@/lib/nav-data";
+import type { Workspace } from "@/lib/workspaces";
 
 interface ConditionalLayoutProps {
   children: React.ReactNode;
   sidebarDefaultOpen?: boolean;
+  workspaces: Workspace[];
+  activeWorkspaceSlug: string | null;
 }
 
 // Routes that render their own full-page chrome (landing, auth, error) and
@@ -24,6 +27,8 @@ const SETTINGS_ROUTES = ["/settings", "/admin/api-keys", "/admin/workspace"];
 export default function ConditionalLayout({
   children,
   sidebarDefaultOpen,
+  workspaces,
+  activeWorkspaceSlug,
 }: ConditionalLayoutProps) {
   const pathname = usePathname();
 
@@ -67,7 +72,11 @@ export default function ConditionalLayout({
                 {isSettings ? (
                   <SettingsSidebarContent />
                 ) : (
-                  <AppSidebarContent data={navData} />
+                  <AppSidebarContent
+                    data={navData}
+                    workspaces={workspaces}
+                    activeWorkspaceSlug={activeWorkspaceSlug}
+                  />
                 )}
               </motion.div>
             </AnimatePresence>

--- a/agentarea-webapp/src/components/MainLayout/components/AppSidebar.tsx
+++ b/agentarea-webapp/src/components/MainLayout/components/AppSidebar.tsx
@@ -16,6 +16,7 @@ import {
 import { QUICK_TASK_OPEN_EVENT } from "@/components/QuickTask/QuickTaskDialog";
 import { APP_VERSION } from "@/lib/app-version";
 import { cn } from "@/lib/utils";
+import type { Workspace } from "@/lib/workspaces";
 import { NavMain } from "./NavMain";
 import { NavUser } from "./NavUser";
 import { SidebarNavScroll } from "./SidebarNavScroll";
@@ -56,11 +57,18 @@ function SocialLinks({ iconClass }: { iconClass: string }) {
 }
 
 interface AppSidebarData {
-  workspaces: React.ComponentProps<typeof TeamSwitcher>["teams"];
   navSections: React.ComponentProps<typeof NavMain>["sections"];
 }
 
-export function AppSidebarContent({ data }: { data: AppSidebarData }) {
+export function AppSidebarContent({
+  data,
+  workspaces,
+  activeWorkspaceSlug,
+}: {
+  data: AppSidebarData;
+  workspaces: Workspace[];
+  activeWorkspaceSlug: string | null;
+}) {
   const { open } = useSidebar();
 
   const openQuickTask = React.useCallback(() => {
@@ -71,7 +79,10 @@ export function AppSidebarContent({ data }: { data: AppSidebarData }) {
   return (
     <>
       <SidebarHeader>
-        <TeamSwitcher teams={data.workspaces} />
+        <TeamSwitcher
+          workspaces={workspaces}
+          activeSlug={activeWorkspaceSlug}
+        />
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/agentarea-webapp/src/components/MainLayout/components/TeamSwitcher.tsx
+++ b/agentarea-webapp/src/components/MainLayout/components/TeamSwitcher.tsx
@@ -1,15 +1,22 @@
 "use client";
 
 import * as React from "react";
-import Image from "next/image";
-import { ChevronsUpDown, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Building2, Check, ChevronsUpDown, Plus, User } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -18,98 +25,189 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  createWorkspaceAction,
+  switchWorkspaceAction,
+} from "@/lib/workspace-actions";
+import type { Workspace } from "@/lib/workspaces";
+
+function WorkspaceIcon({
+  type,
+  className,
+}: {
+  type: string;
+  className?: string;
+}) {
+  const Icon = type === "personal" ? User : Building2;
+  return <Icon className={className} />;
+}
+
+function workspaceKind(type: string): string {
+  return type === "personal" ? "Personal" : "Organization";
+}
 
 export function TeamSwitcher({
-  teams,
+  workspaces,
+  activeSlug,
 }: {
-  teams: {
-    name: string;
-    logo: React.ElementType;
-    plan: string;
-    logoFile?: string;
-  }[];
+  workspaces: Workspace[];
+  activeSlug: string | null;
 }) {
   const { isMobile } = useSidebar();
-  const [activeTeam, setActiveTeam] = React.useState(teams[0]);
+  const router = useRouter();
+  const [isPending, startTransition] = React.useTransition();
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [name, setName] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
 
-  if (!activeTeam) {
+  const active =
+    workspaces.find((workspace) => workspace.slug === activeSlug) ?? null;
+
+  const switchTo = (slug: string) => {
+    if (slug === activeSlug) return;
+    startTransition(async () => {
+      const result = await switchWorkspaceAction(slug);
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  const create = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await createWorkspaceAction(name);
+      if (result.error) {
+        setError(result.error);
+        return;
+      }
+      setName("");
+      setCreateOpen(false);
+      router.refresh();
+    });
+  };
+
+  // Before the first /v1/workspaces response there is nothing to switch
+  // between; rendering a nameless button would just flash empty chrome.
+  if (!active) {
     return null;
   }
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton
-              size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground transition-all duration-200 hover:bg-zinc-100 dark:hover:bg-zinc-800"
-            >
-              <div className="flex aspect-square size-8 items-center justify-center bg-transparent text-sidebar-primary-foreground">
-                {activeTeam.logoFile ? (
-                  <Image
-                    src={activeTeam.logoFile}
-                    alt={activeTeam.name}
-                    width={32}
-                    height={32}
-                    className=""
-                  />
-                ) : (
-                  <activeTeam.logo className="size-4 text-zinc-900 dark:text-zinc-100" />
-                )}
-              </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
-                  {activeTeam.name}
-                </span>
-                <span className="truncate text-[10px] font-medium text-zinc-500 uppercase tracking-wider">
-                  {activeTeam.plan}
-                </span>
-              </div>
-              <ChevronsUpDown className="ml-auto text-zinc-400" />
-            </SidebarMenuButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
-            align="start"
-            side={isMobile ? "bottom" : "right"}
-            sideOffset={4}
-          >
-            <DropdownMenuLabel className="text-xs text-muted-foreground">
-              Workspaces
-            </DropdownMenuLabel>
-            {teams.map((team, index) => (
-              <DropdownMenuItem
-                key={team.name}
-                onClick={() => setActiveTeam(team)}
-                className="gap-2 p-2"
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <SidebarMenuButton
+                size="lg"
+                className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground transition-all duration-200 hover:bg-zinc-100 dark:hover:bg-zinc-800"
               >
-                <div className="flex size-6 items-center justify-center rounded-md border">
-                  {team.logoFile ? (
-                    <Image
-                      src={team.logoFile}
-                      alt={team.name}
-                      width={32}
-                      height={32}
-                    />
-                  ) : (
-                    <team.logo className="size-3.5 shrink-0" />
-                  )}
+                <div className="flex aspect-square size-8 items-center justify-center rounded-md border border-border/60 bg-transparent">
+                  <WorkspaceIcon
+                    type={active.type}
+                    className="size-4 text-zinc-900 dark:text-zinc-100"
+                  />
                 </div>
-                {team.name}
-                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+                    {active.name}
+                  </span>
+                  <span className="truncate text-[10px] font-medium text-zinc-500 uppercase tracking-wider">
+                    {workspaceKind(active.type)}
+                  </span>
+                </div>
+                <ChevronsUpDown className="ml-auto text-zinc-400" />
+              </SidebarMenuButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+              align="start"
+              side={isMobile ? "bottom" : "right"}
+              sideOffset={4}
+            >
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Workspaces
+              </DropdownMenuLabel>
+              {workspaces.map((workspace) => (
+                <DropdownMenuItem
+                  key={workspace.id}
+                  onClick={() => switchTo(workspace.slug)}
+                  disabled={isPending}
+                  className="gap-2 p-2 cursor-pointer"
+                >
+                  <div className="flex size-6 items-center justify-center rounded-md border">
+                    <WorkspaceIcon type={workspace.type} className="size-3.5" />
+                  </div>
+                  <span className="flex-1 truncate">{workspace.name}</span>
+                  {workspace.slug === activeSlug && (
+                    <Check className="size-4 text-muted-foreground" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => {
+                  setError(null);
+                  setCreateOpen(true);
+                }}
+                className="gap-2 p-2 cursor-pointer"
+              >
+                <div className="flex size-6 items-center justify-center rounded-md border bg-primary/10">
+                  <Plus className="size-4 text-primary" />
+                </div>
+                <span className="text-sm font-medium">Add workspace</span>
               </DropdownMenuItem>
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className="gap-2 p-2 cursor-pointer">
-              <div className="flex size-6 items-center justify-center rounded-md border bg-primary/10">
-                <Plus className="size-4 text-primary" />
-              </div>
-              <span className="text-sm font-medium">Add Workspace</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarMenuItem>
-    </SidebarMenu>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SidebarMenuItem>
+      </SidebarMenu>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New workspace</DialogTitle>
+            <DialogDescription>
+              A workspace is an isolation boundary: its own members, budgets,
+              policies and provider credentials. You can invite people into it
+              from the Members page.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="workspace-name">Name</Label>
+            <Input
+              id="workspace-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && name.trim() && !isPending) {
+                  create();
+                }
+              }}
+              placeholder="Acme Inc"
+              autoFocus
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setCreateOpen(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={create} disabled={isPending || !name.trim()}>
+              {isPending ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/agentarea-webapp/src/lib/api.ts
+++ b/agentarea-webapp/src/lib/api.ts
@@ -1436,6 +1436,16 @@ export const importWorkspace = async (body: {
   return { data, error };
 };
 
+// Listing workspaces deliberately lives outside this client — see
+// getWorkspaceContext(), which must not send X-Workspace-Slug.
+export const createWorkspace = async (name: string) => {
+  const { data, error } = await sdk.createWorkspaceV1WorkspacesPost({
+    client: serverClient,
+    body: { name },
+  });
+  return { data, error };
+};
+
 export const listWorkspaceMembers = async (workspaceId: string) => {
   const { data, error } =
     await sdk.listMembersV1WorkspacesWorkspaceIdMembersGet({

--- a/agentarea-webapp/src/lib/getAuthContext.ts
+++ b/agentarea-webapp/src/lib/getAuthContext.ts
@@ -2,6 +2,7 @@
 
 import { cache } from "react";
 import { getAuthToken } from "./getAuthToken";
+import { getWorkspaceContext } from "./workspace-context";
 
 export interface AuthContext {
   userId: string | null;
@@ -62,9 +63,15 @@ async function getAuthContextImpl(): Promise<AuthContext> {
   const email = getStringClaim(payload, "email");
   const name = getNameClaim(payload);
   const username = getStringClaim(payload, "username");
-  // The backend falls back to user_id when the token has no workspace_id claim
-  // (each user gets their own personal workspace by default).
-  const workspaceId = (payload?.workspace_id as string) ?? userId;
+  // The token's workspace claim only names the default workspace, so it goes
+  // stale the moment the switcher points elsewhere. Callers pass workspaceId
+  // into path-scoped endpoints (members, invitations), which would then read
+  // the wrong workspace — resolve the active one instead, and fall back to the
+  // claim when the list is unavailable. The backend falls back to user_id when
+  // the token carries no claim at all (every user has a personal workspace).
+  const { active } = await getWorkspaceContext();
+  const workspaceId =
+    active?.id ?? (payload?.workspace_id as string) ?? userId;
 
   return { userId, workspaceId, email, name, username };
 }

--- a/agentarea-webapp/src/lib/nav-data.ts
+++ b/agentarea-webapp/src/lib/nav-data.ts
@@ -35,14 +35,6 @@ export type NavSection = {
 };
 
 export const navData = {
-  workspaces: [
-    {
-      name: "AgentArea",
-      logo: GalleryVerticalEnd,
-      plan: "Base workspace",
-      logoFile: "/Icon.svg",
-    },
-  ],
   navSections: [
     {
       label: "Work",

--- a/agentarea-webapp/src/lib/workspace-actions.ts
+++ b/agentarea-webapp/src/lib/workspace-actions.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { createWorkspace } from "@/lib/api";
+import { getWorkspaceContext } from "@/lib/workspace-context";
+import { WORKSPACE_SLUG_COOKIE } from "@/lib/workspaces";
+
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+async function setActiveSlug(slug: string) {
+  const cookieStore = await cookies();
+  cookieStore.set(WORKSPACE_SLUG_COOKIE, slug, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: ONE_YEAR_SECONDS,
+  });
+  // Every page's data is workspace-scoped, so switching invalidates the whole
+  // cached tree, not one route.
+  revalidatePath("/", "layout");
+}
+
+export async function switchWorkspaceAction(slug: string) {
+  // Never persist a slug the backend would reject: the cookie is sent with
+  // every subsequent request, so a bad one breaks the whole session.
+  const { workspaces } = await getWorkspaceContext();
+  if (!workspaces.some((workspace) => workspace.slug === slug)) {
+    return { error: "You are not a member of that workspace" };
+  }
+
+  await setActiveSlug(slug);
+  return { ok: true };
+}
+
+export async function createWorkspaceAction(name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) return { error: "Workspace name must not be empty" };
+
+  const { data, error } = await createWorkspace(trimmed);
+  if (error || !data) {
+    const detail = (error as { detail?: unknown })?.detail;
+    return {
+      error: typeof detail === "string" ? detail : "Failed to create workspace",
+    };
+  }
+
+  await setActiveSlug(data.slug);
+  return { data };
+}

--- a/agentarea-webapp/src/lib/workspace-context.ts
+++ b/agentarea-webapp/src/lib/workspace-context.ts
@@ -1,0 +1,78 @@
+import { cache } from "react";
+import { env } from "@/env";
+import { SERVER_API_TIMEOUT_MS } from "@/lib/server-timeouts";
+import {
+  resolveActiveWorkspace,
+  WORKSPACE_SLUG_COOKIE,
+  type Workspace,
+} from "@/lib/workspaces";
+
+// next/headers and the session helper are imported lazily. The generated API
+// client pulls this module's caller into the browser bundle, and Turbopack
+// traces static server-only imports through it even when they are unreachable
+// at runtime.
+const serverCookies = async () => (await import("next/headers")).cookies();
+const serverAuthToken = async () =>
+  (await import("@/lib/getAuthToken")).getAuthToken();
+
+export interface WorkspaceContext {
+  workspaces: Workspace[];
+  active: Workspace | null;
+}
+
+const EMPTY: WorkspaceContext = { workspaces: [], active: null };
+
+/**
+ * Fetch the caller's workspaces without going through the generated client.
+ *
+ * The client wrapper stamps X-Workspace-Slug on every request, and the backend
+ * 403s a slug the caller is not a member of — including on this endpoint. A
+ * cookie left over from a workspace the user was removed from would therefore
+ * break the one call needed to recover from it. Listing is user-scoped anyway,
+ * so it deliberately carries no workspace header.
+ */
+async function fetchWorkspaces(): Promise<Workspace[]> {
+  const token = await serverAuthToken();
+  if (!token) return [];
+
+  const response = await fetch(`${env.API_URL}/v1/workspaces`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(SERVER_API_TIMEOUT_MS),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`GET /v1/workspaces responded ${response.status}`);
+  }
+  return (await response.json()) as Workspace[];
+}
+
+async function getWorkspaceContextImpl(): Promise<WorkspaceContext> {
+  try {
+    const cookieStore = await serverCookies();
+    const workspaces = await fetchWorkspaces();
+    return {
+      workspaces,
+      active: resolveActiveWorkspace(
+        workspaces,
+        cookieStore.get(WORKSPACE_SLUG_COOKIE)?.value
+      ),
+    };
+  } catch (error) {
+    // The switcher is chrome, not content: an API outage must not take the
+    // whole app shell down with it.
+    console.error("[workspace-context] failed to list workspaces:", error);
+    return EMPTY;
+  }
+}
+
+export const getWorkspaceContext = cache(getWorkspaceContextImpl);
+
+/**
+ * The slug every outgoing request should be scoped to, or null for the
+ * backend's own default. Resolved rather than read straight from the cookie so
+ * a stale value degrades to the personal workspace instead of 403-ing the app.
+ */
+export async function getActiveWorkspaceSlug(): Promise<string | null> {
+  const { active } = await getWorkspaceContext();
+  return active?.slug ?? null;
+}

--- a/agentarea-webapp/src/lib/workspace-request.ts
+++ b/agentarea-webapp/src/lib/workspace-request.ts
@@ -1,0 +1,15 @@
+import { getActiveWorkspaceSlug } from "@/lib/workspace-context";
+import { WORKSPACE_SLUG_HEADER } from "@/lib/workspaces";
+
+/**
+ * Resolve the active workspace for a route handler.
+ *
+ * Route handlers are not covered by the generated client's fetch wrapper, so
+ * they forward the slug themselves. An explicit header wins; otherwise the
+ * switcher decides. Transport only — the backend authorizes membership.
+ */
+export async function resolveRequestWorkspaceSlug(
+  request: Request
+): Promise<string | null> {
+  return request.headers.get(WORKSPACE_SLUG_HEADER) ?? getActiveWorkspaceSlug();
+}

--- a/agentarea-webapp/src/lib/workspaces.test.ts
+++ b/agentarea-webapp/src/lib/workspaces.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { resolveActiveWorkspace, type Workspace } from "./workspaces";
+
+const personal: Workspace = {
+  id: "user-1",
+  slug: "user-1",
+  name: "Personal",
+  type: "personal",
+};
+const acme: Workspace = {
+  id: "ws-acme",
+  slug: "acme",
+  name: "Acme",
+  type: "shared",
+};
+const globex: Workspace = {
+  id: "ws-globex",
+  slug: "globex",
+  name: "Globex",
+  type: "shared",
+};
+
+describe("resolveActiveWorkspace", () => {
+  it("returns the workspace matching the preferred slug", () => {
+    expect(resolveActiveWorkspace([personal, acme, globex], "globex")).toBe(
+      globex
+    );
+  });
+
+  it("falls back to the personal workspace when the slug is unknown", () => {
+    // A stale cookie must not win: the backend 403s every request made with a
+    // slug the user is no longer a member of.
+    expect(resolveActiveWorkspace([personal, acme], "left-this-one")).toBe(
+      personal
+    );
+  });
+
+  it("falls back to the personal workspace when no slug is set", () => {
+    expect(resolveActiveWorkspace([acme, personal], null)).toBe(personal);
+  });
+
+  it("falls back to the first workspace when there is no personal one", () => {
+    expect(resolveActiveWorkspace([acme, globex], undefined)).toBe(acme);
+  });
+
+  it("returns null when the user has no workspaces", () => {
+    expect(resolveActiveWorkspace([], "acme")).toBeNull();
+  });
+});

--- a/agentarea-webapp/src/lib/workspaces.ts
+++ b/agentarea-webapp/src/lib/workspaces.ts
@@ -1,0 +1,32 @@
+export const WORKSPACE_SLUG_COOKIE = "workspace_slug";
+export const WORKSPACE_SLUG_HEADER = "x-workspace-slug";
+
+export type Workspace = {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+};
+
+/**
+ * Pick the workspace a request should run against.
+ *
+ * The preferred slug comes from the switcher cookie and is deliberately not
+ * trusted: a user who left a workspace keeps the cookie, and sending a slug
+ * they are no longer a member of makes the backend reject every request. An
+ * unrecognised slug therefore falls back to the personal workspace, which the
+ * backend provisions for every user.
+ */
+export function resolveActiveWorkspace<T extends Workspace>(
+  workspaces: T[],
+  preferredSlug: string | null | undefined
+): T | null {
+  if (workspaces.length === 0) return null;
+
+  if (preferredSlug) {
+    const match = workspaces.find((w) => w.slug === preferredSlug);
+    if (match) return match;
+  }
+
+  return workspaces.find((w) => w.type === "personal") ?? workspaces[0];
+}


### PR DESCRIPTION
## Why

The backend workspace layer — create, list, invite, membership, per-request slug override — shipped some time ago, but nothing in the UI reached it. `nav-data.ts` fed `TeamSwitcher` a hardcoded `{name: "AgentArea", plan: "Base workspace"}` entry and `GET /v1/workspaces` was never called from the webapp at all. A user with more than one workspace could only switch by hand-setting `X-Workspace-Slug`.

## What

The switcher renders the caller's real workspaces, marks the active one, distinguishes personal from shared, and creates new ones inline via a dialog.

Active workspace lives in an httpOnly `workspace_slug` cookie, written only by the server actions in `lib/workspace-actions.ts` and read by both outgoing paths — the generated client's fetch wrapper and the three route handlers (proxy, task create, upload-url) via a shared `resolveRequestWorkspaceSlug`. Switching calls `revalidatePath("/", "layout")`, since every page's data is workspace-scoped.

The `Referer = /w/{slug}` heuristic in the route handlers went away with it: no such routes exist in the app, so it never matched.

## Two bugs this surfaced

**Stale workspace id.** `getAuthContext().workspaceId` read the JWT `workspace_id` claim, which names the *default* workspace and goes stale the moment the switcher points elsewhere. Members, Audit and Policies pass that id into path-scoped endpoints, so they would have kept reading the pre-switch workspace. It now resolves the active one, falling back to the claim.

**Stale-cookie deadlock.** The backend 403s any request carrying a slug the caller is not a member of — `GET /v1/workspaces` included, since it goes through the same `UserContextDep`. A cookie left over from a workspace the user was removed from would therefore break the one call needed to recover from it. Listing is user-scoped, so it now goes out as a direct fetch with no workspace header, and every other request sends a slug *validated against that list* rather than the raw cookie: an unrecognised value degrades to the personal workspace instead of failing every page.

## Note for reviewers

`api/client-runtime.ts` is pulled into the browser bundle via `client.gen.ts` → `api.ts` → client components, and Turbopack traces static server-only imports through it *including through dynamic `import()`*. That is why `workspace-context.ts` keeps `next/headers` and `getAuthToken` behind lazy wrappers rather than importing them normally.

## Verification

Diff is webapp-only, so CI wakes `webapp-lint` and `webapp-build`. Both run clean locally, plus:

- `pnpm run lint` — clean
- `next build` — exit 0
- `tsc --noEmit` — clean
- `vitest` — 91 passed, including 5 new cases covering the slug-resolution fallbacks
- `prettier --check` — clean

Not covered: no e2e run against a live stack, so the switch flow itself is verified by construction and unit tests rather than by driving the UI.