### PR TITLE
Scope a codex bundle to the project it belongs to

### DIFF
--- a/agentarea-cli/source/cli.tsx
+++ b/agentarea-cli/source/cli.tsx
@@ -35,7 +35,9 @@ const cli = meow(
 	  --alias         Local MCP server name in the harness (default: agentarea)
 	  --mcp           MCP instance (name or id) to attach to the client
 	  --no-login      Skip the harness's own OAuth step after wiring it up
-	  --scope         Connection scope: project or user (default: project)
+	  --scope         project = write ./.codex/config.toml (codex) or the
+	                  project scope (claude); user = the harness's own global
+	                  config (default: project)
 	  --client        Existing client id for 'mcp sync'
 	  --target        Harness for 'mcp sync': codex or claude (default: codex)
 	  --data          JSON request body (api / tasks submit)

--- a/agentarea-cli/source/commands/connect.ts
+++ b/agentarea-cli/source/commands/connect.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import * as sdk from '@agentarea/api-client';
 import {
 	attachMcpInstance,
+	codexProjectConfigPath,
+	codexSeesServer,
 	defaultClientName,
 	harnessAddArgs,
 	harnessLoginArgs,
@@ -11,6 +13,7 @@ import {
 	resolveMcpInstanceId,
 	resolveOrCreateClient,
 	runHarnessCommand,
+	upsertCodexServer,
 	type ClientApi,
 	type ClientRecord,
 	type ClientRef,
@@ -239,11 +242,41 @@ export async function connectClient(
 	}
 
 	const alias = options.alias ?? mcpAlias('default');
-	await runHarnessCommand(
-		harness,
-		harnessAddArgs(harness, {alias, url: mcpUrl, scope}),
-	);
-	console.log(`Registered MCP server "${alias}" with ${harness}`);
+	if (harness === 'codex' && scope === 'project') {
+		// `codex mcp add` only ever writes the user-wide config, so a project
+		// scope has to be written as the file codex itself resolves: it walks up
+		// from the working directory and the closest .codex/config.toml wins.
+		const configPath = codexProjectConfigPath(process.cwd());
+		let existing = '';
+		try {
+			existing = await fs.readFile(configPath, 'utf8');
+		} catch (error: unknown) {
+			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+				throw error;
+			}
+		}
+
+		await fs.mkdir(path.dirname(configPath), {recursive: true});
+		await fs.writeFile(
+			configPath,
+			upsertCodexServer(existing, alias, mcpUrl),
+			'utf8',
+		);
+		console.log(`Wrote ${configPath}`);
+
+		if (!(await codexSeesServer(alias))) {
+			console.error(
+				`codex does not resolve "${alias}" from ${process.cwd()} — a project-scoped config is only read for a trusted project. Trust this directory in codex (or use --scope=user) and run this again.`,
+			);
+			return false;
+		}
+	} else {
+		await runHarnessCommand(
+			harness,
+			harnessAddArgs(harness, {alias, url: mcpUrl, scope}),
+		);
+		console.log(`Registered MCP server "${alias}" with ${harness}`);
+	}
 
 	const loginArgs = harnessLoginArgs(harness, alias);
 	if (loginArgs && options.login !== false) {

--- a/agentarea-cli/source/commands/harness.test.ts
+++ b/agentarea-cli/source/commands/harness.test.ts
@@ -1,12 +1,14 @@
 import test from 'ava';
 import {
 	attachMcpInstance,
+	codexProjectConfigPath,
 	defaultClientName,
 	harnessAddArgs,
 	harnessLoginArgs,
 	mcpAlias,
 	resolveMcpInstanceId,
 	resolveOrCreateClient,
+	upsertCodexServer,
 	type ClientApi,
 	type ClientRecord,
 } from './harness.js';
@@ -190,4 +192,59 @@ test('attachMcpInstance is idempotent against what the client already has', asyn
 		'attached',
 	);
 	t.is(calls, 1);
+});
+
+const PROJECT_URL = 'https://api.example.test/client-mcp/abc';
+
+test('codexProjectConfigPath points at the project-scoped file codex reads', t => {
+	t.is(codexProjectConfigPath('/repo'), '/repo/.codex/config.toml');
+});
+
+test('upsertCodexServer writes a managed block into an empty file', t => {
+	const written = upsertCodexServer('', 'agentarea_tg', PROJECT_URL);
+
+	t.is(
+		written,
+		[
+			'# >>> agentarea-cli managed: agentarea_tg',
+			'[mcp_servers.agentarea_tg]',
+			`url = "${PROJECT_URL}"`,
+			'# <<< agentarea-cli managed: agentarea_tg',
+			'',
+		].join('\n'),
+	);
+});
+
+test('upsertCodexServer keeps unrelated config intact', t => {
+	const existing = '[mcp_servers.other]\nurl = "https://other.test/mcp"\n';
+
+	const written = upsertCodexServer(existing, 'agentarea_tg', PROJECT_URL);
+
+	t.true(written.startsWith(existing.trimEnd()));
+	t.true(written.includes('[mcp_servers.agentarea_tg]'));
+	t.true(written.includes('[mcp_servers.other]'));
+});
+
+test('upsertCodexServer is idempotent and refreshes the url in place', t => {
+	const once = upsertCodexServer('', 'agentarea_tg', PROJECT_URL);
+
+	t.is(upsertCodexServer(once, 'agentarea_tg', PROJECT_URL), once);
+
+	const moved = upsertCodexServer(
+		once,
+		'agentarea_tg',
+		'https://api.example.test/client-mcp/xyz',
+	);
+	t.true(moved.includes('client-mcp/xyz'));
+	t.false(moved.includes('client-mcp/abc'));
+	t.is(moved.match(/\[mcp_servers\.agentarea_tg]/g)?.length, 1);
+});
+
+test('upsertCodexServer refuses to clobber a hand-written entry', t => {
+	const existing =
+		'[mcp_servers.agentarea_tg]\nurl = "https://hand.written/mcp"\n';
+
+	t.throws(() => upsertCodexServer(existing, 'agentarea_tg', PROJECT_URL), {
+		message: /unmanaged/i,
+	});
 });

--- a/agentarea-cli/source/commands/harness.test.ts
+++ b/agentarea-cli/source/commands/harness.test.ts
@@ -209,6 +209,8 @@ test('upsertCodexServer writes a managed block into an empty file', t => {
 			'# >>> agentarea-cli managed: agentarea_tg',
 			'[mcp_servers.agentarea_tg]',
 			`url = "${PROJECT_URL}"`,
+			'startup_timeout_sec = 60',
+			'tool_timeout_sec = 120',
 			'# <<< agentarea-cli managed: agentarea_tg',
 			'',
 		].join('\n'),
@@ -247,4 +249,13 @@ test('upsertCodexServer refuses to clobber a hand-written entry', t => {
 	t.throws(() => upsertCodexServer(existing, 'agentarea_tg', PROJECT_URL), {
 		message: /unmanaged/i,
 	});
+});
+
+test('upsertCodexServer budgets for a bundle that aggregates its members', t => {
+	// Codex drops a server that misses its 10s startup budget, silently: no
+	// tools, no error. A bundle's tools/list fans out to every member MCP.
+	const written = upsertCodexServer('', 'agentarea_tg', PROJECT_URL);
+
+	t.true(written.includes('startup_timeout_sec = 60'));
+	t.true(written.includes('tool_timeout_sec = 120'));
 });

--- a/agentarea-cli/source/commands/harness.ts
+++ b/agentarea-cli/source/commands/harness.ts
@@ -9,6 +9,9 @@ import {spawn} from 'node:child_process';
  * its OAuth tokens in a store only it can read.
  */
 
+const STARTUP_TIMEOUT_SEC = 60;
+const TOOL_TIMEOUT_SEC = 120;
+
 export type Harness = 'codex' | 'claude';
 export type Scope = 'project' | 'user';
 
@@ -218,6 +221,12 @@ export function upsertCodexServer(
 		managedStart(alias),
 		`[mcp_servers.${alias}]`,
 		`url = "${url}"`,
+		// Codex defaults to a 10s startup budget, and it drops a server that
+		// misses it without a word in the log. A bundle aggregates every member
+		// MCP's tools on `tools/list`, which measured ~15s for a single member
+		// against prod, so the default is not survivable here.
+		`startup_timeout_sec = ${STARTUP_TIMEOUT_SEC}`,
+		`tool_timeout_sec = ${TOOL_TIMEOUT_SEC}`,
 		managedEnd(alias),
 		'',
 	].join('\n');

--- a/agentarea-cli/source/commands/harness.ts
+++ b/agentarea-cli/source/commands/harness.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {spawn} from 'node:child_process';
 
 /**
@@ -176,6 +177,84 @@ export async function runHarnessCommand(
 			reject(
 				new Error(`\`${bin} ${args.join(' ')}\` exited with code ${code}`),
 			);
+		});
+	});
+}
+
+function escapeForRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function managedStart(alias: string): string {
+	return `# >>> agentarea-cli managed: ${alias}`;
+}
+
+function managedEnd(alias: string): string {
+	return `# <<< agentarea-cli managed: ${alias}`;
+}
+
+/**
+ * Where codex reads a project-scoped server from. Codex walks up from the
+ * working directory to the project root and the closest file wins, so a repo
+ * can carry its own bundle without touching the user-wide config — which is
+ * also the config other tools rewrite.
+ */
+export function codexProjectConfigPath(projectRoot: string): string {
+	return path.join(projectRoot, '.codex', 'config.toml');
+}
+
+/**
+ * Merge one server into a project `config.toml`, leaving everything else alone.
+ * `codex mcp add` cannot do this — it only ever writes the user-wide config —
+ * so this is the one place we edit a harness's file, and only inside markers we
+ * own. An entry of the same name that we did not write is left untouched.
+ */
+export function upsertCodexServer(
+	existing: string,
+	alias: string,
+	url: string,
+): string {
+	const block = [
+		managedStart(alias),
+		`[mcp_servers.${alias}]`,
+		`url = "${url}"`,
+		managedEnd(alias),
+		'',
+	].join('\n');
+
+	const managed = new RegExp(
+		`${escapeForRegExp(managedStart(alias))}[\\s\\S]*?${escapeForRegExp(
+			managedEnd(alias),
+		)}\n?`,
+		'm',
+	);
+	if (managed.test(existing)) {
+		return existing.replace(managed, block);
+	}
+
+	const table = new RegExp(`^\\[mcp_servers\\.${escapeForRegExp(alias)}]`, 'm');
+	if (table.test(existing)) {
+		throw new Error(
+			`Refusing to overwrite the unmanaged codex MCP entry "${alias}"; rename it or pass a different --alias`,
+		);
+	}
+
+	return existing.trim() ? `${existing.trimEnd()}\n\n${block}` : block;
+}
+
+/**
+ * Ask codex whether it actually resolves *alias* from the current directory.
+ * A project-scoped file is ignored for an untrusted project, and codex says so
+ * nowhere on write — only a later `mcp login` fails with "No MCP server named".
+ */
+export async function codexSeesServer(alias: string): Promise<boolean> {
+	return new Promise<boolean>(resolve => {
+		const child = spawn('codex', ['mcp', 'get', alias], {stdio: 'ignore'});
+		child.on('error', () => {
+			resolve(false);
+		});
+		child.on('close', code => {
+			resolve(code === 0);
 		});
 	});
 }

--- a/agentarea-webapp/src/app/(main)/clients/[id]/page.tsx
+++ b/agentarea-webapp/src/app/(main)/clients/[id]/page.tsx
@@ -444,6 +444,14 @@ export default function ClientDetailPage() {
                 {client.description ||
                   "A governed, scoped tool bundle an external harness can connect to over MCP."}
               </p>
+              {client.created_by && (
+                <p className="text-xs text-muted-foreground">
+                  Registered by{" "}
+                  <span className="font-medium text-foreground">
+                    {client.created_by}
+                  </span>
+                </p>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
Follow-up to #355. `--scope` was only honoured for claude — for codex every bundle landed in the user-wide `$CODEX_HOME/config.toml`.

## Why the difference existed

`codex mcp add` has no scope flag; it always writes the user-wide config. But codex itself does read a project-scoped file — per the docs, MCP servers can be scoped "to a project with `.codex/config.toml` (trusted projects only)", resolved by walking up from the working directory with the closest file winning. So the scope exists, just not through that command.

## What changed

- `--scope=project` (already the flag default) writes `./.codex/config.toml`. `--scope=user` still shells out to `codex mcp add`.
- The entry lives inside `# >>> agentarea-cli managed: <alias>` markers: unrelated config is preserved, re-running only refreshes the url, and an entry of the same name that we did not write is refused rather than clobbered.
- After writing we ask codex whether it actually resolves the server (`codex mcp get`) and stop with the reason if it does not. A project config is silently ignored for an untrusted project, and without this the user only finds out later, as `No MCP server named '<alias>'` from `mcp login`.

Editing a harness's own file is the thing #355 deliberately avoided, so to be explicit: it is done here only because codex's CLI cannot express this scope, and only inside markers we own.

## Verified

Against RU prod, with the client from #355:

- in a git repo: file written, codex resolves it (`codex mcp get agentarea_tg` → the client-mcp url), user-wide config untouched;
- in an untrusted scratch directory: file written, then the run stops with the trust explanation instead of pretending it worked;
- `pnpm run test` (prettier + tsc + ava): 40 passing, 5 of them new for the TOML merge.