### PR TITLE
Check task ownership on the event endpoints, finish the placeholder sweep

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/agents_tasks.py
@@ -1838,13 +1838,14 @@ async def get_task_events(
     task_service: TaskService = Depends(get_read_task_service),
 ):
     """Get paginated task execution events for the specified task from database."""
-    # Gate on the task, not the agent. `agent_id` is a route parameter that is
-    # never tied to the task, so requiring it to resolve gated a task's history
-    # on its agent still existing — deleting an agent silently took the Events
-    # tab of every task it ever ran down with it. The workspace filter inside
-    # the repositories is the actual authorization boundary.
+    # Gate on the task, not the agent. Requiring `agent_id` to still resolve
+    # gated a task's history on its agent existing — deleting an agent silently
+    # took the Events tab of every task it ever ran down with it. The workspace
+    # filter inside the repositories is the actual authorization boundary; the
+    # ownership check matches the sibling task endpoints and keeps the caller
+    # from stamping an arbitrary `agent_id` onto this task's events below.
     task = await task_service.get_task(task_id)
-    if not task:
+    if not task or str(task.agent_id) != str(agent_id):
         raise HTTPException(status_code=404, detail="Task not found")
 
     try:
@@ -1895,10 +1896,12 @@ async def stream_task_events(
 ):
     """Stream real-time task execution events via Server-Sent Events."""
     try:
-        # Gated on the task alone — see get_task_events. An agent that no longer
-        # resolves must not take the live stream of its past tasks down with it.
+        # Gated on the task, not the agent — see get_task_events. An agent that
+        # no longer resolves must not take the live stream of its past tasks
+        # down with it, but `agent_id` still has to own the task: it is echoed
+        # into every frame this stream emits.
         task = await task_service.get_task(task_id)
-        if not task:
+        if not task or str(task.agent_id) != str(agent_id):
             raise HTTPException(status_code=404, detail="Task not found")
 
         # Create SSE stream by tailing the task_events table (single source of

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/dashboard.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/dashboard.py
@@ -49,14 +49,16 @@ class SpendCard(BaseModel):
 class HitlBlocker(BaseModel):
     task_id: UUID
     agent_id: UUID
-    agent_name: str
+    # None when the agent no longer resolves — never a fabricated placeholder.
+    agent_name: str | None = None
     description: str
     created_at: UtcDatetime
 
 
 class WalletExhaustedBlocker(BaseModel):
     agent_id: UUID
-    agent_name: str
+    # None when the agent no longer resolves — never a fabricated placeholder.
+    agent_name: str | None = None
     budget_usd: float
     period: str
 
@@ -64,7 +66,8 @@ class WalletExhaustedBlocker(BaseModel):
 class FailedTaskBlocker(BaseModel):
     task_id: UUID
     agent_id: UUID
-    agent_name: str
+    # None when the agent no longer resolves — never a fabricated placeholder.
+    agent_name: str | None = None
     error: str | None
     occurred_at: UtcDatetime
 
