### PR TITLE
Size button icons from the size variant, not the call site

### DIFF
--- a/agentarea-webapp/src/app/(main)/admin/api-keys/APIKeysClient.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/api-keys/APIKeysClient.tsx
@@ -254,14 +254,13 @@ export default function APIKeysClient({
           <Button
             variant="destructiveOutline"
             size="xs"
-            className="gap-1"
             onClick={(e) => {
               e.stopPropagation();
               setRevokeTarget(item);
               setRevokeOpen(true);
             }}
           >
-            <Trash2 className="h-3.5 w-3.5" />
+            <Trash2 />
             {t("revoke.button")}
           </Button>
         ) : null,
@@ -307,7 +306,7 @@ export default function APIKeysClient({
               disabled={revoking}
             >
               {t("revoke.button")}
-              {revoking && <Loader2 className="h-4 w-4 animate-spin" />}
+              {revoking && <Loader2 className="animate-spin" />}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -335,9 +334,9 @@ export default function APIKeysClient({
                 onClick={handleCopyToken}
               >
                 {copied ? (
-                  <Check className="h-4 w-4 text-green-500" />
+                  <Check className="text-green-500" />
                 ) : (
-                  <Copy className="h-4 w-4" />
+                  <Copy />
                 )}
               </Button>
             </div>

--- a/agentarea-webapp/src/app/(main)/admin/api-keys/components/CreateAPIKeyButton.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/api-keys/components/CreateAPIKeyButton.tsx
@@ -23,12 +23,12 @@ export default function CreateAPIKeyButton() {
   return (
     <>
       <Button
-        className="shrink-0 gap-2"
+        className="shrink-0"
         size="xs"
         onClick={() => setDialogOpen(true)}
         data-test="create-api-key-button"
       >
-        <Plus className="h-4 w-4" />
+        <Plus />
         {t("createKey")}
       </Button>
       <CreateAPIKeyDialog

--- a/agentarea-webapp/src/app/(main)/admin/provider-configs/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/provider-configs/page.tsx
@@ -56,11 +56,11 @@ export default async function ProviderConfigsPage({
         controls: (
           <Link href="/admin/provider-configs/create">
             <Button
-              className="shrink-0 gap-2"
+              className="shrink-0"
               size="xs"
               data-test="new-config-button"
             >
-              <Settings className="mr-2 h-4 w-4" />
+              <Settings />
               {t("createButton")}
             </Button>
           </Link>

--- a/agentarea-webapp/src/app/(main)/admin/providers/page.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/providers/page.tsx
@@ -118,7 +118,7 @@ export default async function ProviderSpecsPage({
             data-test="new-provider-button"
           >
             <Link href="/admin/provider-configs">
-              <PlusCircleIcon className="mr-2 h-4 w-4" />
+              <PlusCircleIcon className="mr-2" />
               {tProviders("addProvider")}
             </Link>
           </Button>

--- a/agentarea-webapp/src/app/(main)/admin/workspace/WorkspaceConfigClient.tsx
+++ b/agentarea-webapp/src/app/(main)/admin/workspace/WorkspaceConfigClient.tsx
@@ -225,7 +225,7 @@ export default function WorkspaceConfigClient() {
               size="sm"
               className="gap-2 mt-4"
             >
-              <Download className="h-4 w-4" />
+              <Download />
               {isExporting ? t("export.exporting") : t("export.button")}
             </Button>
           </div>
@@ -350,7 +350,7 @@ export default function WorkspaceConfigClient() {
               size="sm"
               className="gap-2 w-fit"
             >
-              <Upload className="h-4 w-4" />
+              <Upload />
               {isImporting ? t("import.importing") : t("import.button")}
             </Button>
           </div>

--- a/agentarea-webapp/src/app/(main)/agents/[id]/components/AgentHeaderControls.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/components/AgentHeaderControls.tsx
@@ -32,7 +32,7 @@ export default function AgentHeaderControls() {
           type="button"
           onClick={() => setIsChatSheetOpen(true)}
         >
-          <MessageSquare className="h-4 w-4" />
+          <MessageSquare />
         </Button>
       )}
       <Button size="xs" type="submit" form={formId} isLoading={isSubmitting}>

--- a/agentarea-webapp/src/app/(main)/agents/[id]/edit/components/SkillsSection.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/edit/components/SkillsSection.tsx
@@ -86,9 +86,9 @@ export default function SkillsSection({
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <Button variant="outline" size="sm" className="gap-2">
-              <Plus className="h-4 w-4" />
+              <Plus />
               {t("addSkill")}
-              <ChevronsUpDown className="ml-1 h-4 w-4 shrink-0 opacity-50" />
+              <ChevronsUpDown className="ml-1 shrink-0 opacity-50" />
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-[300px] p-0" align="end">
@@ -172,7 +172,7 @@ export default function SkillsSection({
                 className="h-5 w-5 hover:bg-transparent"
                 onClick={() => handleRemove(skill.id)}
               >
-                <X className="h-3 w-3" />
+                <X />
               </Button>
             </Badge>
           ))}

--- a/agentarea-webapp/src/app/(main)/agents/[id]/payments/components/PaymentHistoryTable.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/payments/components/PaymentHistoryTable.tsx
@@ -225,7 +225,7 @@ export function PaymentHistoryTable({ agentId }: PaymentHistoryTableProps) {
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page <= 1 || loading}
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ChevronLeft />
           </Button>
           <span className="text-sm">
             Page {page} of {totalPages}
@@ -236,7 +236,7 @@ export function PaymentHistoryTable({ agentId }: PaymentHistoryTableProps) {
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={page >= totalPages || loading}
           >
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight />
           </Button>
         </div>
       )}

--- a/agentarea-webapp/src/app/(main)/agents/[id]/tasks/[taskId]/AgentTaskClient.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/[id]/tasks/[taskId]/AgentTaskClient.tsx
@@ -253,7 +253,7 @@ export default function AgentTaskClient({ agent, taskId, task }: Props) {
                     variant="outline"
                     onClick={() => handleTaskAction("pause")}
                   >
-                    <Pause className="mr-2 h-4 w-4" />
+                    <Pause className="mr-2" />
                     Pause
                   </Button>
                 )}
@@ -264,7 +264,7 @@ export default function AgentTaskClient({ agent, taskId, task }: Props) {
                     variant="outline"
                     onClick={() => handleTaskAction("resume")}
                   >
-                    <Play className="mr-2 h-4 w-4" />
+                    <Play className="mr-2" />
                     Resume
                   </Button>
                 )}
@@ -273,7 +273,7 @@ export default function AgentTaskClient({ agent, taskId, task }: Props) {
                   variant="destructive"
                   onClick={() => handleTaskAction("cancel")}
                 >
-                  <Square className="mr-2 h-4 w-4" />
+                  <Square className="mr-2" />
                   Cancel
                 </Button>
               </div>
@@ -320,7 +320,7 @@ export default function AgentTaskClient({ agent, taskId, task }: Props) {
                 />
               </label>
               <Button size="sm" onClick={handleContinue} disabled={continuing}>
-                <Play className="mr-2 h-4 w-4" />
+                <Play className="mr-2" />
                 {continuing ? "Continuing…" : "Continue task"}
               </Button>
             </div>

--- a/agentarea-webapp/src/app/(main)/agents/create/CreateAgentHeaderControls.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/CreateAgentHeaderControls.tsx
@@ -24,7 +24,7 @@ export default function CreateAgentHeaderControls({
           type="button"
           onClick={() => setIsChatSheetOpen(true)}
         >
-          <MessageSquare className="h-4 w-4" />
+          <MessageSquare />
         </Button>
       )}
       <Button size="xs" type="submit" form="agent-form" isLoading={isSubmitting}>

--- a/agentarea-webapp/src/app/(main)/agents/create/components/BuiltinToolIconGrid.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/components/BuiltinToolIconGrid.tsx
@@ -234,9 +234,9 @@ export const BuiltinToolIconGrid = ({
                             }}
                           >
                             {isExpanded ? (
-                              <ChevronUp className="h-3 w-3" />
+                              <ChevronUp />
                             ) : (
-                              <ChevronDown className="h-3 w-3" />
+                              <ChevronDown />
                             )}
                           </Button>
                         )}

--- a/agentarea-webapp/src/app/(main)/agents/create/components/SkillsConfig.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/components/SkillsConfig.tsx
@@ -159,7 +159,7 @@ const SkillsConfig = ({
                         className="h-4 w-4 flex-shrink-0 text-muted-foreground/60 hover:bg-transparent hover:text-red-500"
                         aria-label="Remove Skill"
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 />
                       </Button>
                     </div>
                   }

--- a/agentarea-webapp/src/app/(main)/agents/create/components/ToolConfig.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/components/ToolConfig.tsx
@@ -1048,7 +1048,7 @@ const ToolConfig = ({
                           strokeWidth="2"
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          className="h-4 w-4"
+                         
                         >
                           <path d="M3 6h18" />
                           <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />

--- a/agentarea-webapp/src/app/(main)/agents/create/components/TriggerControl.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/create/components/TriggerControl.tsx
@@ -152,7 +152,7 @@ export const TriggerControl = ({
         className="h-4 w-4 flex-shrink-0 text-muted-foreground/60 hover:bg-transparent hover:text-primary"
         aria-label="Edit Event"
       >
-        <Edit className="h-4 w-4" />
+        <Edit />
       </Button>
     );
   };
@@ -168,7 +168,7 @@ export const TriggerControl = ({
         className="h-4 w-4 flex-shrink-0 text-muted-foreground/60 hover:bg-transparent hover:text-red-500"
         aria-label="Remove Event"
       >
-        <Trash2 className="h-4 w-4" />
+        <Trash2 />
       </Button>
     );
   };

--- a/agentarea-webapp/src/app/(main)/agents/page.tsx
+++ b/agentarea-webapp/src/app/(main)/agents/page.tsx
@@ -54,11 +54,11 @@ export default async function AgentsBrowsePage({
         controls: (
           <Link href="/agents/create">
             <Button
-              className="shrink-0 gap-2"
+              className="shrink-0"
               size="xs"
               data-test="deploy-button"
             >
-              <Plus className="h-5 w-5" />
+              <Plus />
               {t("deployNewAgent")}
             </Button>
           </Link>

--- a/agentarea-webapp/src/app/(main)/bundles/components/BundleInstallWizard.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/BundleInstallWizard.tsx
@@ -886,7 +886,7 @@ function ModelPicker({
             ) : (
               <span className="truncate text-muted-foreground">Select a model</span>
             )}
-            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+            <ChevronsUpDown className="shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent

--- a/agentarea-webapp/src/app/(main)/bundles/components/ImportWizard.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/ImportWizard.tsx
@@ -511,7 +511,7 @@ export default function ImportWizard({ initialSrc }: { initialSrc?: string } = {
         {/* Actions */}
         <div className="flex items-center gap-3 pt-1">
           <Button onClick={handleReset} variant="outline">
-            <RotateCcw className="h-4 w-4" />
+            <RotateCcw />
             Import another
           </Button>
           <Button asChild>

--- a/agentarea-webapp/src/app/(main)/clients/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/clients/[id]/page.tsx
@@ -87,9 +87,9 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
       aria-label={`Copy ${label ?? "value"}`}
     >
       {copied ? (
-        <Check className="h-4 w-4 text-green-500" />
+        <Check className="text-green-500" />
       ) : (
-        <Copy className="h-4 w-4" />
+        <Copy />
       )}
     </Button>
   );
@@ -164,7 +164,7 @@ function ScopeSection({
           </span>
         </div>
         <Button size="xs" variant="outline" onClick={() => setShowAdd(true)}>
-          <Plus className="mr-1 h-3.5 w-3.5" />
+          <Plus className="mr-1" />
           {addLabel}
         </Button>
       </div>
@@ -188,9 +188,9 @@ function ScopeSection({
                 disabled={removingId === String(item.id)}
               >
                 {removingId === String(item.id) ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Loader2 className="animate-spin" />
                 ) : (
-                  <Trash2 className="h-3.5 w-3.5" />
+                  <Trash2 />
                 )}
               </Button>
             </li>
@@ -230,7 +230,7 @@ function ScopeSection({
               onClick={handleAdd}
               disabled={!selectedId || adding || available.length === 0}
             >
-              {adding ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {adding ? <Loader2 className="mr-2 animate-spin" /> : null}
               Add
             </Button>
           </DialogFooter>
@@ -402,7 +402,7 @@ export default function ClientDetailPage() {
         controls: (
           <div className="flex items-center gap-1.5">
             <Button size="xs" variant="outline" onClick={openEdit}>
-              <Pencil className="mr-1 h-3.5 w-3.5" />
+              <Pencil className="mr-1" />
               Edit
             </Button>
             <Button
@@ -412,7 +412,7 @@ export default function ClientDetailPage() {
               onClick={() => setShowDelete(true)}
               aria-label="Delete client"
             >
-              <Trash2 className="h-3.5 w-3.5" />
+              <Trash2 />
             </Button>
           </div>
         ),
@@ -556,7 +556,7 @@ export default function ClientDetailPage() {
               Cancel
             </Button>
             <Button onClick={handleSave} disabled={!editName.trim() || saving}>
-              {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {saving ? <Loader2 className="mr-2 animate-spin" /> : null}
               Save
             </Button>
           </DialogFooter>
@@ -584,7 +584,7 @@ export default function ClientDetailPage() {
               disabled={deleting}
             >
               {deleting ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="mr-2 animate-spin" />
               ) : null}
               Delete
             </Button>

--- a/agentarea-webapp/src/app/(main)/clients/page.tsx
+++ b/agentarea-webapp/src/app/(main)/clients/page.tsx
@@ -181,8 +181,8 @@ export default function ClientsPage() {
         breadcrumb: [{ label: "Clients" }],
         description: "Agent-proxies: scoped MCP + skill bundles for external harnesses (codex, claude-code)",
         controls: (
-          <Button className="shrink-0 gap-2" size="xs" onClick={() => setShowCreate(true)}>
-            <Plus className="h-5 w-5" />
+          <Button className="shrink-0" size="xs" onClick={() => setShowCreate(true)}>
+            <Plus />
             New Client
           </Button>
         ),
@@ -276,7 +276,7 @@ export default function ClientsPage() {
               Cancel
             </Button>
             <Button onClick={handleCreate} disabled={!name.trim() || creating}>
-              {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {creating ? <Loader2 className="mr-2 animate-spin" /> : null}
               Create
             </Button>
           </DialogFooter>

--- a/agentarea-webapp/src/app/(main)/connections/[id]/MCPInstanceDetail.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/[id]/MCPInstanceDetail.tsx
@@ -86,9 +86,9 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
   return (
     <Button variant="outline" size="xs" onClick={handleCopy}>
       {copied ? (
-        <Check className="h-4 w-4 text-green-500" />
+        <Check className="text-green-500" />
       ) : (
-        <Copy className="h-4 w-4" />
+        <Copy />
       )}
     </Button>
   );
@@ -534,7 +534,7 @@ export default function MCPInstanceDetail({
                         size="xs"
                         onClick={() => setIsEditingConfig(true)}
                       >
-                        <Pencil className="h-3 w-3 mr-1" /> Edit
+                        <Pencil className="mr-1" /> Edit
                       </Button>
                     )}
                   </div>
@@ -659,7 +659,7 @@ export default function MCPInstanceDetail({
                     disabled={isRefreshingTools}
                   >
                     <RefreshCw
-                      className={`mr-1.5 h-3.5 w-3.5 ${isRefreshingTools ? "animate-spin" : ""}`}
+                      className={`mr-1.5 ${isRefreshingTools ? "animate-spin" : ""}`}
                     />
                     Refresh
                   </Button>
@@ -680,7 +680,7 @@ export default function MCPInstanceDetail({
                   disabled={isRefreshingTools}
                 >
                   <RefreshCw
-                    className={`mr-1.5 h-3.5 w-3.5 ${isRefreshingTools ? "animate-spin" : ""}`}
+                    className={`mr-1.5 ${isRefreshingTools ? "animate-spin" : ""}`}
                   />
                   Discover Tools
                 </Button>

--- a/agentarea-webapp/src/app/(main)/connections/add-openapi/form.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/add-openapi/form.tsx
@@ -436,7 +436,7 @@ export function AddOpenAPIForm() {
                 size="xs"
                 onClick={addHeader}
               >
-                <Plus className="mr-1 h-3 w-3" />
+                <Plus className="mr-1" />
                 {t("addHeader")}
               </Button>
             </div>
@@ -477,7 +477,7 @@ export function AddOpenAPIForm() {
                     size="xs"
                     onClick={() => removeHeader(i)}
                   >
-                    <Trash2 className="h-3.5 w-3.5" />
+                    <Trash2 />
                   </Button>
                 </div>
               );

--- a/agentarea-webapp/src/app/(main)/connections/add/form.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/add/form.tsx
@@ -602,7 +602,7 @@ export function AddMCPServerForm() {
                 size="sm"
                 onClick={() => appendEnv({ key: "", value: "", secret: true })}
               >
-                <Plus className="mr-2 h-4 w-4" />
+                <Plus className="mr-2" />
                 Add variable
               </Button>
             </div>
@@ -630,9 +630,9 @@ export function AddMCPServerForm() {
                     onClick={() => setValue(`env.${index}.secret`, !isSecret)}
                   >
                     {isSecret ? (
-                      <Lock className="h-4 w-4" />
+                      <Lock />
                     ) : (
-                      <LockOpen className="h-4 w-4" />
+                      <LockOpen />
                     )}
                   </Button>
                   <Button
@@ -641,7 +641,7 @@ export function AddMCPServerForm() {
                     size="sm"
                     onClick={() => removeEnv(index)}
                   >
-                    <X className="h-4 w-4" />
+                    <X />
                   </Button>
                 </div>
               );
@@ -687,7 +687,7 @@ export function AddMCPServerForm() {
                   size="sm"
                   onClick={() => append({ key: "", value: "" })}
                 >
-                  <Plus className="mr-2 h-4 w-4" />
+                  <Plus className="mr-2" />
                   Add Header
                 </Button>
               </div>
@@ -710,7 +710,7 @@ export function AddMCPServerForm() {
                     size="sm"
                     onClick={() => remove(index)}
                   >
-                    <X className="h-4 w-4" />
+                    <X />
                   </Button>
                 </div>
               ))}

--- a/agentarea-webapp/src/app/(main)/connections/components/AddConnectionDropdown.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/components/AddConnectionDropdown.tsx
@@ -75,11 +75,11 @@ export function AddConnectionDropdown() {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
-          className="shrink-0 gap-2"
+          className="shrink-0"
           size="xs"
           data-test="new-connection-button"
         >
-          <Plus className="mr-1 h-4 w-4" />
+          <Plus />
           {t("trigger")}
         </Button>
       </DialogTrigger>

--- a/agentarea-webapp/src/app/(main)/connections/components/CustomHeadersEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/components/CustomHeadersEditor.tsx
@@ -71,7 +71,7 @@ export function CustomHeadersEditor({
       <div className="flex items-center justify-between">
         <Label>{t("editHeaders")}</Label>
         <Button type="button" variant="outline" size="xs" onClick={addRow}>
-          <Plus className="mr-1 h-3 w-3" />
+          <Plus className="mr-1" />
           {t("addHeader")}
         </Button>
       </div>
@@ -103,7 +103,7 @@ export function CustomHeadersEditor({
               </div>
             </div>
             <Button type="button" variant="ghost" size="xs" onClick={() => removeRow(i)}>
-              <Trash2 className="h-3.5 w-3.5" />
+              <Trash2 />
             </Button>
           </div>
         );

--- a/agentarea-webapp/src/app/(main)/connections/openapi/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/openapi/[id]/page.tsx
@@ -185,7 +185,7 @@ export default function OpenAPIConnectionDetailPage() {
                 disabled={discovering}
               >
                 <RefreshCw
-                  className={`mr-1 h-3.5 w-3.5 ${discovering ? "animate-spin" : ""}`}
+                  className={`mr-1 ${discovering ? "animate-spin" : ""}`}
                 />
                 {discovering ? "Refreshing..." : "Refresh from Spec URL"}
               </Button>
@@ -196,7 +196,7 @@ export default function OpenAPIConnectionDetailPage() {
               onClick={handleDelete}
               disabled={deleting}
             >
-              <Trash2 className="mr-1 h-3.5 w-3.5" />
+              <Trash2 className="mr-1" />
               {deleting ? "Deleting..." : "Delete"}
             </Button>
           </div>
@@ -271,7 +271,7 @@ export default function OpenAPIConnectionDetailPage() {
                   variant="outline"
                   onClick={() => setEditingHeaders(true)}
                 >
-                  <Pencil className="mr-1 h-3 w-3" />
+                  <Pencil className="mr-1" />
                   {connection.custom_headers &&
                   connection.custom_headers.length > 0
                     ? "Edit"

--- a/agentarea-webapp/src/app/(main)/dashboard/components/AgentRows.tsx
+++ b/agentarea-webapp/src/app/(main)/dashboard/components/AgentRows.tsx
@@ -81,7 +81,7 @@ export function AgentRows({ agents }: { agents: DashboardAgentRow[] }) {
             <Button asChild variant="ghost" size="xs" className="text-muted-foreground">
               <Link href="/agents">
                 {t("viewAllAgents")}
-                <ArrowUpRight className="h-3.5 w-3.5" />
+                <ArrowUpRight />
               </Link>
             </Button>
           }

--- a/agentarea-webapp/src/app/(main)/files/page.tsx
+++ b/agentarea-webapp/src/app/(main)/files/page.tsx
@@ -96,9 +96,9 @@ export default function WorkspaceFilesPage() {
               disabled={uploading}
             >
               {uploading ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                <Loader2 className="mr-1.5 animate-spin" />
               ) : (
-                <Upload className="mr-1.5 h-3.5 w-3.5" />
+                <Upload className="mr-1.5" />
               )}
               Upload File
             </Button>

--- a/agentarea-webapp/src/app/(main)/invite/InviteClient.tsx
+++ b/agentarea-webapp/src/app/(main)/invite/InviteClient.tsx
@@ -65,7 +65,7 @@ export default function InviteClient({ token }: { token: string | null }) {
                 onClick={handleAccept}
                 disabled={isPending}
               >
-                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isPending && <Loader2 className="mr-2 animate-spin" />}
                 {t("acceptButton")}
               </Button>
             </>

--- a/agentarea-webapp/src/app/(main)/members/MembersClient.tsx
+++ b/agentarea-webapp/src/app/(main)/members/MembersClient.tsx
@@ -206,7 +206,7 @@ export default function MembersClient({
             </p>
           </div>
           <Button size="sm" className="gap-1.5" onClick={openInvite}>
-            <UserPlus className="h-4 w-4" />
+            <UserPlus />
             {t("invitePeople")}
           </Button>
         </div>
@@ -270,9 +270,9 @@ export default function MembersClient({
                           onClick={() => handleRemove(m.user_id)}
                         >
                           {isPending && busyId === m.user_id ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
+                            <Loader2 className="animate-spin" />
                           ) : (
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 />
                           )}
                           <span className="ml-1">
                             {isSelf ? t("leave") : t("remove")}
@@ -342,9 +342,9 @@ export default function MembersClient({
                         onClick={() => handleRevoke(inv.id)}
                       >
                         {isPending && busyId === inv.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <Loader2 className="animate-spin" />
                         ) : (
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 />
                         )}
                         <span className="ml-1">{t("revoke")}</span>
                       </Button>
@@ -378,9 +378,9 @@ export default function MembersClient({
                   onClick={handleCopy}
                 >
                   {copied ? (
-                    <Check className="h-4 w-4 text-green-600" />
+                    <Check className="text-green-600" />
                   ) : (
-                    <Copy className="h-4 w-4" />
+                    <Copy />
                   )}
                 </Button>
               </div>
@@ -420,7 +420,7 @@ export default function MembersClient({
               <Button onClick={() => setInviteOpen(false)}>{t("done")}</Button>
             ) : (
               <Button onClick={handleCreate} disabled={isPending}>
-                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isPending && <Loader2 className="mr-2 animate-spin" />}
                 {t("createInvite")}
               </Button>
             )}

--- a/agentarea-webapp/src/app/(main)/network/NetworkClient.tsx
+++ b/agentarea-webapp/src/app/(main)/network/NetworkClient.tsx
@@ -75,7 +75,7 @@ export function NetworkHeaderControls() {
         className="h-7 w-7 text-muted-foreground"
         aria-label="Refresh topology"
       >
-        <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+        <RefreshCw className={loading ? "animate-spin" : ""} />
       </Button>
     </div>
   );

--- a/agentarea-webapp/src/app/(main)/network/components/NetworkToolbar.tsx
+++ b/agentarea-webapp/src/app/(main)/network/components/NetworkToolbar.tsx
@@ -40,7 +40,7 @@ export default function NetworkToolbar({
           className={`gap-1 text-xs h-7 px-2 ${!filters[key] ? "opacity-40" : ""}`}
           aria-label={`Toggle ${label}`}
         >
-          <Icon className={`h-3.5 w-3.5 ${color}`} />
+          <Icon className={color} />
           {label}
         </Button>
       ))}
@@ -55,7 +55,7 @@ export default function NetworkToolbar({
           className="gap-1 text-xs h-7 px-2"
           aria-label="Toggle governance"
         >
-          <Shield className="h-3.5 w-3.5" />
+          <Shield />
           Gov
         </Button>
       )}
@@ -67,7 +67,7 @@ export default function NetworkToolbar({
         onClick={onRefresh}
         disabled={loading}
       >
-        <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+        <RefreshCw className={loading ? "animate-spin" : ""} />
       </Button>
     </div>
   );

--- a/agentarea-webapp/src/app/(main)/network/components/NodeDetailDrawer.tsx
+++ b/agentarea-webapp/src/app/(main)/network/components/NodeDetailDrawer.tsx
@@ -476,7 +476,7 @@ export default function NodeDetailDrawer({
             className="h-7 w-7 -mr-1 shrink-0"
             onClick={onClose}
           >
-            <X className="h-3.5 w-3.5" />
+            <X />
           </Button>
         </div>
 

--- a/agentarea-webapp/src/app/(main)/network/components/NodeDetailPanel.tsx
+++ b/agentarea-webapp/src/app/(main)/network/components/NodeDetailPanel.tsx
@@ -46,7 +46,7 @@ export default function NodeDetailPanel({
           </div>
         </div>
         <Button variant="ghost" size="icon" className="h-6 w-6 -mr-1" onClick={onClose}>
-          <X className="h-3.5 w-3.5" />
+          <X />
         </Button>
       </div>
 

--- a/agentarea-webapp/src/app/(main)/policies/components/PoliciesHeaderControls.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PoliciesHeaderControls.tsx
@@ -8,7 +8,7 @@ export default function PoliciesHeaderControls() {
   return (
     <Button size="sm" className="shrink-0 gap-2" asChild>
       <Link href="/policies/new">
-        <Plus className="h-4 w-4" />
+        <Plus />
         New policy
       </Link>
     </Button>

--- a/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/PolicyEditor.tsx
@@ -1635,7 +1635,7 @@ export default function PolicyEditor({
                   onClick={addSelectedAgent}
                   aria-label="Add agent"
                 >
-                  <Plus className="h-4 w-4" />
+                  <Plus />
                 </Button>
               </div>
 
@@ -1658,7 +1658,7 @@ export default function PolicyEditor({
                         onClick={() => removeSelectedAgent(agent.id)}
                         aria-label={`Remove ${agent.name}`}
                       >
-                        <X className="h-4 w-4" />
+                        <X />
                       </Button>
                     </div>
                   ))
@@ -1730,7 +1730,7 @@ export default function PolicyEditor({
                             }}
                             aria-label={`Remove rule ${index + 1}`}
                           >
-                            <X className="h-4 w-4" />
+                            <X />
                           </Button>
                         )}
                       </div>
@@ -1746,7 +1746,7 @@ export default function PolicyEditor({
                   size="sm"
                   onClick={addDraft}
                 >
-                  <Plus className="mr-1.5 h-4 w-4" />
+                  <Plus className="mr-1.5" />
                   Add rule
                 </Button>
               )}

--- a/agentarea-webapp/src/app/(main)/policies/components/access/AccessControlHeaderControls.tsx
+++ b/agentarea-webapp/src/app/(main)/policies/components/access/AccessControlHeaderControls.tsx
@@ -15,7 +15,7 @@ export default function AccessControlHeaderControls() {
 
   return (
     <Button size="sm" className="shrink-0 gap-2" onClick={handleClick}>
-      <Plus className="h-4 w-4" />
+      <Plus />
       New rule
     </Button>
   );

--- a/agentarea-webapp/src/app/(main)/projects/[id]/components/AssociationSection.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/components/AssociationSection.tsx
@@ -121,7 +121,7 @@ export function AssociationSection({
         className="mt-4 w-full border-dashed bg-muted/20 hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
         onClick={() => setShowAddDialog(true)}
       >
-        <Plus className="mr-1.5 h-3.5 w-3.5" />
+        <Plus className="mr-1.5" />
         {addLabel}
       </Button>
 
@@ -148,9 +148,9 @@ export function AssociationSection({
                 disabled={removingId === item.id}
               >
                 {removingId === item.id ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Loader2 className="animate-spin" />
                 ) : (
-                  <Trash2 className="h-3.5 w-3.5" />
+                  <Trash2 />
                 )}
               </Button>
             </li>
@@ -192,7 +192,7 @@ export function AssociationSection({
               disabled={!selectedId || isAdding || available.length === 0}
             >
               {isAdding ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="mr-2 animate-spin" />
               ) : null}
               Add
             </Button>

--- a/agentarea-webapp/src/app/(main)/projects/[id]/files/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/files/page.tsx
@@ -123,9 +123,9 @@ export default function ProjectFilesPage() {
           disabled={uploading}
         >
           {uploading ? (
-            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            <Loader2 className="mr-1.5 animate-spin" />
           ) : (
-            <Upload className="mr-1.5 h-3.5 w-3.5" />
+            <Upload className="mr-1.5" />
           )}
           Upload File
         </Button>

--- a/agentarea-webapp/src/app/(main)/projects/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/page.tsx
@@ -222,7 +222,7 @@ export default function ProjectOverviewPage() {
                 >
                   <Link href={`/projects/${projectId}/settings`}>
                     Edit
-                    <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+                    <ArrowUpRight className="ml-1" />
                   </Link>
                 </Button>
               </div>

--- a/agentarea-webapp/src/app/(main)/projects/[id]/settings/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/[id]/settings/page.tsx
@@ -113,7 +113,7 @@ export default function ProjectSettingsPage() {
         </div>
         <div className="flex justify-end">
           <Button type="submit" size="xs" disabled={saving}>
-            {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {saving ? <Loader2 className="mr-2 animate-spin" /> : null}
             Save Changes
           </Button>
         </div>

--- a/agentarea-webapp/src/app/(main)/projects/page.tsx
+++ b/agentarea-webapp/src/app/(main)/projects/page.tsx
@@ -30,8 +30,8 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
         description: "Organize agents, skills, and tools into projects",
         controls: (
           <Link href="/projects/create">
-            <Button className="shrink-0 gap-2" size="xs">
-              <Plus className="h-5 w-5" />
+            <Button className="shrink-0" size="xs">
+              <Plus />
               New Project
             </Button>
           </Link>

--- a/agentarea-webapp/src/app/(main)/settings/SettingsClient.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/SettingsClient.tsx
@@ -44,7 +44,7 @@ export default function SettingsClient() {
             size="sm"
             className="gap-1"
           >
-            <LogOut className="h-3 w-3" />
+            <LogOut />
             {t("logout")}
           </Button>
         ),

--- a/agentarea-webapp/src/app/(main)/settings/audit/AuditLogClient.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/audit/AuditLogClient.tsx
@@ -246,7 +246,7 @@ export default function AuditLogClient({
             disabled={isPending}
           >
             {isPending ? (
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              <Loader2 className="mr-2 animate-spin" />
             ) : null}
             {t("loadMore")}
           </Button>

--- a/agentarea-webapp/src/app/(main)/settings/billing/BillingClient.tsx
+++ b/agentarea-webapp/src/app/(main)/settings/billing/BillingClient.tsx
@@ -154,9 +154,9 @@ function CloudBillingPreview({
           </div>
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row lg:flex-col">
             <Button onClick={() => window.open(CLOUD_URL, "_blank")}>
-              <Cloud className="h-4 w-4" />
+              <Cloud />
               {t("cloudBilling.openCloud")}
-              <ExternalLink className="h-3.5 w-3.5" />
+              <ExternalLink />
             </Button>
             <Button
               variant="outline"
@@ -167,7 +167,7 @@ function CloudBillingPreview({
                 )
               }
             >
-              <Users className="h-4 w-4" />
+              <Users />
               {t("cloudBilling.contactSales")}
             </Button>
           </div>
@@ -366,9 +366,9 @@ function CloudMigrationPanel() {
           </div>
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row lg:flex-col">
             <Button onClick={() => window.open(CLOUD_URL, "_blank")}>
-              <Cloud className="h-4 w-4" />
+              <Cloud />
               {t("cloudMigration.openCloud")}
-              <ExternalLink className="h-3.5 w-3.5" />
+              <ExternalLink />
             </Button>
             <Button
               variant="outline"
@@ -379,7 +379,7 @@ function CloudMigrationPanel() {
                 )
               }
             >
-              <Users className="h-4 w-4" />
+              <Users />
               {t("cloudMigration.contactSales")}
             </Button>
           </div>
@@ -705,7 +705,7 @@ function PlanCard({
               window.open("https://agentarea.ai/pricing", "_blank")
             }
           >
-            <Sparkles className="h-3 w-3 mr-1.5" />
+            <Sparkles className="mr-1.5" />
             {t("availablePlans.setUpBilling")}
           </Button>
         )}

--- a/agentarea-webapp/src/app/(main)/skills/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/[id]/page.tsx
@@ -411,9 +411,9 @@ export default function SkillDetailPage() {
                 disabled={installing}
               >
                 {installing ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="mr-2 animate-spin" />
                 ) : (
-                  <Plus className="mr-2 h-4 w-4" />
+                  <Plus className="mr-2" />
                 )}
                 {installing ? tDetail("installing") : tDetail("customize")}
               </Button>
@@ -426,9 +426,9 @@ export default function SkillDetailPage() {
                   disabled={!hasChanges || saving}
                 >
                   {saving ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 className="mr-2 animate-spin" />
                   ) : (
-                    <Save className="mr-2 h-4 w-4" />
+                    <Save className="mr-2" />
                   )}
                   {tDetail("save")}
                 </Button>
@@ -469,9 +469,9 @@ export default function SkillDetailPage() {
                       disabled={saving}
                     >
                       {saving ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <Loader2 className="mr-2 animate-spin" />
                       ) : (
-                        <Save className="mr-2 h-4 w-4" />
+                        <Save className="mr-2" />
                       )}
                       {tDetail("save")}
                     </Button>
@@ -486,9 +486,9 @@ export default function SkillDetailPage() {
                       disabled={installing}
                     >
                       {installing ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <Loader2 className="mr-2 animate-spin" />
                       ) : (
-                        <Plus className="mr-2 h-4 w-4" />
+                        <Plus className="mr-2" />
                       )}
                       {installing
                         ? tDetail("installing")
@@ -602,7 +602,7 @@ export default function SkillDetailPage() {
               variant="outline"
               onClick={() => setShowAddChildDialog(true)}
             >
-              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              <Plus className="mr-1.5" />
               Add Child Skill
             </Button>
           </div>
@@ -625,9 +625,9 @@ export default function SkillDetailPage() {
                     disabled={removingChildId === child.id}
                   >
                     {removingChildId === child.id ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      <Loader2 className="animate-spin" />
                     ) : (
-                      <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                      <Trash2 className="text-destructive" />
                     )}
                   </Button>
                 </li>
@@ -675,7 +675,7 @@ export default function SkillDetailPage() {
               disabled={!addingChildId || isAddingChild}
             >
               {isAddingChild ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="mr-2 animate-spin" />
               ) : null}
               Add
             </Button>

--- a/agentarea-webapp/src/app/(main)/skills/components/CreateSkillButton.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/components/CreateSkillButton.tsx
@@ -10,13 +10,13 @@ export default function CreateSkillButton() {
 
   return (
     <Button
-      className="shrink-0 gap-2"
+      className="shrink-0"
       size="xs"
       asChild
       data-test="new-skill-button"
     >
       <Link href="/skills/create">
-        <Plus className="mr-2 h-4 w-4" />
+        <Plus />
         {t("addSkill")}
       </Link>
     </Button>

--- a/agentarea-webapp/src/app/(main)/skills/create/CreateSkillForm.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/create/CreateSkillForm.tsx
@@ -545,7 +545,7 @@ export function CreateSkillForm() {
               size="sm"
               onClick={useTemplate}
             >
-              <FilePlus className="h-3.5 w-3.5" />
+              <FilePlus />
               {tCreate("useTemplate")}
             </Button>
             <SegPill<ViewMode>
@@ -658,7 +658,7 @@ export function CreateSkillForm() {
               autoComplete="off"
             />
             <Button type="submit" variant="outline" size="sm" className="h-10">
-              <Search className="h-3.5 w-3.5" />
+              <Search />
               {tCreate("browseRepo")}
             </Button>
           </div>

--- a/agentarea-webapp/src/app/(main)/skills/create/page.tsx
+++ b/agentarea-webapp/src/app/(main)/skills/create/page.tsx
@@ -21,7 +21,7 @@ export default function CreateSkillPage() {
               <Link href="/skills">{t("cancel")}</Link>
             </Button>
             <Button size="xs" type="submit" form="create-skill-form">
-              <Plus className="h-3.5 w-3.5" />
+              <Plus />
               {t("createSkill")}
             </Button>
           </div>

--- a/agentarea-webapp/src/app/(main)/tasks/TasksFilters.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/TasksFilters.tsx
@@ -133,7 +133,7 @@ export function TasksFilters({
               onClick={clearFilters}
               className="h-12 gap-2 rounded-xl border-gray-200 px-4 transition-colors duration-200 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
             >
-              <X className="h-4 w-4" />
+              <X />
               <span className="hidden sm:inline">{t("clearFilters")}</span>
             </Button>
           )}

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/artifacts/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/artifacts/page.tsx
@@ -74,7 +74,7 @@ export default function TaskArtifactsPage() {
           variant="outline"
           onClick={() => void loadArtifacts()}
         >
-          <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+          <RefreshCw className="mr-1.5" />
           Refresh
         </Button>
       </div>
@@ -99,7 +99,7 @@ export default function TaskArtifactsPage() {
               </div>
               <Button variant="outline" size="sm" className="gap-1" asChild>
                 <a href={`/api/proxy${artifact.download_url}`}>
-                  <Download className="h-4 w-4" />
+                  <Download />
                   Download
                 </a>
               </Button>

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/components/TaskHeader.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/components/TaskHeader.tsx
@@ -137,17 +137,15 @@ export default function TaskHeader({
           onClick={onRefresh}
           disabled={refreshing}
         >
-          <RefreshCw
-            className={`h-3 w-3 ${refreshing ? "animate-spin" : ""}`}
-          />
+          <RefreshCw className={refreshing ? "animate-spin" : ""} />
           Refresh
         </Button>
         <Button variant="outline" size="sm" className="gap-1">
-          <Download className="h-3 w-3" />
+          <Download />
           Export
         </Button>
         <Button variant="outline" size="sm" className="gap-1">
-          <Share2 className="h-3 w-3" />
+          <Share2 />
           Share
         </Button>
       </div>

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/events/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/events/page.tsx
@@ -171,7 +171,7 @@ export default function TaskEventsPage() {
             disabled={eventsLoading}
           >
             <RefreshCw
-              className={`h-3 w-3 mr-1 ${eventsLoading ? "animate-spin" : ""}`}
+              className={`mr-1 ${eventsLoading ? "animate-spin" : ""}`}
             />
             Refresh
           </Button>

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/files/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/files/page.tsx
@@ -100,7 +100,7 @@ export default function TaskFilesPage() {
           </p>
         </div>
         <Button size="xs" variant="outline" onClick={() => void loadFiles()}>
-          <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+          <RefreshCw className="mr-1.5" />
           Refresh
         </Button>
       </div>

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/page.tsx
@@ -389,9 +389,9 @@ export default function TaskDetailsPage() {
                   </label>
                   <Button onClick={handleContinueTask} disabled={continuing}>
                     {continuing ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="mr-2 animate-spin" />
                     ) : (
-                      <Play className="mr-2 h-4 w-4" />
+                      <Play className="mr-2" />
                     )}
                     Continue task
                   </Button>
@@ -480,12 +480,12 @@ export default function TaskDetailsPage() {
             >
               {controlling ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="mr-2 animate-spin" />
                   Cancelling...
                 </>
               ) : (
                 <>
-                  <X className="mr-2 h-4 w-4" />
+                  <X className="mr-2" />
                   Cancel Task
                 </>
               )}

--- a/agentarea-webapp/src/app/(main)/triggers/[id]/TriggerDetail.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/[id]/TriggerDetail.tsx
@@ -54,9 +54,9 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
   return (
     <Button variant="outline" size="xs" onClick={handleCopy}>
       {copied ? (
-        <Check className="h-4 w-4 text-green-500" />
+        <Check className="text-green-500" />
       ) : (
-        <Copy className="h-4 w-4" />
+        <Copy />
       )}
     </Button>
   );

--- a/agentarea-webapp/src/app/(main)/triggers/components/CreateTriggerButton.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/components/CreateTriggerButton.tsx
@@ -10,13 +10,13 @@ export default function CreateTriggerButton() {
 
   return (
     <Button
-      className="shrink-0 gap-2"
+      className="shrink-0"
       size="xs"
       asChild
       data-test="new-trigger-button"
     >
       <Link href="/triggers/create">
-        <Plus className="mr-2 h-4 w-4" />
+        <Plus />
         {t("createTrigger")}
       </Link>
     </Button>

--- a/agentarea-webapp/src/app/(main)/triggers/create/CreateTriggerForm.tsx
+++ b/agentarea-webapp/src/app/(main)/triggers/create/CreateTriggerForm.tsx
@@ -303,7 +303,7 @@ export function CreateTriggerForm({
         className="h-4 w-4 shrink-0 text-muted-foreground hover:bg-transparent hover:text-destructive"
         onClick={() => onRemove(resource.id)}
       >
-        <X className="h-3 w-3" />
+        <X />
       </Button>
     </div>
   );

--- a/agentarea-webapp/src/components/BaseModal/BaseModal.tsx
+++ b/agentarea-webapp/src/components/BaseModal/BaseModal.tsx
@@ -166,7 +166,7 @@ export default function BaseModal({
             variant={type === "delete" ? "destructive" : "default"}
           >
             {type === "delete" ? tCommon("delete") : tCommon("confirm")}
-            {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+            {isLoading && <Loader2 className="animate-spin" />}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/agentarea-webapp/src/components/CatalogSuggestions.tsx
+++ b/agentarea-webapp/src/components/CatalogSuggestions.tsx
@@ -92,7 +92,7 @@ export default function CatalogSuggestions({
         <Button asChild variant="outline">
           <Link href={`/explore?type=${type}`}>
             Browse the catalog
-            <ArrowRight className="h-4 w-4" />
+            <ArrowRight />
           </Link>
         </Button>
       </div>

--- a/agentarea-webapp/src/components/Chat/AgentChat.tsx
+++ b/agentarea-webapp/src/components/Chat/AgentChat.tsx
@@ -189,7 +189,7 @@ export default function AgentChat({
             size="sm"
             className="h-8 w-8 rounded-full bg-white text-text shadow-lg hover:text-white dark:bg-zinc-900 dark:text-zinc-200"
           >
-            <ChevronDown className="h-4 w-4" />
+            <ChevronDown />
           </Button>
         </div>
       </CardContent>

--- a/agentarea-webapp/src/components/Chat/WorkplaceOnboarding.tsx
+++ b/agentarea-webapp/src/components/Chat/WorkplaceOnboarding.tsx
@@ -53,7 +53,7 @@ export function WorkplaceOnboarding({
           >
             <Link href={primaryHref}>
               {primaryLabel}
-              <ArrowRight className="h-3 w-3" />
+              <ArrowRight />
             </Link>
           </Button>
         </div>
@@ -83,10 +83,10 @@ export function WorkplaceOnboarding({
               disabled
               className="h-8 w-8 text-muted-foreground"
             >
-              <Paperclip className="h-4 w-4" />
+              <Paperclip />
             </Button>
             <Button disabled size="icon" className="h-8 w-8">
-              <Send className="h-4 w-4" />
+              <Send />
             </Button>
           </div>
         </div>

--- a/agentarea-webapp/src/components/Chat/componets/ApprovalRequestMessage.tsx
+++ b/agentarea-webapp/src/components/Chat/componets/ApprovalRequestMessage.tsx
@@ -108,7 +108,7 @@ const ApprovalRequestMessage: React.FC<Props> = ({ data }) => {
                 onClick={handleApprove}
                 className="bg-green-600 hover:bg-green-700"
               >
-                <Check className="mr-1 h-3 w-3" />
+                <Check className="mr-1" />
                 {t("approve")}
               </Button>
 
@@ -119,7 +119,7 @@ const ApprovalRequestMessage: React.FC<Props> = ({ data }) => {
                   onClick={() => setShowDenyForm(true)}
                   className="border-red-300 text-red-600 hover:bg-red-50"
                 >
-                  <X className="mr-1 h-3 w-3" />
+                  <X className="mr-1" />
                   {t("deny")}
                 </Button>
               ) : (

--- a/agentarea-webapp/src/components/Chat/componets/ChatInputArea.tsx
+++ b/agentarea-webapp/src/components/Chat/componets/ChatInputArea.tsx
@@ -459,7 +459,7 @@ export function ChatInputArea({
                 disabled={isLoading}
                 className="h-8 w-8 rounded-full p-0 hover:bg-zinc-200 hover:text-text dark:hover:bg-gray-800"
               >
-                <Paperclip className="h-4 w-4" />
+                <Paperclip />
               </Button>
 
               {showSendButton && (
@@ -476,7 +476,7 @@ export function ChatInputArea({
                       {isResuming ? (
                         <LoadingSpinner size="sm" />
                       ) : (
-                        <Play className="h-4 w-4" />
+                        <Play />
                       )}
                     </Button>
                   ) : isLoading && onStop ? (
@@ -491,7 +491,7 @@ export function ChatInputArea({
                       {isStopping ? (
                         <LoadingSpinner variant="light" size="sm" />
                       ) : (
-                        <Pause className="h-4 w-4" />
+                        <Pause />
                       )}
                     </Button>
                   ) : (
@@ -507,7 +507,7 @@ export function ChatInputArea({
                       {isLoading ? (
                         <LoadingSpinner variant="light" size="sm" />
                       ) : (
-                        <SendIcon className="h-4 w-4" />
+                        <SendIcon />
                       )}
                     </Button>
                   )}

--- a/agentarea-webapp/src/components/Chat/componets/ScrollToBottomButton.tsx
+++ b/agentarea-webapp/src/components/Chat/componets/ScrollToBottomButton.tsx
@@ -25,7 +25,7 @@ export const ScrollToBottomButton: React.FC<ScrollToBottomButtonProps> = ({
         variant="outline"
         className="h-8 w-8 rounded-full shadow-lg"
       >
-        <ChevronDown className="h-4 w-4" />
+        <ChevronDown />
       </Button>
     </div>
   );

--- a/agentarea-webapp/src/components/DeleteButton/DeleteButton.tsx
+++ b/agentarea-webapp/src/components/DeleteButton/DeleteButton.tsx
@@ -89,7 +89,7 @@ export default function DeleteButton({
       type="delete"
     >
       <Button variant="destructiveOutline" size={size}>
-        <Trash2 className="h-4 w-4" />
+        <Trash2 />
         {tCommon("delete")}
       </Button>
     </BaseModal>

--- a/agentarea-webapp/src/components/MainLayout/components/AppSidebar.tsx
+++ b/agentarea-webapp/src/components/MainLayout/components/AppSidebar.tsx
@@ -94,7 +94,7 @@ export function AppSidebarContent({
               )}
               onClick={openQuickTask}
             >
-              <SquarePen className="h-3.5 w-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground" />
+              <SquarePen className="shrink-0 text-muted-foreground/80 group-hover:text-foreground" />
               {open && (
                 <>
                   <span className="flex-1 truncate text-left">New task</span>

--- a/agentarea-webapp/src/components/ProviderConfigForm/components/ApiKeyEditInput.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/components/ApiKeyEditInput.tsx
@@ -42,9 +42,9 @@ export default function ApiKeyEditInput({ field }: { field: FieldValues }) {
               }}
             >
               {editApiKey ? (
-                <X className="h-4 w-4" />
+                <X />
               ) : (
-                <Edit className="h-4 w-4" />
+                <Edit />
               )}
             </Button>
           </TooltipTrigger>

--- a/agentarea-webapp/src/components/ProviderConfigForm/components/BaseInfo.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/components/BaseInfo.tsx
@@ -103,7 +103,7 @@ export default function BaseInfo<T extends FieldValues = FieldValues>({
                   disabled={(!apiKeyValue?.trim() && !endpointUrlValue?.trim()) || isDiscovering}
                 >
                   <RefreshCw
-                    className={`mr-1.5 h-3 w-3 ${isDiscovering ? "animate-spin" : ""}`}
+                    className={`mr-1.5 ${isDiscovering ? "animate-spin" : ""}`}
                   />
                   {isDiscovering ? "Discovering..." : "Test & Discover"}
                 </Button>

--- a/agentarea-webapp/src/components/ProviderConfigForm/components/ModelInstances.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/components/ModelInstances.tsx
@@ -230,7 +230,7 @@ export default function ModelInstances({
                 : t("testAndDiscoverTooltip")
             }
           >
-            <RefreshCw className={`h-3 w-3 ${isDiscovering ? "animate-spin" : ""}`} />
+            <RefreshCw className={isDiscovering ? "animate-spin" : ""} />
             {isDiscovering
               ? t("discovering")
               : providerConfigId

--- a/agentarea-webapp/src/components/Table/Table.tsx
+++ b/agentarea-webapp/src/components/Table/Table.tsx
@@ -59,7 +59,7 @@ export default function Table<T>({
               {column.header}
               {column.sortable && (
                 <Button variant="ghost" size="icon" className="ml-2">
-                  <ArrowUpIcon className="h-4 w-4" />
+                  <ArrowUpIcon />
                 </Button>
               )}
             </TableHead>

--- a/agentarea-webapp/src/components/TaskCreator.tsx
+++ b/agentarea-webapp/src/components/TaskCreator.tsx
@@ -179,12 +179,12 @@ export default function TaskCreator() {
         >
           {loading ? (
             <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Loader2 className="mr-2 animate-spin" />
               Creating Task...
             </>
           ) : (
             <>
-              <Send className="mr-2 h-4 w-4" />
+              <Send className="mr-2" />
               Create Task
             </>
           )}

--- a/agentarea-webapp/src/components/TaskEvents/EventsDisplay.tsx
+++ b/agentarea-webapp/src/components/TaskEvents/EventsDisplay.tsx
@@ -242,7 +242,7 @@ export function EventsDisplay({
               onClick={onRefresh}
               disabled={loading}
             >
-              <Activity className="mr-1 h-3 w-3" />
+              <Activity className="mr-1" />
               Refresh
             </Button>
           )}
@@ -271,10 +271,10 @@ export function EventsDisplay({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="sm" className="gap-1">
-                  <Filter className="h-3 w-3" />
+                  <Filter />
                   Level{" "}
                   {selectedLevels.length > 0 && `(${selectedLevels.length})`}
-                  <ChevronDown className="h-3 w-3" />
+                  <ChevronDown />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent>

--- a/agentarea-webapp/src/components/TaskInfoPanel/components/ModelPicker.tsx
+++ b/agentarea-webapp/src/components/TaskInfoPanel/components/ModelPicker.tsx
@@ -119,7 +119,7 @@ export default function ModelPicker({
           disabled={loading}
         >
           {loading ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
+            <Loader2 className="animate-spin" />
           ) : (
             "Change"
           )}

--- a/agentarea-webapp/src/components/WalletConfig/WalletConfigPanel.tsx
+++ b/agentarea-webapp/src/components/WalletConfig/WalletConfigPanel.tsx
@@ -340,7 +340,7 @@ export function WalletConfigPanel({ agentId }: WalletConfigPanelProps) {
       <div className="flex justify-between">
         {wallet && (
           <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-            <Trash2 className="h-4 w-4 mr-2" />
+            <Trash2 className="mr-2" />
             {deleting ? "Removing..." : "Remove Wallet"}
           </Button>
         )}

--- a/agentarea-webapp/src/components/files/file-viewer.tsx
+++ b/agentarea-webapp/src/components/files/file-viewer.tsx
@@ -266,7 +266,7 @@ export function FileViewerContent({
           <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
             <span>Preview not available for this file type.</span>
             <Button size="sm" variant="outline" onClick={handleDownload}>
-              <Download className="mr-1.5 h-3.5 w-3.5" />
+              <Download className="mr-1.5" />
               Download
             </Button>
           </div>

--- a/agentarea-webapp/src/components/mcp-servers/InstanceList.tsx
+++ b/agentarea-webapp/src/components/mcp-servers/InstanceList.tsx
@@ -102,9 +102,9 @@ export function InstanceList({ mcpInstanceList }: InstanceListProps) {
                           className={`h-8 w-8 p-0 ${isRunning ? "text-amber-600 hover:text-amber-700" : "text-green-600 hover:text-green-700"}`}
                         >
                           {isRunning ? (
-                            <Pause className="h-4 w-4" />
+                            <Pause />
                           ) : (
-                            <Play className="h-4 w-4" />
+                            <Play />
                           )}
                           <span className="sr-only">
                             {isRunning ? "Pause" : "Start"}
@@ -117,7 +117,7 @@ export function InstanceList({ mcpInstanceList }: InstanceListProps) {
                           asChild
                         >
                           <Link href={`/connections/instances/${instance.id}`}>
-                            <Edit className="h-4 w-4" />
+                            <Edit />
                             <span className="sr-only">Edit</span>
                           </Link>
                         </Button>
@@ -126,7 +126,7 @@ export function InstanceList({ mcpInstanceList }: InstanceListProps) {
                           size="sm"
                           className="h-8 w-8 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 />
                           <span className="sr-only">Remove</span>
                         </Button>
                       </div>

--- a/agentarea-webapp/src/components/ui/attachment-card.tsx
+++ b/agentarea-webapp/src/components/ui/attachment-card.tsx
@@ -72,9 +72,9 @@ export const AttachmentCard: React.FC<AttachmentCardProps> = ({
             className={`${actionSizeClass} absolute -right-1 -top-1 flex-shrink-0 rounded-full bg-zinc-700 p-0 text-white hover:bg-zinc-900 dark:hover:bg-gray-600`}
           >
             {actionType === "remove" ? (
-              <X className="h-3 w-3" />
+              <X />
             ) : (
-              <Download className="h-3 w-3" />
+              <Download />
             )}
           </Button>
         </div>
@@ -109,9 +109,9 @@ export const AttachmentCard: React.FC<AttachmentCardProps> = ({
         className={`${actionSizeClass} absolute -right-1 -top-1 flex-shrink-0 rounded-full bg-zinc-700 p-0 text-white hover:bg-zinc-900 dark:hover:bg-gray-600`}
       >
         {actionType === "remove" ? (
-          <X className="h-3 w-3" />
+          <X />
         ) : (
-          <Download className="h-3 w-3" />
+          <Download />
         )}
       </Button>
     </div>

--- a/agentarea-webapp/src/components/ui/button.tsx
+++ b/agentarea-webapp/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition duration-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition duration-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -23,12 +23,15 @@ const buttonVariants = cva(
           "hover:bg-primary/10 hover:text-accent/80 dark:hover:text-accent-foreground dark:hover:bg-primary/30",
         link: "text-primary underline-offset-4 hover:underline",
       },
+      // `[&_svg]:size-*` outranks any `h-4 w-4` a call site puts on the glyph,
+      // so icon size can only be set here. `xs` gets 14px to keep the glyph
+      // within the cap height of its 12px label.
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        xs: "h-6 rounded-sm px-1 text-xs font-normal gap-1",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-9 px-4 py-2 [&_svg]:size-4",
+        sm: "h-8 rounded-md px-3 text-xs [&_svg]:size-4",
+        xs: "h-6 rounded-sm px-1 text-xs font-normal gap-1 [&_svg]:size-3.5",
+        lg: "h-10 rounded-md px-8 [&_svg]:size-4",
+        icon: "h-9 w-9 [&_svg]:size-4",
       },
     },
     defaultVariants: {

--- a/agentarea-webapp/src/components/ui/error-fallback.tsx
+++ b/agentarea-webapp/src/components/ui/error-fallback.tsx
@@ -101,7 +101,7 @@ export function ErrorFallback({
               onClick={reset}
               className="gap-2"
             >
-              <RefreshCw className="h-4 w-4" />
+              <RefreshCw />
               Try again
             </Button>
           )}
@@ -113,7 +113,7 @@ export function ErrorFallback({
               onClick={handleGoHome}
               className="gap-2"
             >
-              <Home className="h-4 w-4" />
+              <Home />
               Go home
             </Button>
           )}

--- a/agentarea-webapp/src/components/ui/provider-model-selector.tsx
+++ b/agentarea-webapp/src/components/ui/provider-model-selector.tsx
@@ -239,7 +239,7 @@ export function ProviderModelSelector({
           disabled={disabled}
         >
           {renderDefaultTrigger()}
-          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <ChevronDown className="ml-2 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="p-0" style={{ width: popoverWidth }}>
@@ -281,7 +281,7 @@ export function ProviderModelSelector({
                         onClick={onAddProvider}
                         className="h-5 w-5"
                       >
-                        <Plus className="h-3 w-3" />
+                        <Plus />
                       </Button>
                     )}
                   </div>

--- a/agentarea-webapp/src/components/ui/searchable-select.tsx
+++ b/agentarea-webapp/src/components/ui/searchable-select.tsx
@@ -189,7 +189,7 @@ export function SearchableSelect({
           {renderTrigger
             ? renderTrigger(selectedOption)
             : renderDefaultTrigger(selectedOption)}
-          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <ChevronDown className="ml-2 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="p-0" style={{ width: popoverWidth }}>

--- a/agentarea-webapp/src/components/ui/sidebar.tsx
+++ b/agentarea-webapp/src/components/ui/sidebar.tsx
@@ -303,7 +303,7 @@ const SidebarTrigger = React.forwardRef<
       }}
       {...props}
     >
-      <PanelLeft className="h-3 w-3 text-zinc-700" />
+      <PanelLeft className="text-zinc-700" />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );


### PR DESCRIPTION
Fixes #349.

## What was wrong

The base button class carries `[&_svg]:size-4`, which compiles to `.\[\&_svg\]\:size-4 svg { … }` — specificity (0,1,1) — and beats the plain `.h-5`/`.w-5` utilities at (0,1,0). So the `h-5 w-5` on the header CTAs' `<Plus>` icons never rendered anything, and `xs` (`h-6 … text-xs`) was left with a 16px glyph against a 12px label in a 24px-tall button.

## The fix

Icon sizing moves out of the base and into each size variant, so `xs` can declare `[&_svg]:size-3.5` — 14px keeps the glyph within the cap height of its label. Putting it in the variants rather than adding a second `[&_svg]:size-*` to the base means exactly one icon-size rule is ever emitted, with no same-modifier conflict for tailwind-merge to resolve.

`xs` keeps its declared `gap-1`. That's what ~50 other `xs` buttons already render with; the header CTAs were the outliers, and 4px matches the variant's own `px-1` side padding, where 8px left the glyph pressed against the button edge.

Call sites: 178 dead icon-size classes removed across 82 files. All were already overridden, so nothing there changes visually — live classes (`mr-2`, `animate-spin`, colors) are preserved. The eight "New …" header CTAs (the three from the issue plus triggers, skills, api-keys, provider-configs, connections) now render from one shape: `className="shrink-0"`, `size="xs"`, bare `<Plus />`. Some of those icons also carried a stray `mr-1`/`mr-2` that stacked on top of the gap.

## Verification

Rendered the actual component through `react-dom/server`, compiled the real `globals.css` + `tailwind.config.ts` against that markup with the Tailwind CLI, and screenshotted it in Chrome — the plus now sits inside the label's cap height instead of overshooting it. `pnpm lint`, `type-check`, and `test` (97 tests) all pass.

## Deliberately left alone

- `ConfigSheet.tsx` keeps `cn("gap-1.5", triggerClassName)` — a sheet trigger with an extra Badge child and a caller-override prop, not one of the list-page CTAs.
- One `h-4 w-4` inside a Button survives, in `BundleInstallWizard.tsx:874` — it's on a `next/image`, so that class is live, not dead.