### PR TITLE
Stop dropping fields on the way out of Hydra's discovery document

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_oauth_as.py
@@ -35,6 +35,18 @@ oauth_as_router = APIRouter(tags=["oauth-as"])
 # request cannot escape /oauth2/ on the Hydra host (partial-SSRF hardening).
 _SAFE_OAUTH2_SUBPATH = re.compile(r"^[A-Za-z0-9._~/-]+$")
 
+# Metadata endpoints we serve ourselves, and therefore rewrite to point here.
+# Everything else in Hydra's document keeps pointing at Hydra: rewriting a path
+# we do not proxy (``/userinfo``) would hand clients a 404, and ``/oauth2/
+# sessions/logout`` is browser-facing, so proxying it server-side would strand
+# the session cookies on our domain the same way ``/oauth2/auth`` would.
+_PROXIED_ENDPOINTS = (
+    "authorization_endpoint",
+    "token_endpoint",
+    "revocation_endpoint",
+    "jwks_uri",
+)
+
 
 def _is_safe_oauth2_subpath(path: str) -> bool:
     if not path or not _SAFE_OAUTH2_SUBPATH.match(path):
@@ -154,26 +166,21 @@ async def oauth_authorization_server_metadata() -> JSONResponse:
                 return url.replace(prefix, api_base, 1)
         return url
 
-    return JSONResponse(
-        content={
-            "issuer": api_base,
-            "authorization_endpoint": _rewrite(hydra_meta.get("authorization_endpoint")),
-            "token_endpoint": _rewrite(hydra_meta.get("token_endpoint")),
-            "registration_endpoint": f"{api_base}/oauth2/register",
-            "jwks_uri": _rewrite(hydra_meta.get("jwks_uri")),
-            "response_types_supported": hydra_meta.get("response_types_supported", ["code"]),
-            "grant_types_supported": hydra_meta.get(
-                "grant_types_supported", ["authorization_code"]
-            ),
-            "code_challenge_methods_supported": hydra_meta.get(
-                "code_challenge_methods_supported", ["S256"]
-            ),
-            "token_endpoint_auth_methods_supported": hydra_meta.get(
-                "token_endpoint_auth_methods_supported", ["none"]
-            ),
-            "revocation_endpoint": _rewrite(hydra_meta.get("revocation_endpoint")),
-        }
-    )
+    # Pass Hydra's document through and rewrite only what we actually serve.
+    # Enumerating the fields by hand silently dropped everything nobody listed —
+    # including `scopes_supported`, so clients never learned `offline_access`
+    # exists, never requested it, and never got a refresh token; and
+    # `subject_types_supported` / `id_token_signing_alg_values_supported`, which
+    # OIDC Discovery requires. Copying forward keeps a Hydra upgrade's new
+    # fields from going missing the same way.
+    metadata = dict(hydra_meta)
+    for field in _PROXIED_ENDPOINTS:
+        if field in metadata:
+            metadata[field] = _rewrite(metadata[field])
+    metadata["issuer"] = api_base
+    metadata["registration_endpoint"] = f"{api_base}/oauth2/register"
+
+    return JSONResponse(content=metadata)
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +219,7 @@ async def hydra_dcr_proxy(request: Request) -> Response:
     We inject server-side defaults:
       - skip_consent: true — MCP clients accessing their own workspace don't need consent
       - audience: [API_BASE_URL] — ensures issued JWTs have the correct audience for validation
