### PR TITLE
Stop paying for a bundle's members one at a time

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
@@ -112,17 +112,19 @@ async def _resolve_client_scope(
         instance_urls: dict[str, str] = {}
         instance_names: dict[str, str] = {}
         instance_headers: dict[str, dict[str, str]] = {}
+        instance_transports: dict[str, str | None] = {}
         for order, (iid, inst) in enumerate(instances.items()):
             full = await instance_service.repository.get_by_id(inst.id)
             if full is None:
                 continue
             try:
-                url, headers, _transport = await instance_service._resolve_mcp_url_and_headers(full)
+                url, headers, transport = await instance_service._resolve_mcp_url_and_headers(full)
             except Exception:
                 logger.exception("Failed to resolve MCP url for instance %s", iid)
                 continue
             instance_urls[iid] = url
             instance_names[iid] = full.name
+            instance_transports[iid] = transport
             if headers:
                 instance_headers[iid] = headers
             members.append(
@@ -130,6 +132,7 @@ async def _resolve_client_scope(
                     mcp_instance_id=iid,
                     order=order,
                     namespace_prefix=namespaces.get(iid),
+                    transport=instance_transports[iid],
                 )
             )
         proxy = MCPAggregatorProxy(

--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/mcp_aggregator.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/mcp_aggregator.py
@@ -8,6 +8,7 @@ a Project bundle, or a standalone compound.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 from collections.abc import Callable
@@ -44,6 +45,10 @@ class AggregatedMember:
     order: int = 0
     namespace_prefix: str | None = None
     config: dict = field(default_factory=dict)
+    # Transport declared by the instance's spec. Without it every discovery
+    # re-probes by URL suffix, and a wrong first candidate costs a full connect
+    # timeout — on every tools/list, not once.
+    transport: str | None = None
 
 
 class MCPAggregatorProxy:
@@ -67,14 +72,14 @@ class MCPAggregatorProxy:
         self._server: FastMCP | None = None
 
     @staticmethod
-    def _streamable_candidates(url: str) -> list[str]:
+    def _streamable_candidates(url: str, transport: str | None = None) -> list[str]:
         """Ordered streamable-HTTP URLs to try for a member, via the shared resolver.
 
         Honors the URL as-given first (root-streamable remotes like Vercel), then
         /mcp. The aggregator speaks streamable-HTTP only, so an sse-suffixed member
         URL is best-effort mapped to its /mcp sibling.
         """
-        streamable_urls, _ = mcp_transport_candidates(url)
+        streamable_urls, _ = mcp_transport_candidates(url, transport)
         if streamable_urls:
             return streamable_urls
         base = url.rstrip("/")
@@ -88,6 +93,9 @@ class MCPAggregatorProxy:
             return name.lower().replace(" ", "_").replace("-", "_")
         return str(member.mcp_instance_id)[:8]
 
+    def _candidates_for(self, member: AggregatedMember, url: str) -> list[str]:
+        return self._streamable_candidates(url, member.transport)
+
     async def _discover_member_tools(self, member: AggregatedMember) -> list[dict[str, Any]]:
         instance_id = str(member.mcp_instance_id)
         mcp_url = self.instance_urls.get(instance_id)
@@ -96,7 +104,7 @@ class MCPAggregatorProxy:
             return []
         headers = self.instance_headers.get(instance_id) or None
         last_err: BaseException | None = None
-        for candidate in self._streamable_candidates(mcp_url):
+        for candidate in self._candidates_for(member, mcp_url):
             try:
                 async with streamablehttp_client(
                     candidate, timeout=timedelta(seconds=10), headers=headers
@@ -134,7 +142,7 @@ class MCPAggregatorProxy:
         if not mcp_url:
             raise ValueError(f"No URL for member instance {instance_id}")
         headers = self.instance_headers.get(instance_id) or None
-        candidates = self._streamable_candidates(mcp_url)
+        candidates = self._candidates_for(member, mcp_url)
         last_err: BaseException | None = None
         for idx, candidate in enumerate(candidates):
             try:
@@ -226,10 +234,17 @@ class MCPAggregatorProxy:
         Used by the dynamically-scoped client endpoint, which drives the MCP
         protocol itself instead of minting a standalone FastMCP server.
         """
+        # One network round trip per member, so fan out: serialising them makes
+        # a bundle cost the sum of its members, and a harness pays that on every
+        # session start. gather keeps the member order of the results.
+        discovered = await asyncio.gather(
+            *(self._discover_member_tools(member) for member in self.members)
+        )
+
         aggregated: list[dict[str, Any]] = []
-        for member in self.members:
+        for member, tools in zip(self.members, discovered, strict=True):
             namespace = self._get_namespace(member)
-            for tool in await self._discover_member_tools(member):
+            for tool in tools:
                 aggregated.append(
                     {
                         "name": f"{namespace}{NS_SEP}{tool['name']}",

--- a/agentarea-platform/libs/mcp/tests/test_mcp_aggregator.py
+++ b/agentarea-platform/libs/mcp/tests/test_mcp_aggregator.py
@@ -85,3 +85,51 @@ async def test_call_namespaced_tool_unknown_raises():
     p = _proxy([AggregatedMember(mcp_instance_id="1", namespace_prefix="gh")])
     with pytest.raises(ValueError):
         await p.call_namespaced_tool("nope__x", {})
+
+
+def test_streamable_candidates_honor_a_declared_transport():
+    # A declared transport is authoritative: probing a second candidate costs a
+    # full connect timeout per discovery, and discovery runs on every tools/list.
+    assert MCPAggregatorProxy._streamable_candidates(
+        "http://mcp-x:8000", "streamable-http"
+    ) == ["http://mcp-x:8000"]
+
+
+def test_declared_transport_reaches_the_candidate_resolver():
+    member = AggregatedMember(mcp_instance_id="1", transport="streamable-http")
+    proxy = _proxy([member])
+
+    assert proxy._candidates_for(member, "http://mcp-x:8000") == ["http://mcp-x:8000"]
+
+
+def test_unknown_transport_still_probes():
+    member = AggregatedMember(mcp_instance_id="1")
+    proxy = _proxy([member])
+
+    assert proxy._candidates_for(member, "http://mcp-x:8000") == [
+        "http://mcp-x:8000",
+        "http://mcp-x:8000/mcp",
+    ]
+
+
+async def test_members_are_discovered_concurrently(monkeypatch):
+    # Discovery is a network round trip per member (~15s against prod for one).
+    # Serialising them makes a bundle's tools/list cost the sum, and a harness
+    # pays it on every session start.
+    import asyncio
+
+    members = [AggregatedMember(mcp_instance_id=str(i), namespace_prefix=f"n{i}") for i in range(3)]
+    proxy = _proxy(members)
+
+    async def slow_discovery(member):
+        await asyncio.sleep(0.3)
+        return [{"name": "t", "description": "", "inputSchema": {}}]
+
+    monkeypatch.setattr(proxy, "_discover_member_tools", slow_discovery)
+
+    started = asyncio.get_running_loop().time()
+    tools = await proxy.list_namespaced_tools()
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert [t["name"] for t in tools] == ["n0__t", "n1__t", "n2__t"]
+    assert elapsed < 0.6, f"members were serialised: {elapsed:.2f}s for 3 x 0.3s"


### PR DESCRIPTION
Found while checking why codex saw no tools from a client bundle. Measured against RU prod, `/client-mcp/<id>`:

```
initialize   0.36s
tools/list  16.1s / 15.4s / 15.3s   (three consecutive calls — no cache, fixed cost)
```

A harness pays that on every session start.

## What was wrong

- **Members were discovered serially.** `list_namespaced_tools` walked `for member in self.members` with an `await` inside, so the round trips added up: three members ≈ three times the wait, for work that has no ordering dependency. They now fan out with `asyncio.gather`, which preserves member order for namespacing.
- **The declared transport was dropped.** `_resolve_mcp_url_and_headers` returns it and `_call_tool_via_mcp` honours it, but the aggregator path assigned it to `_transport` and called `mcp_transport_candidates(url)` with no transport — so it re-probed by URL suffix. Its own docstring says a declared transport is authoritative and skips probing; without it a URL with no `/mcp` suffix connects to the wrong candidate first and eats the full 10s connect timeout, on every discovery.

## Tests

- a declared transport yields exactly one candidate, an unknown one still probes both;
- the member fan-out is concurrent: three members with a 0.3s stub complete in under 0.6s, and the namespaced order still matches the member order.

## Not in scope

Discovery is still uncached, which is what remains of the ~15s for a single member. That needs its own change: for a third-party remote the tool list moves without anything on our row changing, so key-by-version does not help and it needs a short TTL, stale-while-revalidate, and invalidation when a call hits a tool the upstream no longer has.