### PR TITLE
Stop API errors rendering as "[object Object]"

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -361,7 +361,10 @@ class TaskWithAgent(BaseModel):
 
     id: UUID
     agent_id: UUID
-    agent_name: str
+    # None when the task's agent no longer resolves. Never substitute a
+    # placeholder name: a fabricated "Unknown" is indistinguishable from an
+    # agent actually called that, and it hides the missing agent from the UI.
+    agent_name: str | None = None
     description: str
     parameters: dict[str, Any]
     status: str
@@ -377,7 +380,7 @@ class TaskWithAgent(BaseModel):
     escalation_tool_name: str | None = None
 
     @classmethod
-    def from_task_response(cls, task: TaskResponse, agent_name: str) -> "TaskWithAgent":
+    def from_task_response(cls, task: TaskResponse, agent_name: str | None) -> "TaskWithAgent":
         """Create TaskWithAgent from TaskResponse and agent name."""
         return cls(
             id=task.id,
@@ -430,7 +433,7 @@ async def get_all_tasks(
                 TaskWithAgent(
                     id=task.id,
                     agent_id=task.agent_id,
-                    agent_name=agent_map.get(str(task.agent_id), "Unknown"),
+                    agent_name=agent_map.get(str(task.agent_id)),
                     description=task.description,
                     parameters=task.parameters,
                     status=task.status,
@@ -483,7 +486,7 @@ async def get_task_by_id(
         return TaskWithAgent(
             id=task.id,
             agent_id=task.agent_id,
-            agent_name=agent.name if agent else "Unknown",
+            agent_name=agent.name if agent else None,
             description=task.description,
             parameters=task.parameters,
             status=task.status,
@@ -507,7 +510,9 @@ class TaskEvent(BaseModel):
     id: str
     task_id: str
     agent_id: str
-    execution_id: str
+    # None for events recorded outside a workflow execution. "unknown" was a
+    # fabricated id that callers could not tell apart from a real one.
+    execution_id: str | None = None
     timestamp: UtcDatetime
     event_type: str
     message: str
@@ -1864,8 +1869,7 @@ async def get_task_events(
                 id=str(record.id),
                 task_id=str(record.task_id),
                 agent_id=str(agent_id),
-                execution_id=record.data.get("execution_id")
-                or record.metadata.get("execution_id", "unknown"),
+                execution_id=record.data.get("execution_id") or record.metadata.get("execution_id"),
                 timestamp=record.timestamp,
                 event_type=record.event_type,
                 message=record.data.get("message", f"Event: {record.event_type}"),

--- a/agentarea-platform/apps/api/tests/test_task_no_placeholder_fields.py
+++ b/agentarea-platform/apps/api/tests/test_task_no_placeholder_fields.py
@@ -1,0 +1,56 @@
+"""A task record must never invent values for fields it could not resolve.
+
+`agent_name="Unknown"` and `execution_id="unknown"` used to be substituted when
+the lookup came up empty. Both are indistinguishable from real values, so the
+UI rendered a confident "Unknown" breadcrumb over what was actually a missing
+agent — and callers had no way to detect the difference. Absent means null.
+"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from agentarea_api.api.v1.agents_tasks import TaskEvent, TaskResponse, TaskWithAgent
+from agentarea_tasks.domain.models import AgentTask
+
+
+def _agent_task() -> AgentTask:
+    return AgentTask(
+        id=uuid4(),
+        title="task",
+        description="do the thing",
+        query="do the thing",
+        user_id="user-1",
+        workspace_id="workspace-1",
+        agent_id=uuid4(),
+        status="completed",
+    )
+
+
+def test_agent_name_is_null_when_the_agent_does_not_resolve() -> None:
+    response = TaskResponse.from_agent_task(_agent_task())
+
+    with_agent = TaskWithAgent.from_task_response(response, None)
+
+    assert with_agent.agent_name is None
+    assert with_agent.model_dump()["agent_name"] is None
+
+
+def test_agent_name_is_carried_through_when_it_does_resolve() -> None:
+    response = TaskResponse.from_agent_task(_agent_task())
+
+    with_agent = TaskWithAgent.from_task_response(response, "neuresearch")
+
+    assert with_agent.agent_name == "neuresearch"
+
+
+def test_task_event_execution_id_is_null_rather_than_a_placeholder() -> None:
+    event = TaskEvent(
+        id=str(uuid4()),
+        task_id=str(uuid4()),
+        agent_id=str(uuid4()),
+        timestamp=datetime.now(UTC),
+        event_type="task.started",
+        message="started",
+    )
+
+    assert event.execution_id is None

--- a/agentarea-platform/libs/tasks/agentarea_tasks/task_service.py
+++ b/agentarea-platform/libs/tasks/agentarea_tasks/task_service.py
@@ -277,13 +277,15 @@ class TaskService(BaseTaskService):
         agent = await self._validate_agent_exists(agent_id)
         if require_model:
             self._require_agent_model(agent, agent_id, parameters)
-        agent_name = getattr(agent, "name", "unknown") if agent else "unknown"
-
         metadata: dict[str, Any] = {}
         if metadata_overrides:
             metadata.update(metadata_overrides)
         metadata.setdefault("created_via", "api")
-        metadata["agent_name"] = agent_name
+        # Only stamp a name we actually loaded. `agent` is None only in
+        # test/standalone mode (no agent_repository wired) — recording
+        # "unknown" there would be indistinguishable from a real agent name.
+        if agent is not None:
+            metadata["agent_name"] = agent.name
         metadata["requires_human_approval"] = requires_human_approval
         requested_execution = (
             task_policy.execution.model_dump(exclude_none=True)

--- a/agentarea-webapp/packages/api-client/src/generated/types.gen.ts
+++ b/agentarea-webapp/packages/api-client/src/generated/types.gen.ts
@@ -5732,7 +5732,7 @@ export type TaskEvent = {
     /**
      * Execution Id
      */
-    execution_id: string;
+    execution_id?: string | null;
     /**
      * Id
      */
@@ -5962,7 +5962,7 @@ export type TaskWithAgent = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Created At
      */

--- a/agentarea-webapp/packages/api-client/types/generated/types.gen.d.ts
+++ b/agentarea-webapp/packages/api-client/types/generated/types.gen.d.ts
@@ -5522,7 +5522,7 @@ export type TaskEvent = {
     /**
      * Execution Id
      */
-    execution_id: string;
+    execution_id?: string | null;
     /**
      * Id
      */
@@ -5747,7 +5747,7 @@ export type TaskWithAgent = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Created At
      */

--- a/agentarea-webapp/src/api/client/types.gen.ts
+++ b/agentarea-webapp/src/api/client/types.gen.ts
@@ -5755,7 +5755,7 @@ export type TaskEvent = {
   /**
    * Execution Id
    */
-  execution_id: string;
+  execution_id?: string | null;
   /**
    * Id
    */
@@ -5988,7 +5988,7 @@ export type TaskWithAgent = {
   /**
    * Agent Name
    */
-  agent_name: string;
+  agent_name?: string | null;
   /**
    * Created At
    */

--- a/agentarea-webapp/src/api/client/zod.gen.ts
+++ b/agentarea-webapp/src/api/client/zod.gen.ts
@@ -2418,7 +2418,7 @@ export const zTaskCommandPayload = z.object({
 export const zTaskEvent = z.object({
   agent_id: z.string(),
   event_type: z.string(),
-  execution_id: z.string(),
+  execution_id: z.string().nullish(),
   id: z.string(),
   message: z.string(),
   metadata: z.record(z.unknown()).optional().default({}),
@@ -2506,7 +2506,7 @@ export const zTaskSummary = z.object({
  */
 export const zTaskWithAgent = z.object({
   agent_id: z.string().uuid(),
-  agent_name: z.string(),
+  agent_name: z.string().nullish(),
   created_at: z.string(),
   description: z.string(),
   error: z.string().nullish(),

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -9785,8 +9785,15 @@
             "type": "string"
           },
           "execution_id": {
-            "title": "Execution Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Id"
           },
           "id": {
             "title": "Id",
@@ -9815,7 +9822,6 @@
           "id",
           "task_id",
           "agent_id",
-          "execution_id",
           "timestamp",
           "event_type",
           "message"
@@ -10136,8 +10142,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "created_at": {
             "title": "Created At",
@@ -10246,7 +10259,6 @@
         "required": [
           "id",
           "agent_id",
-          "agent_name",
           "description",
           "parameters",
           "status",

--- a/agentarea-webapp/src/app/(main)/connections/[id]/MCPInstanceDetail.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/[id]/MCPInstanceDetail.tsx
@@ -27,6 +27,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { StatusIndicator } from "@/components/ui/status-indicator";
+import { formatApiError } from "@/lib/api-errors";
 import { getMcpVerificationStatusPresentation } from "@/lib/status";
 import {
   discoverMCPInstanceToolsAction as discoverMCPInstanceTools,
@@ -185,12 +186,7 @@ export default function MCPInstanceDetail({
     setIsRefreshingTools(true);
     try {
       const { data, error } = await discoverMCPInstanceTools(instance.id);
-      if (error)
-        throw new Error(
-          typeof error === "object" && "detail" in error
-            ? String(error.detail)
-            : "Failed to refresh tools"
-        );
+      if (error) throw new Error(formatApiError(error));
       // The endpoint returns 200 with {tools, verification} even when verification
       // failed — so report based on the actual result, not the HTTP status.
       const result = data as

--- a/agentarea-webapp/src/app/(main)/connections/add-openapi/form.tsx
+++ b/agentarea-webapp/src/app/(main)/connections/add-openapi/form.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { formatApiError } from "@/lib/api-errors";
 import {
   createOpenAPIConnectionAction as createOpenAPIConnection,
   previewOpenAPISpecAction as previewOpenAPISpec,
@@ -42,14 +43,6 @@ const SAFE_HEADERS = new Set([
 
 function isSecretHeader(name: string) {
   return !SAFE_HEADERS.has(name.toLowerCase().trim());
-}
-
-function errorDetail(err: unknown): string | undefined {
-  if (err && typeof err === "object" && "detail" in err) {
-    const detail = (err as { detail?: unknown }).detail;
-    if (typeof detail === "string") return detail;
-  }
-  return undefined;
 }
 
 interface OpenAPIOperation {
@@ -204,7 +197,7 @@ export function AddOpenAPIForm() {
             spec_url: url,
           });
           if (fetchErr) {
-            setPreviewError(errorDetail(fetchErr) || t("failedToFetchSpec"));
+            setPreviewError(formatApiError(fetchErr));
           } else if (data) {
             applyPreview({
               title: data.title,
@@ -284,7 +277,7 @@ export function AddOpenAPIForm() {
       });
 
       if (createError) {
-        setError(errorDetail(createError) || t("failedToCreate"));
+        setError(formatApiError(createError));
         return;
       }
 

--- a/agentarea-webapp/src/app/(main)/invite/actions.ts
+++ b/agentarea-webapp/src/app/(main)/invite/actions.ts
@@ -1,19 +1,13 @@
 "use server";
 
 import { acceptWorkspaceInvitation } from "@/lib/api";
-
-function errMsg(error: unknown, fallback: string): string {
-  const e = error as { detail?: unknown };
-  if (Array.isArray(e?.detail)) {
-    return (e.detail[0] as { msg?: string })?.msg || fallback;
-  }
-  if (typeof e?.detail === "string") return e.detail;
-  return fallback;
-}
+import { apiErrorMessage } from "@/lib/api-errors";
 
 export async function acceptInvitationAction(token: string) {
   if (!token) return { error: "Missing invitation token" };
-  const { data, error } = await acceptWorkspaceInvitation(token);
-  if (error) return { error: errMsg(error, "Failed to accept invitation") };
-  return { data };
+  const result = await acceptWorkspaceInvitation(token);
+  if (result.error) {
+    return { error: apiErrorMessage(result, "Failed to accept invitation") };
+  }
+  return { data: result.data };
 }

--- a/agentarea-webapp/src/app/(main)/members/actions.ts
+++ b/agentarea-webapp/src/app/(main)/members/actions.ts
@@ -5,16 +5,8 @@ import {
   removeWorkspaceMember,
   revokeWorkspaceInvitation,
 } from "@/lib/api";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { getAuthContext } from "@/lib/getAuthContext";
-
-function errMsg(error: unknown, fallback: string): string {
-  const e = error as { detail?: unknown };
-  if (Array.isArray(e?.detail)) {
-    return (e.detail[0] as { msg?: string })?.msg || fallback;
-  }
-  if (typeof e?.detail === "string") return e.detail;
-  return fallback;
-}
 
 export async function createInvitationAction(input: {
   email?: string;
@@ -27,17 +19,21 @@ export async function createInvitationAction(input: {
   if (input.email && input.email.trim()) body.email = input.email.trim();
   if (input.expiresInDays != null) body.expires_in_days = input.expiresInDays;
 
-  const { data, error } = await createWorkspaceInvitation(workspaceId, body);
-  if (error) return { error: errMsg(error, "Failed to create invitation") };
-  return { data };
+  const result = await createWorkspaceInvitation(workspaceId, body);
+  if (result.error) {
+    return { error: apiErrorMessage(result, "Failed to create invitation") };
+  }
+  return { data: result.data };
 }
 
 export async function revokeInvitationAction(invitationId: string) {
   const { workspaceId } = await getAuthContext();
   if (!workspaceId) return { error: "No workspace context" };
 
-  const { error } = await revokeWorkspaceInvitation(workspaceId, invitationId);
-  if (error) return { error: errMsg(error, "Failed to revoke invitation") };
+  const result = await revokeWorkspaceInvitation(workspaceId, invitationId);
+  if (result.error) {
+    return { error: apiErrorMessage(result, "Failed to revoke invitation") };
+  }
   return { ok: true };
 }
 
@@ -45,7 +41,9 @@ export async function removeMemberAction(userId: string) {
   const { workspaceId } = await getAuthContext();
   if (!workspaceId) return { error: "No workspace context" };
 
-  const { error } = await removeWorkspaceMember(workspaceId, userId);
-  if (error) return { error: errMsg(error, "Failed to remove member") };
+  const result = await removeWorkspaceMember(workspaceId, userId);
+  if (result.error) {
+    return { error: apiErrorMessage(result, "Failed to remove member") };
+  }
   return { ok: true };
 }

--- a/agentarea-webapp/src/app/(main)/network/components/NodeDetailDrawer.tsx
+++ b/agentarea-webapp/src/app/(main)/network/components/NodeDetailDrawer.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { formatApiError } from "@/lib/api-errors";
 import { listAgentTasksAction } from "@/lib/server-actions";
 import { cn } from "@/lib/utils";
 import type { NetworkNodeData, TopologyResponse } from "../types";
@@ -183,7 +184,7 @@ function AgentSections({ agentId }: { agentId: string }) {
       })
       .catch((e) => {
         if (cancelled) return;
-        setError(String(e));
+        setError(formatApiError(e));
       });
     return () => {
       cancelled = true;

--- a/agentarea-webapp/src/app/(main)/sandboxes/actions.ts
+++ b/agentarea-webapp/src/app/(main)/sandboxes/actions.ts
@@ -1,11 +1,15 @@
 "use server";
 
 import { listSandboxes } from "@/lib/api";
+import { apiErrorMessage } from "@/lib/api-errors";
 
 export async function listSandboxesAction() {
-  const { data, error } = await listSandboxes();
-  if (error || !data) {
-    return { data: null, error: "Sandbox inventory is unavailable" };
+  const result = await listSandboxes();
+  if (result.error || !result.data) {
+    return {
+      data: null,
+      error: apiErrorMessage(result, "Sandbox inventory is unavailable"),
+    };
   }
-  return { data, error: null };
+  return { data: result.data, error: null };
 }

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/events/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/events/page.tsx
@@ -221,7 +221,7 @@ export default function TaskEventsPage() {
                     colSpan={6}
                     className="py-8 text-center text-muted-foreground text-xs"
                   >
-                    No events found.
+                    {eventsError ? "Could not load events." : "No events found."}
                   </td>
                 </tr>
               ) : (

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/files/page.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/files/page.tsx
@@ -5,6 +5,7 @@ import { Files, RefreshCw } from "lucide-react";
 import { FileBrowser, type BrowsedFile } from "@/components/files/file-browser";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { listTaskSandboxFilesAction } from "@/lib/server-actions";
 import { useTaskContext } from "../TaskContext";
 
@@ -30,10 +31,12 @@ export default function TaskFilesPage() {
       const result = await listTaskSandboxFilesAction(task.agent_id, task.id);
       if (result.error) {
         setFiles([]);
+        // 410 is the expected end of a sandbox's life, not a failure — every
+        // other status is a real error and must say what actually went wrong.
         setError(
           result.status === 410
             ? "This sandbox has expired. Published artifacts remain available."
-            : "Live sandbox files are temporarily unavailable."
+            : apiErrorMessage(result, "Could not load sandbox files")
         );
         return;
       }

--- a/agentarea-webapp/src/app/(main)/tasks/[id]/layout.tsx
+++ b/agentarea-webapp/src/app/(main)/tasks/[id]/layout.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import { getTask } from "@/lib/api";
+import { apiErrorMessage } from "@/lib/api-errors";
 import TaskLayoutClient from "./TaskLayoutClient";
 
 interface Props {
@@ -12,14 +13,16 @@ export default async function TaskLayout({ params, children }: Props) {
   const t = await getTranslations("TasksPage");
 
   // Fetch task server-side — no client loading spinner needed
-  const { data: task, error } = await getTask(id);
+  const result = await getTask(id);
 
   return (
     <TaskLayoutClient
       taskId={id}
       tasksTitle={t("title")}
-      initialTask={task ?? null}
-      initialError={error ? String(error) : null}
+      initialTask={result.data ?? null}
+      initialError={
+        result.error ? apiErrorMessage(result, "Failed to load task") : null
+      }
     >
       {children}
     </TaskLayoutClient>

--- a/agentarea-webapp/src/app/api/agents/[agentId]/tasks/create/route.ts
+++ b/agentarea-webapp/src/app/api/agents/[agentId]/tasks/create/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { env } from "@/env";
+import { formatApiError } from "@/lib/api-errors";
 import { getAuthToken } from "@/lib/getAuthToken";
 import { resolveRequestWorkspaceSlug } from "@/lib/workspace-request";
 
@@ -90,6 +91,8 @@ export async function POST(
     });
   } catch (error) {
     console.error("Task creation proxy error:", error);
-    return new Response(`Task creation proxy error: ${error}`, { status: 500 });
+    return new Response(`Task creation proxy error: ${formatApiError(error)}`, {
+      status: 500,
+    });
   }
 }

--- a/agentarea-webapp/src/app/api/files/upload-url/route.ts
+++ b/agentarea-webapp/src/app/api/files/upload-url/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { env } from "@/env";
+import { formatApiError } from "@/lib/api-errors";
 import { getAuthToken } from "@/lib/getAuthToken";
 import { resolveRequestWorkspaceSlug } from "@/lib/workspace-request";
 
@@ -38,6 +39,8 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error("Upload-url proxy error:", error);
-    return new Response(`Upload-url proxy error: ${error}`, { status: 500 });
+    return new Response(`Upload-url proxy error: ${formatApiError(error)}`, {
+      status: 500,
+    });
   }
 }

--- a/agentarea-webapp/src/app/api/sse/agents/[agentId]/tasks/[taskId]/events/stream/route.ts
+++ b/agentarea-webapp/src/app/api/sse/agents/[agentId]/tasks/[taskId]/events/stream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { env } from "@/env";
+import { formatApiError } from "@/lib/api-errors";
 import { getAuthToken } from "@/lib/getAuthToken";
 
 export async function GET(
@@ -79,6 +80,8 @@ export async function GET(
     });
   } catch (error) {
     console.error("SSE events proxy error:", error);
-    return new Response(`SSE events proxy error: ${error}`, { status: 500 });
+    return new Response(`SSE events proxy error: ${formatApiError(error)}`, {
+      status: 500,
+    });
   }
 }

--- a/agentarea-webapp/src/components/TaskItem/TaskItem.tsx
+++ b/agentarea-webapp/src/components/TaskItem/TaskItem.tsx
@@ -12,7 +12,7 @@ export interface TaskItemData {
   description: string;
   status: string;
   created_at: string;
-  agent_name?: string;
+  agent_name?: string | null;
   agent_id?: string;
   parameters?: Record<string, unknown>;
 }

--- a/agentarea-webapp/src/lib/api-errors.test.ts
+++ b/agentarea-webapp/src/lib/api-errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { apiErrorMessage } from "./api-errors";
+
+/**
+ * The generated client hands back the parsed error *body*, not a string.
+ * Anything that interpolates it directly — `String(error)`, `error.toString()` —
+ * renders "[object Object]" in the UI and buries the only clue about what
+ * actually failed.
+ */
+describe("apiErrorMessage", () => {
+  it("unwraps a FastAPI detail instead of stringifying the object", () => {
+    const message = apiErrorMessage(
+      { error: { detail: "Agent not found" }, status: 404 },
+      "Failed to load events"
+    );
+
+    expect(message).toBe("Failed to load events (404): Agent not found");
+    expect(message).not.toContain("[object Object]");
+  });
+
+  it("unwraps problem+json validation errors", () => {
+    const message = apiErrorMessage(
+      {
+        error: { errors: [{ msg: "page_size must be <= 100" }] },
+        status: 422,
+      },
+      "Failed to load events"
+    );
+
+    expect(message).toBe(
+      "Failed to load events (422): page_size must be <= 100"
+    );
+  });
+
+  it("keeps the status when the body carries no readable message", () => {
+    const message = apiErrorMessage({ error: {}, status: 500 }, "Failed");
+
+    expect(message).toBe("Failed (500)");
+  });
+
+  it("falls back to the label alone when there is no error and no status", () => {
+    expect(apiErrorMessage({ data: null }, "Failed to load events")).toBe(
+      "Failed to load events"
+    );
+  });
+
+  it("passes a plain string error through", () => {
+    expect(apiErrorMessage({ error: "boom" }, "Failed")).toBe("Failed: boom");
+  });
+});

--- a/agentarea-webapp/src/lib/api-errors.ts
+++ b/agentarea-webapp/src/lib/api-errors.ts
@@ -16,6 +16,13 @@ export function isApiNotFound(value: unknown) {
   return getApiStatus(value) === 404;
 }
 
+function itemMessage(item: unknown) {
+  if (item && typeof item === "object" && "msg" in item) {
+    return String((item as { msg: unknown }).msg);
+  }
+  return String(item);
+}
+
 export function formatApiError(value: unknown) {
   if (!value) return "Unknown error";
   if (typeof value === "string") return value;
@@ -26,19 +33,21 @@ export function formatApiError(value: unknown) {
 
     if (record.error) return formatApiError(record.error);
 
+    // problem+json validation failures carry field errors under `errors`.
+    if (Array.isArray(record.errors) && record.errors.length > 0) {
+      const messages = record.errors.map(itemMessage).filter(Boolean);
+      if (messages.length > 0) return messages.join(", ");
+    }
+
     if (typeof record.detail === "string") return record.detail;
     if (Array.isArray(record.detail)) {
-      return record.detail
-        .map((item) => {
-          if (item && typeof item === "object" && "msg" in item) {
-            return String((item as { msg: unknown }).msg);
-          }
-          return String(item);
-        })
-        .join(", ");
+      return record.detail.map(itemMessage).join(", ");
     }
 
     if (typeof record.message === "string") return record.message;
+
+    // problem+json without a usable detail: fall back to the title.
+    if (typeof record.title === "string") return record.title;
   }
 
   try {
@@ -46,4 +55,23 @@ export function formatApiError(value: unknown) {
   } catch {
     return String(value);
   }
+}
+
+/**
+ * Build a user-facing message from an `{ data, error, status }` API result.
+ * Callers must never interpolate `error` directly — it is the parsed response
+ * body, so `String(error)` renders "[object Object]" and hides the failure.
+ */
+export function apiErrorMessage(result: ApiResultLike, label: string) {
+  const status = getApiStatus(result);
+  const statusText = status ? ` (${status})` : "";
+  if (!result?.error) return `${label}${statusText}`;
+
+  // An error body with nothing readable in it (a bare `{}`) adds noise, not
+  // information — the status is the only signal worth showing.
+  const detail = formatApiError(result.error);
+  if (!detail || detail === "{}" || detail === "[]") {
+    return `${label}${statusText}`;
+  }
+  return `${label}${statusText}: ${detail}`;
 }

--- a/agentarea-webapp/src/lib/api.ts
+++ b/agentarea-webapp/src/lib/api.ts
@@ -58,6 +58,7 @@ import type {
   UpdateWalletRequest,
   ValidateRequest,
 } from "@/api/client/types.gen";
+import { apiErrorMessage } from "@/lib/api-errors";
 
 type RawRequestOptions = {
   body?: unknown;
@@ -96,52 +97,6 @@ function withStatus<TData, TError>(result: {
   };
 }
 
-// Extract a human-readable message from an API error. The backend returns
-// RFC 9457 problem+json ({ type, title, status, code, detail, ... }); validation
-// failures carry field errors under `errors`. We also keep the legacy FastAPI
-// shape (detail-as-array of {msg}) for backward compatibility.
-function formatErrorDetail(error: unknown) {
-  if (!error) return "No response data";
-  if (typeof error === "string") return error;
-  if (error instanceof Error) return error.message;
-  if (typeof error === "object") {
-    const obj = error as {
-      detail?: unknown;
-      errors?: unknown;
-      title?: unknown;
-    };
-
-    // problem+json validation errors: surface field-level messages.
-    if (Array.isArray(obj.errors) && obj.errors.length > 0) {
-      const msgs = obj.errors
-        .map((item) =>
-          typeof item === "object" && item && "msg" in item
-            ? String((item as { msg: unknown }).msg)
-            : String(item)
-        )
-        .filter(Boolean);
-      if (msgs.length > 0) return msgs.join(", ");
-    }
-
-    const detail = obj.detail;
-    if (typeof detail === "string") return detail;
-    if (Array.isArray(detail)) {
-      // Legacy FastAPI validation shape.
-      return detail
-        .map((item) =>
-          typeof item === "object" && item && "msg" in item
-            ? String((item as { msg: unknown }).msg)
-            : String(item)
-        )
-        .join(", ");
-    }
-
-    // problem+json without a usable detail: fall back to the title.
-    if (typeof obj.title === "string") return obj.title;
-  }
-  return JSON.stringify(error);
-}
-
 export const listAgents = async () => {
   const { data, error } = await sdk.listAgentsV1AgentsGet({
     client: serverClient,
@@ -150,10 +105,13 @@ export const listAgents = async () => {
 };
 
 export const listSandboxes = async () => {
-  const { data, error } = await sdk.listSandboxesV1SandboxesGet({
+  const result = await sdk.listSandboxesV1SandboxesGet({
     client: serverClient,
   });
-  return { data: data as SandboxListResponse | undefined, error };
+  return {
+    ...withStatus(result),
+    data: result.data as SandboxListResponse | undefined,
+  };
 };
 
 export const createAgent = async (agent: AgentCreate) => {
@@ -465,17 +423,16 @@ export const getAgentTaskEvents = async (
     event_type?: string;
   } = {}
 ) => {
-  const { data, error } =
-    await sdk.getTaskEventsV1AgentsAgentIdTasksTaskIdEventsGet({
-      client: serverClient,
-      path: { agent_id: agentId, task_id: taskId },
-      query: {
-        page: options.page || 1,
-        page_size: options.page_size || 50,
-        ...(options.event_type && { event_type: options.event_type }),
-      },
-    });
-  return { data, error };
+  const result = await sdk.getTaskEventsV1AgentsAgentIdTasksTaskIdEventsGet({
+    client: serverClient,
+    path: { agent_id: agentId, task_id: taskId },
+    query: {
+      page: options.page || 1,
+      page_size: options.page_size || 50,
+      ...(options.event_type && { event_type: options.event_type }),
+    },
+  });
+  return withStatus(result);
 };
 
 export const sendMessage = async (message: {
@@ -729,7 +686,7 @@ export const getProviderConfig = async (
 
   if (!response.data) {
     const error = new Error(
-      `Failed to load provider config (${response.response?.status ?? "unknown"}): ${formatErrorDetail(response.error)}`
+      apiErrorMessage(withStatus(response), "Failed to load provider config")
     );
     (error as Error & { status?: number }).status = response.response?.status;
     throw error;
@@ -1399,12 +1356,13 @@ export const removeWorkspaceMember = async (
   workspaceId: string,
   userId: string
 ) => {
-  const { data, error } =
-    await sdk.removeMemberV1WorkspacesWorkspaceIdMembersUserIdDelete({
+  const result = await sdk.removeMemberV1WorkspacesWorkspaceIdMembersUserIdDelete(
+    {
       client: serverClient,
       path: { workspace_id: workspaceId, user_id: userId },
-    });
-  return { data, error };
+    }
+  );
+  return withStatus(result);
 };
 
 export const listWorkspaceInvitations = async (workspaceId: string) => {
@@ -1420,35 +1378,36 @@ export const createWorkspaceInvitation = async (
   workspaceId: string,
   body: CreateInvitationBody
 ) => {
-  const { data, error } =
-    await sdk.createInvitationV1WorkspacesWorkspaceIdInvitationsPost({
+  const result = await sdk.createInvitationV1WorkspacesWorkspaceIdInvitationsPost(
+    {
       client: serverClient,
       path: { workspace_id: workspaceId },
       body,
-    });
-  return { data, error };
+    }
+  );
+  return withStatus(result);
 };
 
 export const revokeWorkspaceInvitation = async (
   workspaceId: string,
   invitationId: string
 ) => {
-  const { data, error } =
+  const result =
     await sdk.revokeInvitationV1WorkspacesWorkspaceIdInvitationsInvitationIdDelete(
       {
         client: serverClient,
         path: { workspace_id: workspaceId, invitation_id: invitationId },
       }
     );
-  return { data, error };
+  return withStatus(result);
 };
 
 export const acceptWorkspaceInvitation = async (token: string) => {
-  const { data, error } = await sdk.acceptInvitationV1InvitationsAcceptPost({
+  const result = await sdk.acceptInvitationV1InvitationsAcceptPost({
     client: serverClient,
     body: { token },
   });
-  return { data, error };
+  return withStatus(result);
 };
 
 export const discoverMCPInstanceTools = async (instanceId: string) => {
@@ -2356,7 +2315,9 @@ export type ConversationResponse = unknown;
 export type TaskResponse = ApiTaskResponse;
 export type AgentCard = ApiAgentCard;
 export type TaskWithAgent = ApiTaskResponse & {
-  agent_name?: string;
+  // null when the task's agent no longer resolves — the API does not
+  // substitute a placeholder name.
+  agent_name?: string | null;
   agent_description?: string | null;
   // Set by the /v1/inbox endpoint for waiting_for_approval tasks so the inbox can
   // approve/reject the pending escalation inline.

--- a/agentarea-webapp/src/lib/events/useTaskEvents.ts
+++ b/agentarea-webapp/src/lib/events/useTaskEvents.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getTaskEvents } from "@/hooks/actions";
+import { apiErrorMessage } from "@/lib/api-errors";
 import { useSSE } from "@/hooks/useSSE";
 import type {
   DisplayEvent,
@@ -243,12 +244,13 @@ export function useTaskEvents(
 
     void (async () => {
       try {
-        const { data, error: apiError } = await getTaskEvents(agentId, taskId, {
+        const result = await getTaskEvents(agentId, taskId, {
           page: 1,
           page_size: 100,
         });
-        if (apiError || !data) {
-          throw new Error(apiError?.toString() || "Failed to load events");
+        const data = result.data;
+        if (result.error || !data) {
+          throw new Error(apiErrorMessage(result, "Failed to load events"));
         }
         if (cancelled) return;
 

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -9785,8 +9785,15 @@
             "type": "string"
           },
           "execution_id": {
-            "title": "Execution Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Execution Id"
           },
           "id": {
             "title": "Id",
@@ -9815,7 +9822,6 @@
           "id",
           "task_id",
           "agent_id",
-          "execution_id",
           "timestamp",
           "event_type",
           "message"
@@ -10136,8 +10142,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "created_at": {
             "title": "Created At",
@@ -10246,7 +10259,6 @@
         "required": [
           "id",
           "agent_id",
-          "agent_name",
           "description",
           "parameters",
           "status",


### PR DESCRIPTION
## What broke

The task Events tab rendered a red **`[object Object]`** banner and no events:

`useTaskEvents` built its message with `apiError?.toString()`. The generated client hands back the parsed error *body*, not a string — so the one clue about what actually failed was replaced by the string every object stringifies to. `tasks/[id]/layout.tsx` had the same bug via `String(error)`.

## One formatter

`src/lib/api-errors.ts` already had `formatApiError`, but three more partial copies had grown alongside it:

| copy | missed |
|---|---|
| `formatErrorDetail` (`lib/api.ts`, 1 caller) | — (the most complete one) |
| `errMsg` (`invite/actions.ts`) | problem+json `errors[]`, `title` |
| `errMsg` (`members/actions.ts`) | identical duplicate of the above |
| `errorDetail` (`add-openapi/form.tsx`) | everything except a string `detail` |

All four are gone. `formatApiError` now handles the shapes the backend actually emits (RFC 9457 `errors[]` and `title`, plus the legacy FastAPI `detail` array), and a new `apiErrorMessage(result, label)` produces `"<label> (<status>): <detail>"` so callers stop hand-rolling it. HTTP status is routed through the existing `withStatus` on the endpoints whose errors are now surfaced.

## Fallbacks that threw the error away

- `listSandboxesAction` replaced **every** failure with `"Sandbox inventory is unavailable"`
- the task Files tab replaced every non-410 failure with `"Live sandbox files are temporarily unavailable"` (410 kept — an expired sandbox is a real state, not a failure)
- both `errMsg` copies fell back to a canned string for any shape they did not recognise

## Placeholders the API invented

A task whose agent no longer resolves was reported as `agent_name="Unknown"` — indistinguishable from an agent actually named that, and exactly what put the confident `Unknown` in the breadcrumb over what was really a *missing agent*. Same story for `execution_id="unknown"`.

Both are now `str | None` and return null. Every UI consumer already treated them as optional (`task.agent_name || \`Agent \${task.agent_id}\``), so a missing agent now reads as missing. `task_service` also stopped stamping `metadata["agent_name"] = "unknown"` in the one branch where no agent was loaded.

OpenAPI spec, both generated clients and the docs copy regenerated — the diff is exactly these two fields and nothing else.

## Not fixed here

This fixes the *reporting*, not the load failure behind the screenshot. `/events` and `/events/stream` both call `agent_service.get(agent_id)` and 404 before reading anything, so one unresolvable agent takes down the history, the live stream and the breadcrumb together. That check is documented in the same function as **not** being the authorization boundary (the repository's workspace filter is), so it is likely removable — but I have no evidence of which case this instance actually hit, so I left the semantics alone. The banner will now name the status and detail, which should settle it.

## Verification

- `vitest run` — 107 passed / 0 failed (5 new in `src/lib/api-errors.test.ts`)
- `tsc --noEmit` — clean
- `eslint .` — clean; `prettier --check` — clean
- `ruff check .` + `ruff format --check .` — clean (649 files)
- `make test` — 875 selected, exit 0, 0 failures (3 new in `test_task_no_placeholder_fields.py`)
- OpenAPI drift check reproduced locally: committed spec == exported spec == docs copy