### PR TITLE
Scope MCP secret resolution to the instance's own workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,7 +791,7 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Check MCP gateway lifecycle SQL against the migrated schema
+      - name: Check MCP gateway and secret-resolver SQL against the migrated schema
         working-directory: agentarea-mcp-manager
         env:
           MCP_GATEWAY_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/agentarea_test?sslmode=disable
@@ -801,7 +801,10 @@ jobs:
           MCP_GATEWAY_REQUIRE_DB: "1"
         # -v so the log names the tests that ran, rather than a bare "ok" that
         # looks identical whether they executed or skipped.
-        run: go test -v -count=1 ./internal/mcpgateway/...
+        # internal/secrets joins encrypted_secrets to mcp_server_instances to
+        # keep one workspace's secrets out of another's containers — a rule that
+        # only a real schema can check.
+        run: go test -v -count=1 ./internal/mcpgateway/... ./internal/secrets/...
 
   # Single required status check for branch protection. Monorepo path filters
   # skip irrelevant jobs (they report "skipped", not "failure"), so a per-job

--- a/agentarea-mcp-manager/internal/container/manager.go
+++ b/agentarea-mcp-manager/internal/container/manager.go
@@ -80,16 +80,18 @@ func (m *Manager) SetSecretResolver(resolver SecretResolverInterface) {
 // values are decrypted here from the DB and never sent over the wire.
 //
 // Returns an empty map when no resolver is configured or no secret names are
-// present. This is the single source of secret resolution shared by the HTTP
-// create path (which owns provisioning) and the DB-sync reconcile loop.
-func (m *Manager) ResolveSecretEnvVars(instanceID string, jsonSpec map[string]interface{}) map[string]string {
+// present. A resolver that fails is an error, not an empty map: starting the
+// container anyway would hand the workload a spec whose credentials silently
+// went missing. This is the single source of secret resolution shared by the
+// HTTP create path (which owns provisioning) and the DB-sync reconcile loop.
+func (m *Manager) ResolveSecretEnvVars(instanceID string, jsonSpec map[string]interface{}) (map[string]string, error) {
 	resolved := make(map[string]string)
 	if m.secretResolver == nil || jsonSpec == nil {
-		return resolved
+		return resolved, nil
 	}
 	envVarsRaw, ok := jsonSpec["env_vars"].([]interface{})
 	if !ok || len(envVarsRaw) == 0 {
-		return resolved
+		return resolved, nil
 	}
 	envVarNames := make([]string, 0, len(envVarsRaw))
 	for _, v := range envVarsRaw {
@@ -98,21 +100,18 @@ func (m *Manager) ResolveSecretEnvVars(instanceID string, jsonSpec map[string]in
 		}
 	}
 	if len(envVarNames) == 0 {
-		return resolved
+		return resolved, nil
 	}
 	secretEnvVars, err := m.secretResolver.ResolveInstanceEnvVars(instanceID, envVarNames)
 	if err != nil {
-		m.logger.Error("Failed to resolve secret env vars",
-			slog.String("instance_id", instanceID),
-			slog.String("error", err.Error()))
-		return resolved
+		return nil, fmt.Errorf("resolve secret env vars for instance %s: %w", instanceID, err)
 	}
 	if len(secretEnvVars) > 0 {
 		m.logger.Info("Resolved secret env vars from encrypted_secrets",
 			slog.String("instance_id", instanceID),
 			slog.Int("count", len(secretEnvVars)))
 	}
-	return secretEnvVars
+	return secretEnvVars, nil
 }
 
 // Initialize initializes the container manager
@@ -1948,8 +1947,18 @@ func (m *Manager) syncWithCoreAPI(ctx context.Context) error {
 		}
 
 		// Resolve secret env vars from encrypted_secrets table (shared with the
-		// HTTP create path via Manager.ResolveSecretEnvVars).
-		for k, v := range m.ResolveSecretEnvVars(instance.InstanceID, instance.JSONSpec) {
+		// HTTP create path via Manager.ResolveSecretEnvVars). Skip the instance
+		// rather than start it with its credentials missing — the next sweep
+		// retries once the cause is gone.
+		secretEnvVars, err := m.ResolveSecretEnvVars(instance.InstanceID, instance.JSONSpec)
+		if err != nil {
+			m.logger.Error("Failed to resolve secret env vars for instance",
+				slog.String("instance_id", instance.InstanceID),
+				slog.String("name", instance.Name),
+				slog.String("error", err.Error()))
+			continue
+		}
+		for k, v := range secretEnvVars {
 			environment[k] = v
 		}
 

--- a/agentarea-mcp-manager/internal/container/manager_test.go
+++ b/agentarea-mcp-manager/internal/container/manager_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -78,16 +79,20 @@ func TestGetRunningCount(t *testing.T) {
 }
 
 // stubSecretResolver records the names it was asked to resolve and returns a
-// fixed decrypted value per name.
+// fixed decrypted value per name, or err when set.
 type stubSecretResolver struct {
 	gotInstanceID string
 	gotNames      []string
 	values        map[string]string
+	err           error
 }
 
 func (s *stubSecretResolver) ResolveInstanceEnvVars(instanceID string, names []string) (map[string]string, error) {
 	s.gotInstanceID = instanceID
 	s.gotNames = names
+	if s.err != nil {
+		return nil, s.err
+	}
 	out := make(map[string]string)
 	for _, n := range names {
 		if v, ok := s.values[n]; ok {
@@ -120,7 +125,10 @@ func TestResolveSecretEnvVars_DecryptsNamedSecrets(t *testing.T) {
 		"env_vars":    []interface{}{"TELEGRAM_API_ID", "TELEGRAM_API_HASH"},
 	}
 
-	got := manager.ResolveSecretEnvVars("inst-1", jsonSpec)
+	got, err := manager.ResolveSecretEnvVars("inst-1", jsonSpec)
+	if err != nil {
+		t.Fatalf("ResolveSecretEnvVars() error = %v, want nil", err)
+	}
 
 	if stub.gotInstanceID != "inst-1" {
 		t.Errorf("expected resolver called with instance inst-1, got %q", stub.gotInstanceID)
@@ -132,9 +140,12 @@ func TestResolveSecretEnvVars_DecryptsNamedSecrets(t *testing.T) {
 
 func TestResolveSecretEnvVars_NoResolverIsNoop(t *testing.T) {
 	manager := newTestManager(t) // no SetSecretResolver
-	got := manager.ResolveSecretEnvVars("inst-1", map[string]interface{}{
+	got, err := manager.ResolveSecretEnvVars("inst-1", map[string]interface{}{
 		"env_vars": []interface{}{"TELEGRAM_API_ID"},
 	})
+	if err != nil {
+		t.Fatalf("ResolveSecretEnvVars() error = %v, want nil", err)
+	}
 	if len(got) != 0 {
 		t.Errorf("expected empty map without a resolver, got %v", got)
 	}
@@ -143,11 +154,32 @@ func TestResolveSecretEnvVars_NoResolverIsNoop(t *testing.T) {
 func TestResolveSecretEnvVars_NoEnvVarsIsNoop(t *testing.T) {
 	manager := newTestManager(t)
 	manager.SetSecretResolver(&stubSecretResolver{values: map[string]string{"X": "y"}})
-	got := manager.ResolveSecretEnvVars("inst-1", map[string]interface{}{
+	got, err := manager.ResolveSecretEnvVars("inst-1", map[string]interface{}{
 		"environment": map[string]interface{}{"LOG_LEVEL": "info"},
 	})
+	if err != nil {
+		t.Fatalf("ResolveSecretEnvVars() error = %v, want nil", err)
+	}
 	if len(got) != 0 {
 		t.Errorf("expected empty map when json_spec has no env_vars, got %v", got)
+	}
+}
+
+// A container that starts without the secrets its spec asked for looks healthy
+// and fails somewhere downstream, against whatever the missing credential was
+// guarding. Reporting the failure is what lets the caller skip the container.
+func TestResolveSecretEnvVars_ResolverFailureIsReported(t *testing.T) {
+	manager := newTestManager(t)
+	manager.SetSecretResolver(&stubSecretResolver{err: errors.New("secret lookup failed")})
+
+	got, err := manager.ResolveSecretEnvVars("inst-1", map[string]interface{}{
+		"env_vars": []interface{}{"TELEGRAM_API_ID"},
+	})
+	if err == nil {
+		t.Fatalf("ResolveSecretEnvVars() error = nil, want the resolver failure; got env %v", got)
+	}
+	if got != nil {
+		t.Errorf("ResolveSecretEnvVars() env = %v, want nil alongside an error", got)
 	}
 }
 

--- a/agentarea-mcp-manager/internal/providers/environment.go
+++ b/agentarea-mcp-manager/internal/providers/environment.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/agentarea/mcp-manager/internal/secrets"
 )
@@ -37,19 +36,14 @@ func resolveInstanceSpecSecrets(resolver secrets.SecretResolver, instanceID stri
 		secretNames = append(secretNames, values...)
 	}
 
-	needsResolver := len(secretNames) > 0
 	stringEnvironment := make(map[string]string, len(environment))
 	for key, value := range environment {
-		stringValue := fmt.Sprint(value)
-		stringEnvironment[key] = stringValue
-		if strings.HasPrefix(stringValue, "secret_ref:") {
-			needsResolver = true
-		}
-	}
-	if needsResolver && resolver == nil {
-		return nil, fmt.Errorf("secret resolver is required for MCP instance %s", instanceID)
+		stringEnvironment[key] = fmt.Sprint(value)
 	}
 	if len(secretNames) > 0 {
+		if resolver == nil {
+			return nil, fmt.Errorf("secret resolver is required for MCP instance %s", instanceID)
+		}
 		values, err := resolver.ResolveInstanceEnvVars(instanceID, secretNames)
 		if err != nil {
 			return nil, fmt.Errorf("resolve MCP secret environment: %w", err)
@@ -61,13 +55,6 @@ func resolveInstanceSpecSecrets(resolver secrets.SecretResolver, instanceID stri
 			}
 			stringEnvironment[name] = value
 		}
-	}
-	if needsResolver {
-		values, err := resolver.ResolveSecrets(instanceID, stringEnvironment)
-		if err != nil {
-			return nil, fmt.Errorf("resolve MCP environment references: %w", err)
-		}
-		stringEnvironment = values
 	}
 	if len(stringEnvironment) > 0 {
 		resolvedEnvironment := make(map[string]any, len(stringEnvironment))

--- a/agentarea-mcp-manager/internal/providers/environment_test.go
+++ b/agentarea-mcp-manager/internal/providers/environment_test.go
@@ -10,18 +10,6 @@ type recordingSecretResolver struct {
 	omit           map[string]bool
 }
 
-func (r *recordingSecretResolver) ResolveSecrets(_ string, values map[string]string) (map[string]string, error) {
-	resolved := make(map[string]string, len(values))
-	for key, value := range values {
-		if value == "secret_ref:" {
-			resolved[key] = "resolved-reference"
-		} else {
-			resolved[key] = value
-		}
-	}
-	return resolved, nil
-}
-
 func (r *recordingSecretResolver) ResolveInstanceEnvVars(_ string, names []string) (map[string]string, error) {
 	resolved := make(map[string]string, len(names))
 	for _, name := range names {
@@ -45,13 +33,10 @@ func TestResolveInstanceSpecSecretsRejectsOmittedRequestedSecret(t *testing.T) {
 
 func (r *recordingSecretResolver) Close() error { return nil }
 
-func TestResolveInstanceSpecSecretsResolvesBothSecretForms(t *testing.T) {
+func TestResolveInstanceSpecSecretsMergesNamedSecretsIntoEnvironment(t *testing.T) {
 	source := map[string]any{
-		"environment": map[string]any{
-			"PLAIN": "value",
-			"REF":   "secret_ref:",
-		},
-		"env_vars": []any{"NAMED"},
+		"environment": map[string]any{"PLAIN": "value"},
+		"env_vars":    []any{"NAMED"},
 	}
 	resolver := &recordingSecretResolver{instanceValues: map[string]string{"NAMED": "named-secret"}}
 
@@ -62,20 +47,19 @@ func TestResolveInstanceSpecSecretsResolvesBothSecretForms(t *testing.T) {
 
 	want := map[string]any{
 		"PLAIN": "value",
-		"REF":   "resolved-reference",
 		"NAMED": "named-secret",
 	}
 	if got := resolved["environment"]; !reflect.DeepEqual(got, want) {
 		t.Fatalf("environment = %#v, want %#v", got, want)
 	}
-	if got := source["environment"].(map[string]any)["REF"]; got != "secret_ref:" {
-		t.Fatalf("source mutated: REF = %#v", got)
+	if _, mutated := source["environment"].(map[string]any)["NAMED"]; mutated {
+		t.Fatal("source mutated: NAMED leaked into the caller's spec")
 	}
 }
 
-func TestResolveInstanceSpecSecretsRequiresResolverForEmptyReference(t *testing.T) {
+func TestResolveInstanceSpecSecretsRequiresResolverForNamedSecrets(t *testing.T) {
 	_, err := resolveInstanceSpecSecrets(nil, "instance-1", map[string]any{
-		"environment": map[string]any{"REF": "secret_ref:"},
+		"env_vars": []any{"NAMED"},
 	})
 	if err == nil {
 		t.Fatal("expected missing resolver to fail closed")

--- a/agentarea-mcp-manager/internal/secrets/database_resolver.go
+++ b/agentarea-mcp-manager/internal/secrets/database_resolver.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/agentarea/mcp-manager/internal/database"
@@ -74,36 +73,6 @@ func NewDatabaseSecretResolver(logger *slog.Logger) (*DatabaseSecretResolver, er
 	}, nil
 }
 
-// ResolveSecrets resolves all secrets for an MCP instance from database
-func (dr *DatabaseSecretResolver) ResolveSecrets(instanceID string, envVars map[string]string) (map[string]string, error) {
-	resolved := make(map[string]string)
-
-	for key, value := range envVars {
-		// Check if this is a secret reference or a plain value
-		if strings.HasPrefix(value, "secret_ref:") {
-			// This is a secret reference, resolve it from database
-			secretName := strings.TrimPrefix(value, "secret_ref:")
-			secretValue, err := dr.getSecretFromDatabase(instanceID, secretName)
-			if err != nil {
-				dr.logger.Error("Failed to resolve secret from database",
-					slog.String("instance_id", instanceID))
-				return nil, errors.New("failed to resolve secrets for instance")
-			}
-			resolved[key] = secretValue
-		} else {
-			// This is a plain value, use as-is
-			resolved[key] = value
-		}
-	}
-
-	dr.logger.Debug("Resolved secrets for instance from database",
-		slog.String("instance_id", instanceID),
-		slog.Int("total_vars", len(envVars)),
-		slog.Int("resolved_secrets", len(resolved)))
-
-	return resolved, nil
-}
-
 // getSecretFromDatabase retrieves and decrypts a secret from PostgreSQL
 func (dr *DatabaseSecretResolver) getSecretFromDatabase(instanceID, secretName string) (string, error) {
 	// Use the same secret key pattern as Python:
@@ -113,14 +82,23 @@ func (dr *DatabaseSecretResolver) getSecretFromDatabase(instanceID, secretName s
 	dr.logger.Debug("Retrieving secret from database",
 		slog.String("instance_id", instanceID))
 
-	// Query database for the encrypted secret by full secret name
+	// The instance's own row supplies the workspace. Secret names are unique
+	// only within a workspace (uq_encrypted_secrets_workspace_name), so matching
+	// on the name alone would let any workspace serve a secret named after
+	// another workspace's instance. The instance is committed before the create
+	// event is published, so this join always has a row to find for a real
+	// instance; an unknown instance resolves to nothing, which is correct.
 	var encryptedValue string
-	query := `SELECT encrypted_value FROM encrypted_secrets WHERE secret_name = $1 LIMIT 1`
+	query := `
+		SELECT es.encrypted_value
+		FROM encrypted_secrets es
+		JOIN mcp_server_instances msi ON msi.workspace_id = es.workspace_id
+		WHERE msi.id = $1::uuid AND es.secret_name = $2`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := dr.db.QueryRowContext(ctx, query, fullSecretName).Scan(&encryptedValue)
+	err := dr.db.QueryRowContext(ctx, query, instanceID, fullSecretName).Scan(&encryptedValue)
 	if err == sql.ErrNoRows {
 		return "", errors.New("secret not found")
 	}

--- a/agentarea-mcp-manager/internal/secrets/database_resolver_db_test.go
+++ b/agentarea-mcp-manager/internal/secrets/database_resolver_db_test.go
@@ -1,0 +1,214 @@
+package secrets
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// The resolver reads secrets with raw SQL against the schema alembic produces,
+// and the rule it has to enforce — a container only ever receives secrets from
+// its own instance's workspace — lives entirely in that SQL. A stubbed database
+// would answer whatever the test author wired up and would pass while the real
+// query read across tenants, which is exactly the bug these tests exist to keep
+// out. So the schema comes from the migrations. See repository_db_test.go in
+// internal/mcpgateway for the same arrangement and the local setup recipe.
+
+const (
+	resolverTestDSNEnv  = "MCP_GATEWAY_TEST_DATABASE_URL"
+	resolverRequireDBEn = "MCP_GATEWAY_REQUIRE_DB"
+)
+
+func resolverTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := os.Getenv(resolverTestDSNEnv)
+	if dsn == "" {
+		if os.Getenv(resolverRequireDBEn) != "" {
+			t.Fatalf("%s is set but %s is empty: the schema-backed secret resolver tests were meant to run here, not skip",
+				resolverRequireDBEn, resolverTestDSNEnv)
+		}
+		t.Skipf("%s not set; skipping schema-backed secret resolver tests", resolverTestDSNEnv)
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("ping test database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// fernetEncrypt mirrors the token layout fernetDecrypt parses, so a test can
+// plant a secret the production decryption path accepts.
+func fernetEncrypt(t *testing.T, key []byte, plaintext string) string {
+	t.Helper()
+
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		t.Fatalf("generate iv: %v", err)
+	}
+
+	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
+	padded := append([]byte(plaintext), make([]byte, padding)...)
+	for i := len(plaintext); i < len(padded); i++ {
+		padded[i] = byte(padding)
+	}
+
+	block, err := aes.NewCipher(key[16:])
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	token := make([]byte, 0, 1+8+len(iv)+len(ciphertext)+sha256.Size)
+	token = append(token, 0x80)
+	timestamp := make([]byte, 8)
+	binary.BigEndian.PutUint64(timestamp, uint64(time.Now().Unix()))
+	token = append(token, timestamp...)
+	token = append(token, iv...)
+	token = append(token, ciphertext...)
+
+	mac := hmac.New(sha256.New, key[:16])
+	mac.Write(token)
+	token = append(token, mac.Sum(nil)...)
+
+	return base64.URLEncoding.EncodeToString(token)
+}
+
+func newSchemaBackedResolver(t *testing.T, db *sql.DB) (*DatabaseSecretResolver, []byte) {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		t.Fatalf("generate fernet key: %v", err)
+	}
+	return &DatabaseSecretResolver{
+		db:     db,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		key:    key,
+	}, key
+}
+
+func insertInstance(t *testing.T, db *sql.DB, instanceID, workspaceID string) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO mcp_server_instances
+			(id, name, server_spec_id, json_spec, verification, network_scope,
+			 workspace_id, created_by, created_at, updated_at)
+		VALUES ($1::uuid, $2, 'spec-under-test', '{}'::json, '{}'::json, 'private',
+			 $3, 'resolver-test', now(), now())`,
+		instanceID, "instance-"+instanceID[:8], workspaceID)
+	if err != nil {
+		t.Fatalf("insert instance %s: %v", instanceID, err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM mcp_server_instances WHERE id = $1::uuid`, instanceID)
+	})
+}
+
+func insertSecret(t *testing.T, db *sql.DB, workspaceID, name, encrypted string) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO encrypted_secrets
+			(id, workspace_id, secret_name, encrypted_value, created_by, created_at, updated_at)
+		VALUES (gen_random_uuid(), $1, $2, $3, 'resolver-test', now(), now())`,
+		workspaceID, name, encrypted)
+	if err != nil {
+		t.Fatalf("insert secret %s in %s: %v", name, workspaceID, err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM encrypted_secrets WHERE workspace_id = $1 AND secret_name = $2`,
+			workspaceID, name)
+	})
+}
+
+// A secret named after another workspace's instance must stay invisible to it.
+// Secret names are globally unique only by accident today (they embed a UUID);
+// once a workspace can name a secret, planting `mcp_instance_<their-uuid>_VAR`
+// is how one tenant would inject environment into another tenant's container.
+func TestResolveInstanceEnvVarsRefusesForeignWorkspaceSecret(t *testing.T) {
+	db := resolverTestDB(t)
+	resolver, key := newSchemaBackedResolver(t, db)
+
+	const (
+		victimInstance = "11111111-1111-4111-8111-111111111111"
+		victimWS       = "resolver-test-ws-victim"
+		attackerWS     = "resolver-test-ws-attacker"
+	)
+	secretName := fmt.Sprintf("mcp_instance_%s_API_KEY", victimInstance)
+
+	insertInstance(t, db, victimInstance, victimWS)
+	insertSecret(t, db, attackerWS, secretName, fernetEncrypt(t, key, "attacker-controlled"))
+
+	_, err := resolver.ResolveInstanceEnvVars(victimInstance, []string{"API_KEY"})
+	if err == nil {
+		t.Fatal("ResolveInstanceEnvVars() error = nil, want a failure: the only matching secret belongs to another workspace")
+	}
+}
+
+// With the same name present in both workspaces, the instance's own workspace
+// decides. The pre-fix query had no workspace predicate and no ORDER BY, so it
+// returned whichever row the scan reached first.
+func TestResolveInstanceEnvVarsPrefersOwnWorkspaceOverSameNamedForeignSecret(t *testing.T) {
+	db := resolverTestDB(t)
+	resolver, key := newSchemaBackedResolver(t, db)
+
+	const (
+		victimInstance = "22222222-2222-4222-8222-222222222222"
+		victimWS       = "resolver-test-ws-owner"
+		attackerWS     = "resolver-test-ws-squatter"
+	)
+	secretName := fmt.Sprintf("mcp_instance_%s_API_KEY", victimInstance)
+
+	insertInstance(t, db, victimInstance, victimWS)
+	// Planted first so a scan without a workspace predicate reaches it first.
+	insertSecret(t, db, attackerWS, secretName, fernetEncrypt(t, key, "attacker-controlled"))
+	insertSecret(t, db, victimWS, secretName, fernetEncrypt(t, key, "owner-value"))
+
+	resolved, err := resolver.ResolveInstanceEnvVars(victimInstance, []string{"API_KEY"})
+	if err != nil {
+		t.Fatalf("ResolveInstanceEnvVars() error = %v, want the owning workspace's secret", err)
+	}
+	if resolved["API_KEY"] != "owner-value" {
+		t.Fatalf("ResolveInstanceEnvVars() API_KEY = %q, want %q", resolved["API_KEY"], "owner-value")
+	}
+}
+
+// An instance row that does not exist has no workspace, so nothing can be
+// resolved for it — the lookup must not fall back to matching on name alone.
+func TestResolveInstanceEnvVarsRefusesUnknownInstance(t *testing.T) {
+	db := resolverTestDB(t)
+	resolver, key := newSchemaBackedResolver(t, db)
+
+	const (
+		unknownInstance = "33333333-3333-4333-8333-333333333333"
+		strayWS         = "resolver-test-ws-stray"
+	)
+	secretName := fmt.Sprintf("mcp_instance_%s_API_KEY", unknownInstance)
+
+	insertSecret(t, db, strayWS, secretName, fernetEncrypt(t, key, "stray-value"))
+
+	_, err := resolver.ResolveInstanceEnvVars(unknownInstance, []string{"API_KEY"})
+	if err == nil {
+		t.Fatal("ResolveInstanceEnvVars() error = nil, want a failure for an instance that does not exist")
+	}
+}

--- a/agentarea-mcp-manager/internal/secrets/interface.go
+++ b/agentarea-mcp-manager/internal/secrets/interface.go
@@ -2,10 +2,6 @@ package secrets
 
 // SecretResolver is an interface for resolving secrets from different backends
 type SecretResolver interface {
-	// ResolveSecrets resolves all environment variables for an MCP instance
-	// replacing secret references (secret_ref:xxx) with actual secret values
-	ResolveSecrets(instanceID string, envVars map[string]string) (map[string]string, error)
-
 	// ResolveInstanceEnvVars resolves secret env vars by name from the secret store.
 	// Used when json_spec.env_vars contains a list of secret names that should be
 	// fetched from encrypted_secrets (not from json_spec.environment).

--- a/agentarea-mcp-manager/internal/secrets/resolver.go
+++ b/agentarea-mcp-manager/internal/secrets/resolver.go
@@ -146,35 +146,6 @@ func newInfisicalSecretResolver(logger *slog.Logger) (*InfisicalSecretResolver, 
 	}, nil
 }
 
-// ResolveSecrets resolves all secrets for an MCP instance
-func (sr *InfisicalSecretResolver) ResolveSecrets(instanceID string, envVars map[string]string) (map[string]string, error) {
-	resolved := make(map[string]string)
-
-	for key, value := range envVars {
-		// Check if this is a secret reference or a plain value
-		if strings.HasPrefix(value, "secret_ref:") {
-			// This is a secret reference, resolve it from Infisical
-			secretValue, err := sr.resolveSecretFromInfisical(instanceID, key)
-			if err != nil {
-				sr.logger.Error("Failed to resolve secret from Infisical",
-					slog.String("instance_id", instanceID))
-				return nil, errors.New("failed to resolve secrets for instance")
-			}
-			resolved[key] = secretValue
-		} else {
-			// This is a plain value, use as-is
-			resolved[key] = value
-		}
-	}
-
-	sr.logger.Debug("Resolved secrets for instance",
-		slog.String("instance_id", instanceID),
-		slog.Int("total_vars", len(envVars)),
-		slog.Int("resolved_secrets", len(resolved)))
-
-	return resolved, nil
-}
-
 // resolveSecretFromInfisical retrieves a secret from Infisical using the same pattern as Python service
 func (sr *InfisicalSecretResolver) resolveSecretFromInfisical(instanceID, secretKey string) (string, error) {
 	// Use the same secret key pattern as MCPEnvironmentService in Python:

--- a/agentarea-mcp-manager/internal/secrets/resolver_test.go
+++ b/agentarea-mcp-manager/internal/secrets/resolver_test.go
@@ -97,33 +97,3 @@ func TestDatabaseResolveInstanceEnvVarsHidesSecretIdentifiers(t *testing.T) {
 		}
 	}
 }
-
-func TestDatabaseResolveSecretsHidesSecretIdentifiers(t *testing.T) {
-	const (
-		envName = "PRIVATE_SECRET_KEY"
-		canary  = "dsn=postgres://user:PRIVATE_DB_PASSWORD@host/db"
-	)
-
-	var logs bytes.Buffer
-	resolver := newDatabaseResolverWithFailingDB(&logs, canary)
-	defer resolver.db.Close()
-
-	_, err := resolver.ResolveSecrets("instance-1", map[string]string{
-		envName:      "secret_ref:" + envName,
-		"PLAIN_ONLY": "plain-value",
-	})
-	if err == nil {
-		t.Fatal("ResolveSecrets() error = nil, want error for unreachable database")
-	}
-	if err.Error() != "failed to resolve secrets for instance" {
-		t.Fatalf("ResolveSecrets() error = %q, want the fixed redacted message", err)
-	}
-	for name, value := range map[string]string{"error": err.Error(), "logs": logs.String()} {
-		if strings.Contains(value, envName) {
-			t.Fatalf("%s exposed secret identifier: %s", name, value)
-		}
-		if strings.Contains(value, canary) {
-			t.Fatalf("%s exposed database error text: %s", name, value)
-		}
-	}
-}


### PR DESCRIPTION
## Why

`internal/secrets/database_resolver.go` resolved secrets by name alone:

```sql
SELECT encrypted_value FROM encrypted_secrets WHERE secret_name = $1 LIMIT 1
```

Names are unique only *within* a workspace (`uq_encrypted_secrets_workspace_name`), so a name present in two workspaces returned whichever row the scan reached first — no workspace predicate, no `ORDER BY`.

Nothing exploits this today: the names embed an instance UUID and only platform code mints them. That stops being true as soon as a workspace can name a secret itself, which is the next change on this track (`/v1/secrets`). At that point planting `mcp_instance_<their-uuid>_VAR` injects environment into another tenant's container. This lands first, deliberately.

## What

**Workspace scoping.** The lookup joins `mcp_server_instances` and takes the workspace from the instance being started, so it can only see that workspace's secrets. Go has no `workspace_id` of its own (`internal/models/models.go:105`), and taking one from the event payload would mean trusting a field the platform would have to plumb through — the join reads it from the row instead. The instance is committed before the create event is published (`agentarea_mcp/application/service.py:526` → `:569`), so a real instance always has a row; an unknown instance now resolves to nothing.

Three schema-backed tests cover it, in the CI job that already stands up a migrated database for the gateway's SQL. Against the old query, `TestResolveInstanceEnvVarsPrefersOwnWorkspaceOverSameNamedForeignSecret` returned `attacker-controlled`.

**Fail closed on resolve failure.** `Manager.ResolveSecretEnvVars` logged a resolver error and returned an empty map; the reconcile loop then started the container with the credentials its spec asked for silently missing — healthy-looking, failing later against whatever the secret guarded. The sibling path in `internal/providers` already propagated the error. Now both do, and the loop skips that instance until the next sweep.

**Drop the `secret_ref:` value prefix.** No producer writes it — the two tests covering it drove a stub, which is exactly why they stayed green while the branch was unreachable in production. Removing it takes `ResolveSecrets` out of `SecretResolver` and both implementations with it.

## Operator-visible change

An MCP instance whose secrets cannot be resolved no longer starts. Previously it started without them. The reconcile loop retries on the next sweep, and the error names the instance.

## Testing

- `go test ./...` — 499 pass across 33 packages (`internal/container` run by filter; `TestHandleMCPInstanceCreated_ValidationOnly` shells out to Docker and is unrelated)
- Schema-backed resolver tests against a Postgres migrated to head
- `golangci-lint run ./internal/...` — 0 issues; `gofmt`, `go vet` clean