@@ -203,7 +206,7 @@ async def get_dashboard(
         HitlBlocker(
             task_id=t.id,
             agent_id=t.agent_id,
-            agent_name=agent_name_by_id.get(t.agent_id, "unknown"),
+            agent_name=agent_name_by_id.get(t.agent_id),
             description=t.description,
             created_at=t.created_at,
         )
@@ -215,7 +218,7 @@ async def get_dashboard(
     wallet_exhausted = [
         WalletExhaustedBlocker(
             agent_id=w.agent_id,
-            agent_name=agent_name_by_id.get(w.agent_id, "unknown"),
+            agent_name=agent_name_by_id.get(w.agent_id),
             budget_usd=float(w.service_budget_usd),
             period=w.service_budget_period,
         )
@@ -236,7 +239,7 @@ async def get_dashboard(
         FailedTaskBlocker(
             task_id=t.id,
             agent_id=t.agent_id,
-            agent_name=agent_name_by_id.get(t.agent_id, "unknown"),
+            agent_name=agent_name_by_id.get(t.agent_id),
             error=t.error,
             occurred_at=t.completed_at or t.updated_at,
         )

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/inbox.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/inbox.py
@@ -126,7 +126,7 @@ async def get_inbox_items(
                 TaskWithAgent(
                     id=task.id,
                     agent_id=task.agent_id,
-                    agent_name=agent_map.get(str(task.agent_id), "Unknown"),
+                    agent_name=agent_map.get(str(task.agent_id)),
                     description=task.description,
                     parameters=task.parameters,
                     status=task.status,

--- a/agentarea-platform/apps/api/tests/test_task_events_outlive_agent.py
+++ b/agentarea-platform/apps/api/tests/test_task_events_outlive_agent.py
@@ -164,6 +164,34 @@ async def test_a_task_belonging_to_another_agent_is_still_a_404(async_client, ta
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", ["/events", "/events/stream"])
+async def test_events_reject_an_agent_id_that_does_not_own_the_task(
+    async_client, task_service, suffix
+):
+    """`agent_id` is echoed into every event, so it has to own the task.
+
+    Without this the caller picks the `agent_id` stamped onto another agent's
+    event history — the same fabricated-identifier defect this series removes.
+    """
+    task_service.get_task.return_value = AgentTask(
+        id=TASK_ID,
+        title="task",
+        description="someone else's task",
+        query="q",
+        user_id="test_user",
+        workspace_id="test_workspace",
+        agent_id=uuid4(),
+        status="completed",
+        execution_id="exec-9",
+    )
+
+    response = await async_client.get(f"/v1/agents/{DELETED_AGENT_ID}/tasks/{TASK_ID}{suffix}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Task not found"
+
+
+@pytest.mark.asyncio
 async def test_a_task_that_does_not_exist_is_still_a_404(async_client, task_service):
     task_service.get_task.return_value = None
 

--- a/agentarea-platform/apps/api/tests/test_task_no_placeholder_fields.py
+++ b/agentarea-platform/apps/api/tests/test_task_no_placeholder_fields.py
@@ -7,10 +7,17 @@ agent — and callers had no way to detect the difference. Absent means null.
 """
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
+import pytest
+import pytest_asyncio
+from agentarea_api.api.deps.services import get_read_agent_service, get_read_task_service
 from agentarea_api.api.v1.agents_tasks import TaskEvent, TaskResponse, TaskWithAgent
-from agentarea_tasks.domain.models import AgentTask
+from agentarea_api.main import app
+from agentarea_common.auth.dependencies import get_user_context
+from agentarea_tasks.domain.models import AgentTask, Task
+from httpx import ASGITransport, AsyncClient
 
 
 def _agent_task() -> AgentTask:
@@ -41,6 +48,56 @@ def test_agent_name_is_carried_through_when_it_does_resolve() -> None:
     with_agent = TaskWithAgent.from_task_response(response, "neuresearch")
 
     assert with_agent.agent_name == "neuresearch"
+
+
+@pytest_asyncio.fixture
+async def async_client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_the_task_endpoint_returns_a_null_agent_name_for_a_deleted_agent(async_client):
+    """The contract that matters is the endpoint's, not the helper's.
+
+    GET /v1/tasks/{id} is what the task page reads; it builds TaskWithAgent
+    inline rather than through from_task_response.
+    """
+    # get_task_by_id reads through task_repository._orm_to_domain, which yields
+    # a Task (not an AgentTask) — the model the endpoint's fields come from.
+    task = Task(
+        id=uuid4(),
+        agent_id=uuid4(),
+        description="do the thing",
+        parameters={},
+        status="completed",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    task_service = AsyncMock()
+    task_service.task_repository.get_by_id = AsyncMock(return_value=object())
+    task_service.task_repository._orm_to_domain = MagicMock(return_value=task)
+
+    agent_service = AsyncMock()
+    agent_service.get_with_catalog.return_value = None
+
+    user_context = MagicMock()
+    user_context.user_id = "user-1"
+    user_context.workspace_id = "workspace-1"
+
+    app.dependency_overrides[get_read_task_service] = lambda: task_service
+    app.dependency_overrides[get_read_agent_service] = lambda: agent_service
+    app.dependency_overrides[get_user_context] = lambda: user_context
+    try:
+        response = await async_client.get(f"/v1/tasks/{task.id}")
+    finally:
+        for dep in (get_read_task_service, get_read_agent_service, get_user_context):
+            app.dependency_overrides.pop(dep, None)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["agent_name"] is None
 
 
 def test_task_event_execution_id_is_null_rather_than_a_placeholder() -> None:

--- a/agentarea-webapp/packages/api-client/src/generated/types.gen.ts
+++ b/agentarea-webapp/packages/api-client/src/generated/types.gen.ts
@@ -2161,7 +2161,7 @@ export type FailedTaskBlocker = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Error
      */
@@ -2337,7 +2337,7 @@ export type HitlBlocker = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Created At
      */
@@ -6688,7 +6688,7 @@ export type WalletExhaustedBlocker = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Budget Usd
      */

--- a/agentarea-webapp/packages/api-client/types/generated/types.gen.d.ts
+++ b/agentarea-webapp/packages/api-client/types/generated/types.gen.d.ts
@@ -2077,7 +2077,7 @@ export type FailedTaskBlocker = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Error
      */
@@ -2244,7 +2244,7 @@ export type HitlBlocker = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Created At
      */
@@ -6456,7 +6456,7 @@ export type WalletExhaustedBlocker = {
     /**
      * Agent Name
      */
-    agent_name: string;
+    agent_name?: string | null;
     /**
      * Budget Usd
      */

--- a/agentarea-webapp/src/api/client/types.gen.ts
+++ b/agentarea-webapp/src/api/client/types.gen.ts
@@ -2173,7 +2173,7 @@ export type FailedTaskBlocker = {
   /**
    * Agent Name
    */
-  agent_name: string;
+  agent_name?: string | null;
   /**
    * Error
    */
@@ -2349,7 +2349,7 @@ export type HitlBlocker = {
   /**
    * Agent Name
    */
-  agent_name: string;
+  agent_name?: string | null;
   /**
    * Created At
    */
@@ -6717,7 +6717,7 @@ export type WalletExhaustedBlocker = {
   /**
    * Agent Name
    */
-  agent_name: string;
+  agent_name?: string | null;
   /**
    * Budget Usd
    */

--- a/agentarea-webapp/src/api/client/zod.gen.ts
+++ b/agentarea-webapp/src/api/client/zod.gen.ts
@@ -793,7 +793,7 @@ export const zExecutionTimelineResponse = z.object({
  */
 export const zFailedTaskBlocker = z.object({
   agent_id: z.string().uuid(),
-  agent_name: z.string(),
+  agent_name: z.string().nullish(),
   error: z.string().nullable(),
   occurred_at: z.string(),
   task_id: z.string().uuid(),
@@ -875,7 +875,7 @@ export const zHeaderOutput = z.object({
  */
 export const zHitlBlocker = z.object({
   agent_id: z.string().uuid(),
-  agent_name: z.string(),
+  agent_name: z.string().nullish(),
   created_at: z.string(),
   description: z.string(),
   task_id: z.string().uuid(),
@@ -2851,7 +2851,7 @@ export const zWalletCredentialsSchema = z.object({
  */
 export const zWalletExhaustedBlocker = z.object({
   agent_id: z.string().uuid(),
-  agent_name: z.string(),
+  agent_name: z.string().nullish(),
   budget_usd: z.number(),
   period: z.string(),
 });

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -3781,8 +3781,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "error": {
             "anyOf": [
@@ -3808,7 +3815,6 @@
         "required": [
           "task_id",
           "agent_id",
-          "agent_name",
           "error",
           "occurred_at"
         ],
@@ -4035,8 +4041,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "created_at": {
             "title": "Created At",
@@ -4055,7 +4068,6 @@
         "required": [
           "task_id",
           "agent_id",
-          "agent_name",
           "description",
           "created_at"
         ],
@@ -11398,8 +11410,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "budget_usd": {
             "title": "Budget Usd",
@@ -11412,7 +11431,6 @@
         },
         "required": [
           "agent_id",
-          "agent_name",
           "budget_usd",
           "period"
         ],

--- a/agentarea-webapp/src/lib/api-errors.test.ts
+++ b/agentarea-webapp/src/lib/api-errors.test.ts
@@ -32,6 +32,17 @@ describe("apiErrorMessage", () => {
     );
   });
 
+  it("never emits [object Object] for a validation item with no msg field", () => {
+    const message = apiErrorMessage(
+      { error: { errors: [{ field: "page_size", reason: "too large" }] }, status: 422 },
+      "Failed"
+    );
+
+    expect(message).not.toContain("[object Object]");
+    expect(message).toContain("page_size");
+    expect(message).toContain("too large");
+  });
+
   it("keeps the status when the body carries no readable message", () => {
     const message = apiErrorMessage({ error: {}, status: 500 }, "Failed");
 

--- a/agentarea-webapp/src/lib/api-errors.ts
+++ b/agentarea-webapp/src/lib/api-errors.ts
@@ -17,8 +17,16 @@ export function isApiNotFound(value: unknown) {
 }
 
 function itemMessage(item: unknown) {
-  if (item && typeof item === "object" && "msg" in item) {
-    return String((item as { msg: unknown }).msg);
+  if (item && typeof item === "object") {
+    const record = item as Record<string, unknown>;
+    if (typeof record.msg === "string") return record.msg;
+    // Any other object shape: `String(item)` here would put the very
+    // "[object Object]" this module exists to prevent into the message.
+    try {
+      return JSON.stringify(item);
+    } catch {
+      return "";
+    }
   }
   return String(item);
 }

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3781,8 +3781,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "error": {
             "anyOf": [
@@ -3808,7 +3815,6 @@
         "required": [
           "task_id",
           "agent_id",
-          "agent_name",
           "error",
           "occurred_at"
         ],
@@ -4035,8 +4041,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "created_at": {
             "title": "Created At",
@@ -4055,7 +4068,6 @@
         "required": [
           "task_id",
           "agent_id",
-          "agent_name",
           "description",
           "created_at"
         ],
@@ -11398,8 +11410,15 @@
             "type": "string"
           },
           "agent_name": {
-            "title": "Agent Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
           },
           "budget_usd": {
             "title": "Budget Usd",
@@ -11412,7 +11431,6 @@
         },
         "required": [
           "agent_id",
-          "agent_name",
           "budget_usd",
           "period"
         ],


### PR DESCRIPTION
Fixes the four findings from the code review of #352 / #354 that landed on **my** work in that series. (Findings in the same review about the Go MCP manager belong to #347, not this series — left alone.)

## 1. Event endpoints never checked task↔agent ownership

`get_task_events` and `stream_task_events` did not enforce `task.agent_id == agent_id`, unlike the three sibling task endpoints (`:934`, `:985`, `:1213`).

That was already true before #354 — but #354 removed the agent-existence gate, so `agent_id` became **completely unvalidated**, and it is stamped verbatim into every returned event and every SSE frame:

```python
agent_id=str(agent_id),   # unvalidated route param, echoed as fact
```

A fabricated identifier in the response is precisely what this series set out to remove. Both endpoints now 404 unless the task belongs to the agent. Test is parametrized across `/events` and `/events/stream`.

## 2. Placeholder sweep was incomplete

#352 made `TaskWithAgent.agent_name` nullable but missed two callers that kept substituting into it:

| | was | now |
|---|---|---|
| `inbox.py:129` | `agent_map.get(…, "Unknown")` | `agent_map.get(…)` |
| `dashboard.py:209/221/242` | `agent_name_by_id.get(…, "unknown")` | `agent_name_by_id.get(…)` |

The three dashboard blocker models (`HitlBlocker`, `WalletExhaustedBlocker`, `FailedTaskBlocker`) are now `agent_name: str | None`.

## 3. `[object Object]` still reachable — through a path #352 added

`itemMessage` fell through to `String(item)` for a validation entry that is an object without a `msg` field. Reproduced before fixing:

```
errors[{field,reason}] -> [object Object]
```

The `errors[]` branch that reaches it was **added in #352**, so that PR shipped a new route to the exact bug it was fixing. Now serializes the entry. Regression test asserts the output contains the field and reason and never the literal.

## 4. A test that proved nothing

`test_task_no_placeholder_fields` exercised `TaskWithAgent.from_task_response`, which has **zero production callers** — every endpoint builds the model inline. Retargeted at `GET /v1/tasks/{id}`, the endpoint the task page actually reads.

Writing it surfaced why the helper is unused: `_orm_to_domain` yields `Task`, not `AgentTask`, and only `Task` has `parameters`.

## Verification

- `make test` — 886 selected, exit 0, 0 failures
- `vitest run` — 103 passed / 0 failed
- `tsc --noEmit`, `eslint .`, `prettier --check` — all clean
- `ruff check .` + `ruff format --check .` — clean, 649 files
- Spec, both generated clients and the docs copy regenerated for the nullable dashboard fields; drift check reproduced locally

A first pass at this commit also swept 8 unrelated test files into a `ruff format` run; that churn was reverted, so the diff is 13 files, all intentional.