### PR TITLE
Serve a bundle's tools from the row that already holds them

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
@@ -133,6 +133,7 @@ async def _resolve_client_scope(
                     order=order,
                     namespace_prefix=namespaces.get(iid),
                     transport=instance_transports[iid],
+                    tools=full.tools,
                 )
             )
         proxy = MCPAggregatorProxy(

--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/mcp_aggregator.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/mcp_aggregator.py
@@ -49,6 +49,10 @@ class AggregatedMember:
     # re-probes by URL suffix, and a wrong first candidate costs a full connect
     # timeout — on every tools/list, not once.
     transport: str | None = None
+    # Tools verification already discovered and persisted on the instance row.
+    # None means "nothing stored yet" (never verified) and falls back to a live
+    # listing; an empty list is a real answer and is honoured as one.
+    tools: list[dict[str, Any]] | None = None
 
 
 class MCPAggregatorProxy:
@@ -97,6 +101,28 @@ class MCPAggregatorProxy:
         return self._streamable_candidates(url, member.transport)
 
     async def _discover_member_tools(self, member: AggregatedMember) -> list[dict[str, Any]]:
+        """Tools for a member, preferring what verification already stored.
+
+        Listing upstream is a full session per member per call — ~15s against
+        prod for one member — and it re-derives what the instance row already
+        holds. The stored copy moves when the instance is verified or refreshed,
+        which is also what the instance page shows.
+        """
+        if member.tools is not None:
+            return [
+                {
+                    "name": tool.get("name", ""),
+                    "description": tool.get("description", "") or "",
+                    "inputSchema": tool.get("inputSchema") or {"type": "object"},
+                }
+                for tool in member.tools
+                if tool.get("name")
+            ]
+        return await self._discover_member_tools_upstream(member)
+
+    async def _discover_member_tools_upstream(
+        self, member: AggregatedMember
+    ) -> list[dict[str, Any]]:
         instance_id = str(member.mcp_instance_id)
         mcp_url = self.instance_urls.get(instance_id)
         if not mcp_url:

--- a/agentarea-platform/libs/mcp/tests/test_mcp_aggregator.py
+++ b/agentarea-platform/libs/mcp/tests/test_mcp_aggregator.py
@@ -90,9 +90,9 @@ async def test_call_namespaced_tool_unknown_raises():
 def test_streamable_candidates_honor_a_declared_transport():
     # A declared transport is authoritative: probing a second candidate costs a
     # full connect timeout per discovery, and discovery runs on every tools/list.
-    assert MCPAggregatorProxy._streamable_candidates(
-        "http://mcp-x:8000", "streamable-http"
-    ) == ["http://mcp-x:8000"]
+    assert MCPAggregatorProxy._streamable_candidates("http://mcp-x:8000", "streamable-http") == [
+        "http://mcp-x:8000"
+    ]
 
 
 def test_declared_transport_reaches_the_candidate_resolver():
@@ -133,3 +133,34 @@ async def test_members_are_discovered_concurrently(monkeypatch):
 
     assert [t["name"] for t in tools] == ["n0__t", "n1__t", "n2__t"]
     assert elapsed < 0.6, f"members were serialised: {elapsed:.2f}s for 3 x 0.3s"
+
+
+async def test_stored_tools_are_used_without_touching_the_upstream(monkeypatch):
+    # Verification already lists an instance's tools and persists them on the
+    # row. Re-listing them upstream on every tools/list is what made a bundle
+    # cost ~15s per session start.
+    member = AggregatedMember(
+        mcp_instance_id="1",
+        namespace_prefix="tg",
+        tools=[{"name": "list_accounts", "description": "d", "inputSchema": {"type": "object"}}],
+    )
+    proxy = _proxy([member])
+
+    async def explode(*_args, **_kwargs):
+        raise AssertionError("upstream must not be dialed when tools are stored")
+
+    monkeypatch.setattr(proxy, "_discover_member_tools_upstream", explode)
+
+    assert [t["name"] for t in await proxy.list_namespaced_tools()] == ["tg__list_accounts"]
+
+
+async def test_falls_back_to_upstream_when_nothing_is_stored(monkeypatch):
+    member = AggregatedMember(mcp_instance_id="1", namespace_prefix="tg", tools=None)
+    proxy = _proxy([member])
+
+    async def upstream(_member):
+        return [{"name": "live", "description": "", "inputSchema": {}}]
+
+    monkeypatch.setattr(proxy, "_discover_member_tools_upstream", upstream)
+
+    assert [t["name"] for t in await proxy.list_namespaced_tools()] == ["tg__live"]


### PR DESCRIPTION
Follow-up to #360, and the actual cause of the ~15s `tools/list` on `/client-mcp/<id>`.

## What I found

`mcp_servers_get` returns a full `tools[]` for the telegram instance — schemas and all. That list is **persisted on the instance row**: `verify_instance` lists the tools and stores them, `discover_and_store_tools` reads them back as `instance.tools`, and the instance page renders them.

The aggregator ignored it. Every `tools/list` opened a fresh streamable-HTTP session per member and re-listed upstream, re-deriving data already sitting in the database. Measured against RU prod, three consecutive calls: 16.1s / 15.4s / 15.3s — a fixed cost a harness pays on every session start.

## Change

A member serves `instance.tools` when it has them, and dials upstream only when nothing is stored (`tools is None` — never verified). An empty stored list is a real answer, not a miss.

## Why this instead of a cache

A cache raised a question with no good answer: a third-party remote can change its tool list without anything on our row changing, so key-by-version does nothing and only a TTL guesses. The stored copy has an explicit refresh signal already — verification and the "Refresh Tools" action — and it is the same list the UI shows, so the bundle and the instance page can no longer disagree.

## Tests

- stored tools are served without dialing upstream (the upstream path is stubbed to raise);
- nothing stored falls back to the live listing.

16 passing in that file; ruff clean.