+      - grant_types / scope — so the client can refresh instead of re-authorizing
     """
     import json as _json
 
@@ -232,6 +240,13 @@ async def hydra_dcr_proxy(request: Request) -> Response:
     client_data.setdefault("client_uri", api_base)
     if not client_data.get("contacts"):
         client_data["contacts"] = []
+
+    # RFC 7591 defaults an omitted grant_types to authorization_code alone, which
+    # registers a client that can never refresh: its access token expires on
+    # Hydra's TTL and the user has to walk through the browser flow again. An
+    # explicit choice by the client is left alone.
+    client_data.setdefault("grant_types", ["authorization_code", "refresh_token"])
+    client_data.setdefault("scope", "offline_access openid")
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(15)) as client:
         upstream = await client.post(

--- a/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
@@ -16,11 +16,86 @@ from fastapi.testclient import TestClient
 API_BASE = "https://api.example.com"
 
 
+HYDRA = "https://oauth.example.com"
+HYDRA_ADMIN = "http://hydra-admin.internal:4445"
+
+# Trimmed to the fields these tests reason about; the point of the passthrough
+# is precisely that fields nobody enumerated still reach the client.
+HYDRA_DOC = {
+    "issuer": f"{HYDRA}/",
+    "authorization_endpoint": f"{HYDRA}/oauth2/auth",
+    "token_endpoint": f"{HYDRA}/oauth2/token",
+    "revocation_endpoint": f"{HYDRA}/oauth2/revoke",
+    "jwks_uri": f"{HYDRA}/.well-known/jwks.json",
+    "userinfo_endpoint": f"{HYDRA}/userinfo",
+    "end_session_endpoint": f"{HYDRA}/oauth2/sessions/logout",
+    "registration_endpoint": f"{HYDRA}/oauth2/register",
+    "scopes_supported": ["offline_access", "offline", "openid"],
+    "subject_types_supported": ["public"],
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "response_types_supported": ["code"],
+    "grant_types_supported": ["authorization_code", "refresh_token"],
+    "code_challenge_methods_supported": ["S256"],
+}
+
+
 class _Settings:
     """Minimal stand-in for the app settings the endpoint reads."""
 
     class app:  # noqa: N801 - mirrors the settings attribute name
         API_BASE_URL = API_BASE
+
+    class mcp:  # noqa: N801 - mirrors the settings attribute name
+        HYDRA_PUBLIC_URL = HYDRA
+        HYDRA_ADMIN_URL = HYDRA_ADMIN
+        HYDRA_BROWSER_URL = HYDRA
+
+
+class _FakeResponse:
+    def __init__(self, payload=None, content=b"{}", status_code=200):
+        self._payload = payload
+        self.content = content
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class _FakeAsyncClient:
+    """Stands in for httpx.AsyncClient, recording what was sent upstream."""
+
+    sent: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, **kwargs):
+        return _FakeResponse(payload=HYDRA_DOC)
+
+    async def post(self, url, content=None, **kwargs):
+        type(self).sent.append(json.loads(content))
+        return _FakeResponse(content=b'{"client_id":"x"}')
+
+
+@pytest.fixture
+def hydra(monkeypatch):
+    """Point the endpoints at a stubbed Hydra and settings."""
+    monkeypatch.setattr(mcp_oauth_as, "get_settings", lambda: _Settings())
+    monkeypatch.setattr(mcp_oauth_as.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(_FakeAsyncClient, "sent", [])
+
+    app = FastAPI()
+    app.include_router(mcp_oauth_as.oauth_as_router)
+    return TestClient(app)
 
 
 class TestOAuth2SubpathValidation:
@@ -136,3 +211,67 @@ class TestProtectedResourceMetadataLocations:
     def test_unknown_resource_path_is_not_served(self, client):
         # A catch-all would answer for resources this API does not protect.
         assert client.get("/.well-known/oauth-protected-resource/nope").status_code == 404
+
+
+class TestAuthorizationServerMetadata:
+    """What survives the trip from Hydra's document to the client's (RFC 8414).
+
+    The document is a passthrough, not a hand-written subset: a field nobody
+    thought to enumerate must still reach the client. `scopes_supported` is the
+    one that bit us — without it a client never learns `offline_access` exists,
+    never asks for it, and so never gets a refresh token; the access token then
+    expires an hour later and the user has to redo the browser flow.
+    """
+
+    def test_advertises_the_scopes_hydra_supports(self, hydra):
+        metadata = hydra.get("/.well-known/oauth-authorization-server").json()
+
+        assert metadata["scopes_supported"] == ["offline_access", "offline", "openid"]
+
+    def test_passes_through_fields_it_does_not_rewrite(self, hydra):
+        metadata = hydra.get("/.well-known/oauth-authorization-server").json()
+
+        # Required by OIDC Discovery, and previously dropped on the floor.
+        assert metadata["subject_types_supported"] == ["public"]
+        assert metadata["id_token_signing_alg_values_supported"] == ["RS256"]
+
+    def test_rewrites_the_endpoints_we_proxy(self, hydra):
+        metadata = hydra.get("/.well-known/oauth-authorization-server").json()
+
+        assert metadata["authorization_endpoint"] == f"{API_BASE}/oauth2/auth"
+        assert metadata["token_endpoint"] == f"{API_BASE}/oauth2/token"
+        assert metadata["revocation_endpoint"] == f"{API_BASE}/oauth2/revoke"
+        assert metadata["jwks_uri"] == f"{API_BASE}/.well-known/jwks.json"
+
+    def test_leaves_endpoints_we_do_not_proxy_on_hydra(self, hydra):
+        # Rewriting a path we do not serve would hand clients a 404.
+        metadata = hydra.get("/.well-known/oauth-authorization-server").json()
+
+        assert metadata["userinfo_endpoint"] == f"{HYDRA}/userinfo"
+        assert metadata["end_session_endpoint"] == f"{HYDRA}/oauth2/sessions/logout"
+
+    def test_claims_the_issuer_and_its_own_registration_endpoint(self, hydra):
+        metadata = hydra.get("/.well-known/oauth-authorization-server").json()
+
+        assert metadata["issuer"] == API_BASE
+        assert metadata["registration_endpoint"] == f"{API_BASE}/oauth2/register"
+
+
+class TestDynamicClientRegistration:
+    """A client registered without the refresh grant can only ever re-auth."""
+
+    def test_registers_the_client_for_refresh_by_default(self, hydra):
+        hydra.post("/oauth2/register", json={"client_name": "probe"})
+
+        sent = _FakeAsyncClient.sent[-1]
+        assert "refresh_token" in sent["grant_types"]
+        assert "authorization_code" in sent["grant_types"]
+        assert "offline_access" in sent["scope"].split()
+
+    def test_respects_grant_types_the_client_asked_for(self, hydra):
+        hydra.post(
+            "/oauth2/register",
+            json={"client_name": "probe", "grant_types": ["authorization_code"]},
+        )
+
+        assert _FakeAsyncClient.sent[-1]["grant_types"] == ["authorization_code"]

--- a/agentarea-webapp/packages/api-client/src/generated/sdk.gen.ts
+++ b/agentarea-webapp/packages/api-client/src/generated/sdk.gen.ts
@@ -132,6 +132,7 @@ export const hydraAuthRedirectOauth2AuthGet = <ThrowOnError extends boolean = fa
  * We inject server-side defaults:
  * - skip_consent: true — MCP clients accessing their own workspace don't need consent
  * - audience: [API_BASE_URL] — ensures issued JWTs have the correct audience for validation
+ * - grant_types / scope — so the client can refresh instead of re-authorizing
  */
 export const hydraDcrProxyOauth2RegisterPost = <ThrowOnError extends boolean = false>(options?: Options<HydraDcrProxyOauth2RegisterPostData, ThrowOnError>): RequestResult<HydraDcrProxyOauth2RegisterPostResponses, unknown, ThrowOnError> => (options?.client ?? client).post<HydraDcrProxyOauth2RegisterPostResponses, unknown, ThrowOnError>({
     security: [{

--- a/agentarea-webapp/packages/api-client/types/generated/sdk.gen.d.ts
+++ b/agentarea-webapp/packages/api-client/types/generated/sdk.gen.d.ts
@@ -73,6 +73,7 @@ export declare const hydraAuthRedirectOauth2AuthGet: <ThrowOnError extends boole
  * We inject server-side defaults:
  * - skip_consent: true — MCP clients accessing their own workspace don't need consent
  * - audience: [API_BASE_URL] — ensures issued JWTs have the correct audience for validation
+ * - grant_types / scope — so the client can refresh instead of re-authorizing
  */
 export declare const hydraDcrProxyOauth2RegisterPost: <ThrowOnError extends boolean = false>(options?: Options<HydraDcrProxyOauth2RegisterPostData, ThrowOnError>) => RequestResult<HydraDcrProxyOauth2RegisterPostResponses, unknown, ThrowOnError>;
 /**

--- a/agentarea-webapp/src/api/client/sdk.gen.ts
+++ b/agentarea-webapp/src/api/client/sdk.gen.ts
@@ -970,6 +970,7 @@ export const hydraAuthRedirectOauth2AuthGet = <
  * We inject server-side defaults:
  * - skip_consent: true — MCP clients accessing their own workspace don't need consent
  * - audience: [API_BASE_URL] — ensures issued JWTs have the correct audience for validation
+ * - grant_types / scope — so the client can refresh instead of re-authorizing
  */
 export const hydraDcrProxyOauth2RegisterPost = <
   ThrowOnError extends boolean = false,

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -12140,7 +12140,7 @@
     },
     "/oauth2/register": {
       "post": {
-        "description": "Dynamic Client Registration (RFC 7591) \u2014 proxy to Hydra admin API.\n\nHydra v2 doesn't expose public DCR; we proxy POST /oauth2/register to\nHydra's admin endpoint so Cursor / Claude Desktop can self-register.\n\nWe inject server-side defaults:\n  - skip_consent: true \u2014 MCP clients accessing their own workspace don't need consent\n  - audience: [API_BASE_URL] \u2014 ensures issued JWTs have the correct audience for validation",
+        "description": "Dynamic Client Registration (RFC 7591) \u2014 proxy to Hydra admin API.\n\nHydra v2 doesn't expose public DCR; we proxy POST /oauth2/register to\nHydra's admin endpoint so Cursor / Claude Desktop can self-register.\n\nWe inject server-side defaults:\n  - skip_consent: true \u2014 MCP clients accessing their own workspace don't need consent\n  - audience: [API_BASE_URL] \u2014 ensures issued JWTs have the correct audience for validation\n  - grant_types / scope \u2014 so the client can refresh instead of re-authorizing",
         "operationId": "hydra_dcr_proxy_oauth2_register_post",
         "responses": {
           "200": {

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -12140,7 +12140,7 @@
     },
     "/oauth2/register": {
       "post": {
-        "description": "Dynamic Client Registration (RFC 7591) \u2014 proxy to Hydra admin API.\n\nHydra v2 doesn't expose public DCR; we proxy POST /oauth2/register to\nHydra's admin endpoint so Cursor / Claude Desktop can self-register.\n\nWe inject server-side defaults:\n  - skip_consent: true \u2014 MCP clients accessing their own workspace don't need consent\n  - audience: [API_BASE_URL] \u2014 ensures issued JWTs have the correct audience for validation",
+        "description": "Dynamic Client Registration (RFC 7591) \u2014 proxy to Hydra admin API.\n\nHydra v2 doesn't expose public DCR; we proxy POST /oauth2/register to\nHydra's admin endpoint so Cursor / Claude Desktop can self-register.\n\nWe inject server-side defaults:\n  - skip_consent: true \u2014 MCP clients accessing their own workspace don't need consent\n  - audience: [API_BASE_URL] \u2014 ensures issued JWTs have the correct audience for validation\n  - grant_types / scope \u2014 so the client can refresh instead of re-authorizing",
         "operationId": "hydra_dcr_proxy_oauth2_register_post",
         "responses": {
           "200": {


### PR DESCRIPTION
Fixes the "MCP clients have to re-authorize every hour" problem.

## Hydra is fine; we lose the fields

`/.well-known/oauth-authorization-server` fetched Hydra's discovery document and then rebuilt it by hand, listing ten fields. Everything else was dropped. Diffed against the live RU deployment, that is **21 fields**:

```
scopes_supported                        <- the one that causes the re-auth loop
subject_types_supported                 <- REQUIRED by OIDC Discovery
id_token_signing_alg_values_supported   <- REQUIRED by OIDC Discovery
userinfo_endpoint, end_session_endpoint, response_modes_supported,
claims_supported, claims_parameter_supported, request_parameter_supported,
request_uri_parameter_supported, require_request_uri_registration,
request_object_signing_alg_values_supported, id_token_signed_response_alg,
userinfo_signed_response_alg, userinfo_signing_alg_values_supported,
frontchannel_logout_supported, frontchannel_logout_session_supported,
backchannel_logout_supported, backchannel_logout_session_supported,
credentials_endpoint_draft_00, credentials_supported_draft_00
```

Hydra publishes, live:

```json
"grant_types_supported": ["authorization_code", "implicit", "client_credentials", "refresh_token"],
"scopes_supported": ["offline_access", "offline", "openid"]
```

We published `scopes_supported: null`. A client that reads our metadata therefore never learns `offline_access` exists → never requests it → Hydra issues no refresh token → the access token dies on Hydra's default one-hour TTL → full browser flow again. Visible in the authorize URL our own MCP client builds: no `scope` parameter at all.

So: not a Hydra misconfiguration. The chart sets no Hydra TTLs and does not need to — one hour is a fine access-token lifetime *once refresh works*.

## The fix

Copy Hydra's document forward and rewrite only what we actually serve — `authorization_endpoint`, `token_endpoint`, `revocation_endpoint`, `jwks_uri` — then force `issuer` and `registration_endpoint` to us.

Everything else deliberately keeps pointing at Hydra. `/userinfo` we do not proxy, so rewriting it would hand clients a 404; `/oauth2/sessions/logout` is browser-facing, so proxying it server-side would strand session cookies on our domain exactly the way `/oauth2/auth` would (that is why `/oauth2/auth` is a redirect and not a proxy).

Note this also drops the invented fallbacks the old code carried (`response_types_supported` defaulting to `["code"]`, etc.). If Hydra omits a field we now omit it too, rather than inventing an answer on the upstream's behalf.

Second half, in the DCR proxy: RFC 7591 defaults an omitted `grant_types` to `authorization_code` alone, which registers a client that structurally cannot refresh. Default it to `["authorization_code", "refresh_token"]` and default `scope` to `offline_access openid`. An explicit choice by the client is left alone.

## Tests

`apps/api/tests/test_mcp_oauth_as.py` — a stubbed Hydra behind the real routes:

- `scopes_supported` reaches the client
- fields we never enumerate (`subject_types_supported`, `id_token_signing_alg_values_supported`) survive
- the four proxied endpoints are rewritten to us
- `userinfo_endpoint` / `end_session_endpoint` stay on Hydra
- `issuer` and `registration_endpoint` are ours
- registration defaults to a client that can refresh, and respects an explicit `grant_types`

Four of these fail on `main`.

## What this does not prove

Whether a given MCP client then *asks* for `offline_access` is up to that client, and I cannot read Claude Code's DCR payload from here. If a client sends an explicit `grant_types` without `refresh_token`, `setdefault` leaves it alone by design and that client still re-authorizes hourly. The check after deploy is concrete: re-authenticate and look for `scope=offline_access` in the authorize URL, then confirm the connection outlives an hour.

## Checks

`ruff check` clean · `ruff format --check` clean · `pyright` 0 errors · `make test` 863 passed, 8 skipped (+21 in the separate redaction process) · all three committed spec copies regenerated and in sync
