### PR TITLE
Answer the client MCP mount instead of 421-ing every authenticated call

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
@@ -16,6 +16,7 @@ from contextvars import ContextVar
 from agentarea_agents_sdk.mcp_server.auth import PROTECTED_RESOURCE_SCOPE_KEY
 from agentarea_mcp.application.mcp_aggregator import AggregatedMember, MCPAggregatorProxy
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import TextContent, Tool
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -50,6 +51,12 @@ client_mcp_server = FastMCP(
     instructions="Scoped tool bundle for a registered client (agent-proxy).",
     streamable_http_path="/",
     stateless_http=True,
+    # Same opt-out as the platform ``/mcp`` mount (see ``create_mcp_server``):
+    # FastMCP enables DNS-rebinding protection by default with an empty
+    # ``allowed_hosts``, so every Host header is answered with 421. We run behind
+    # an ingress that owns Host validation, and without this an authenticated
+    # harness gets 421 on every call after finishing its OAuth flow.
+    transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
 )
 
 

--- a/agentarea-platform/apps/api/tests/test_client_mcp_authorization.py
+++ b/agentarea-platform/apps/api/tests/test_client_mcp_authorization.py
@@ -48,3 +48,33 @@ async def test_user_without_use_relation_is_denied(monkeypatch):
 
     with pytest.raises(ClientAccessDeniedError):
         await _authorize_client_access(_ctx(), CLIENT_ID)
+
+
+class TestTransportSecurity:
+    """Host validation belongs to the ingress, not to this mount.
+
+    FastMCP turns DNS-rebinding protection on by default with an empty
+    ``allowed_hosts``, which rejects every Host header with 421. The platform
+    ``/mcp`` server opts out explicitly because it runs behind a reverse proxy;
+    ``/client-mcp`` is the same deployment and must agree, or an authenticated
+    harness gets 421 on every call once it finally has a token.
+    """
+
+    def test_dns_rebinding_protection_is_disabled(self):
+        from agentarea_api.api.v1.client_mcp import client_mcp_server
+
+        security = client_mcp_server.settings.transport_security
+
+        assert security is not None
+        assert security.enable_dns_rebinding_protection is False
+
+    def test_agrees_with_the_platform_mcp_mount(self):
+        from agentarea_agents_sdk.mcp_server import create_mcp_server
+        from agentarea_api.api.v1.client_mcp import client_mcp_server
+
+        platform = create_mcp_server(toolsets=[], name="probe")
+
+        assert (
+            client_mcp_server.settings.transport_security.enable_dns_rebinding_protection
+            is platform.settings.transport_security.enable_dns_rebinding_protection
+        )


### PR DESCRIPTION
Follow-up to #355, found while verifying the harness flow end to end on RU prod.

## Symptom

With a valid token, the two MCP mounts disagree:

```
POST /mcp                    -> 200  (initialize succeeds)
POST /client-mcp/<client id> -> 421  Invalid Host header
```

So even after a harness completes its OAuth flow, its very first `initialize` is rejected and it never sees a tool.

## Cause

`TransportSecuritySettings` defaults to `enable_dns_rebinding_protection=True` with an empty `allowed_hosts`, which rejects **every** Host header. `create_mcp_server()` opts out explicitly for `/mcp`, with a comment that Host validation belongs to the ingress we run behind. `client_mcp.py` builds its `FastMCP` directly and inherited the default instead.

## Fix

Pass the same opt-out, and pin it: one test asserts the setting, the other asserts the two mounts agree, so a third mount cannot quietly inherit the default again.

Local: `ruff check` and `ruff format --check` clean on the changed file; the added tests pass (5 in that file). The rest is CI's to confirm.