### PR TITLE
Declare Apache-2.0 everywhere, not MIT in four places

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ version: 0.1.0
 date-released: 2025-01-01
 url: "https://github.com/agentarea/agentarea"
 repository-code: "https://github.com/agentarea/agentarea"
-license: MIT
+license: Apache-2.0
 authors:
   - family-names: "AgentArea"
     given-names: "Contributors"

--- a/agentarea-cli/readme.md
+++ b/agentarea-cli/readme.md
@@ -219,7 +219,7 @@ npm rebuild
 
 ## License
 
-MIT
+Licensed under the Apache License 2.0 — see [LICENSE.md](../LICENSE.md) for details.
 
 ## See Also
 

--- a/agentarea-mcp-manager/README.md
+++ b/agentarea-mcp-manager/README.md
@@ -103,4 +103,4 @@ curl -X POST http://localhost:80/instances \
 
 ## License
 
-MIT
+Licensed under the Apache License 2.0 — see [LICENSE.md](../LICENSE.md) for details.

--- a/agentarea-mcp-manager/api/openapi.yaml
+++ b/agentarea-mcp-manager/api/openapi.yaml
@@ -50,8 +50,8 @@ info:
     name: MCP Manager Support
     url: https://github.com/your-org/mcp-manager
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
 
 servers:
   - url: http://localhost:8000


### PR DESCRIPTION
`LICENSE.md` and the README badge say Apache-2.0, but four other places claimed MIT — the kind of contradiction a buyer's counsel finds in ten minutes.

| File | Was | Now |
|---|---|---|
| `CITATION.cff` | `license: MIT` | `license: Apache-2.0` |
| `agentarea-mcp-manager/api/openapi.yaml` | `MIT` + opensource.org URL | `Apache-2.0` + apache.org URL |
| `agentarea-mcp-manager/README.md` | `MIT` | link to root `LICENSE.md` |
| `agentarea-cli/readme.md` | `MIT` | link to root `LICENSE.md` |

The CLI was self-contradictory on its own: `agentarea-cli/package.json` already declared `Apache-2.0` while its readme said MIT.

Verified: a repo-wide grep (excluding `node_modules` and lock files) finds no remaining MIT declaration; `CITATION.cff` and the OpenAPI spec still parse; both `../LICENSE.md` links resolve to the root license file.

Not touched: `agentarea-webapp/packages/elements-react` and `packages/nextjs` declare `"license": "Apache License 2.0"` — vendored Ory code, same license, but not a valid SPDX identifier.