### PR TITLE
fix(mcp): stop one stuck instance from wedging the whole gateway

### DIFF
--- a/agentarea-mcp-manager/internal/api/handlers.go
+++ b/agentarea-mcp-manager/internal/api/handlers.go
@@ -179,9 +179,14 @@ func (h *Handler) listInstances(c *gin.Context) {
 		return
 	}
 
+	public := make([]*backends.InstanceStatus, 0, len(instances))
+	for _, instance := range instances {
+		public = append(public, withoutEnvironment(instance))
+	}
+
 	response := gin.H{
-		"instances": instances,
-		"total":     len(instances),
+		"instances": public,
+		"total":     len(public),
 	}
 
 	c.JSON(http.StatusOK, response)
@@ -202,7 +207,26 @@ func (h *Handler) getInstance(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, instance)
+	c.JSON(http.StatusOK, withoutEnvironment(instance))
+}
+
+// withoutEnvironment copies a status with the workload's resolved environment
+// stripped. These inspection routes carry no authentication, and the
+// environment is exactly where the secret resolver's output lands — API keys,
+// tokens, session strings that are themselves full account access. Returning it
+// would hand every instance's credentials to anything that can reach this
+// service, which is the whole of the secret manager's job undone.
+//
+// It copies rather than blanking in place: the status can be state the backend
+// owns and reuses, and clearing that would take the environment away from the
+// workload itself.
+func withoutEnvironment(status *backends.InstanceStatus) *backends.InstanceStatus {
+	if status == nil {
+		return nil
+	}
+	redacted := *status
+	redacted.Environment = nil
+	return &redacted
 }
 
 // validateInstance validates an instance configuration without creating it

--- a/agentarea-mcp-manager/internal/api/instance_disclosure_test.go
+++ b/agentarea-mcp-manager/internal/api/instance_disclosure_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/agentarea/mcp-manager/internal/backends"
+	"github.com/agentarea/mcp-manager/internal/sandboxcontrol"
+)
+
+// The instance inspection routes carry no authentication — deliberately, since
+// they only read. Reading, though, used to include the instance's resolved
+// environment, which is where the secret manager puts the credentials the
+// workload runs with: API keys, tokens, a Telegram session string that is by
+// itself full account access. Any workload that could reach the manager's
+// service could therefore read every instance's secrets, which defeats the
+// point of resolving them out of a secret store at all.
+type disclosureBackendStub struct {
+	status *backends.InstanceStatus
+}
+
+func (b *disclosureBackendStub) CreateInstance(context.Context, *backends.InstanceSpec) (*backends.InstanceResult, error) {
+	return nil, nil
+}
+func (b *disclosureBackendStub) DeleteInstance(context.Context, string) error { return nil }
+func (b *disclosureBackendStub) GetInstanceStatus(context.Context, string) (*backends.InstanceStatus, error) {
+	return b.status, nil
+}
+func (b *disclosureBackendStub) ListInstances(context.Context) ([]*backends.InstanceStatus, error) {
+	return []*backends.InstanceStatus{b.status}, nil
+}
+func (b *disclosureBackendStub) UpdateInstance(context.Context, string, *backends.InstanceSpec) error {
+	return nil
+}
+func (b *disclosureBackendStub) PerformHealthCheck(context.Context, string) (*backends.HealthCheckResult, error) {
+	return &backends.HealthCheckResult{Healthy: true, Status: "running"}, nil
+}
+func (b *disclosureBackendStub) Initialize(context.Context) error { return nil }
+func (b *disclosureBackendStub) Shutdown(context.Context) error   { return nil }
+
+const disclosedSecret = "1AZWarzwBu32uEudLyEwrynvwayCBkkv-test-session"
+
+func disclosureRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	t.Setenv("SANDBOX_EXECUTION_RECORD_TTL", "24h")
+	gin.SetMode(gin.TestMode)
+
+	backend := &disclosureBackendStub{status: &backends.InstanceStatus{
+		ID:          "container-1",
+		Name:        "659b1561-79bf-424d-b707-7897a4304c98",
+		ServiceName: "659b1561-79bf-424d-b707-7897a4304c98",
+		Status:      "running",
+		Image:       "registry.example/pool/telegram-mcp:1",
+		Port:        8765,
+		Environment: map[string]string{
+			"TELEGRAM_SESSION_STRING": disclosedSecret,
+			"MCP_PORT":                "8765",
+		},
+	}}
+
+	handler, err := NewHandler(
+		backend, nil,
+		slog.New(slog.NewTextHandler(nopWriter{}, nil)),
+		"test",
+		SandboxPolicy{},
+		sandboxcontrol.Config{
+			RedisURL:                       "redis://127.0.0.1:6379",
+			ExecutionRecordTTL:             24 * time.Hour,
+			DefaultExecutionTimeoutSeconds: 120,
+			MaxExecutionTimeoutSeconds:     1800,
+			QueueTimeout:                   5 * time.Minute,
+			CompletionGrace:                2 * time.Minute,
+		},
+		&controlRuntimeStub{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	handler.SetupRoutes(router)
+	return router
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestGetInstanceDoesNotDiscloseTheInstanceEnvironment(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	disclosureRouter(t).ServeHTTP(recorder,
+		httptest.NewRequest(http.MethodGet, "/instances/659b1561-79bf-424d-b707-7897a4304c98", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), disclosedSecret) {
+		t.Error("instance inspection returned the workload's credentials to an unauthenticated caller")
+	}
+	// The route still has to be useful: redacting must not empty the response.
+	if !strings.Contains(recorder.Body.String(), "running") {
+		t.Errorf("instance state went missing along with the secrets: %s", recorder.Body.String())
+	}
+}
+
+func TestListInstancesDoesNotDiscloseInstanceEnvironments(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	disclosureRouter(t).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/instances", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), disclosedSecret) {
+		t.Error("instance listing returned workload credentials to an unauthenticated caller")
+	}
+}

--- a/agentarea-mcp-manager/internal/mcpgateway/gateway.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/gateway.go
@@ -203,6 +203,15 @@ func (g *Gateway) ServeHTTP(response http.ResponseWriter, request *http.Request)
 		return nil
 	})
 	cancelStart()
+	if errors.Is(err, ErrStartInProgress) {
+		// Another caller holds the lifecycle and is bringing this workload up.
+		// Answering "unavailable" would be wrong twice over: nothing failed, and
+		// the start this caller wanted is already running. Ask it to come back
+		// instead — that retry is what completes the cold start.
+		response.Header().Set("Retry-After", "1")
+		http.Error(response, "MCP instance is starting", http.StatusServiceUnavailable)
+		return
+	}
 	if err != nil {
 		g.logger.Warn("MCP demand could not be satisfied", slog.String("instance_id", instanceID), slog.String("error", err.Error()))
 		response.Header().Set("Retry-After", "5")
@@ -277,6 +286,9 @@ func (g *Gateway) RetireHTTP(response http.ResponseWriter, request *http.Request
 		case errors.Is(err, ErrInstanceBusy):
 			response.Header().Set("Retry-After", "5")
 			http.Error(response, "MCP instance has active requests", http.StatusConflict)
+		case errors.Is(err, ErrStartInProgress):
+			response.Header().Set("Retry-After", "5")
+			http.Error(response, "MCP instance is starting", http.StatusConflict)
 		case errors.Is(err, ErrInstanceNotFound):
 			http.Error(response, "MCP instance not found", http.StatusNotFound)
 		default:
@@ -354,6 +366,12 @@ func (g *Gateway) Reap(ctx context.Context) (int, error) {
 	reaped := 0
 	for _, instanceID := range ids {
 		removed, err := g.repository.ReapIfIdle(ctx, instanceID, g.policy.IdleTimeout, g.runtime.Delete)
+		if errors.Is(err, ErrStartInProgress) {
+			// The candidate went from idle to starting between the query and the
+			// lock. It is no longer eligible, and the next sweep will see the
+			// truth; the sweep did its job.
+			continue
+		}
 		if err != nil {
 			g.logger.Warn("Failed to reap idle MCP instance", slog.String("instance_id", instanceID), slog.String("error", err.Error()))
 			continue

--- a/agentarea-mcp-manager/internal/mcpgateway/gateway_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/gateway_test.go
@@ -1,6 +1,7 @@
 package mcpgateway
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -20,17 +21,22 @@ const testGatewaySecret = "0123456789abcdef0123456789abcdef"
 type gatewayRepositoryStub struct {
 	mu            sync.Mutex
 	instance      *models.MCPServerInstance
+	lockErr       error
 	starting      int
 	failed        int
 	started       int
 	finished      int
 	idle          []string
+	reapErr       error
 	reapCallbacks int
 	retireErr     error
 	retired       int
 }
 
 func (r *gatewayRepositoryStub) WithInstanceLock(ctx context.Context, _ string, fn func(context.Context) error) error {
+	if r.lockErr != nil {
+		return r.lockErr
+	}
 	return fn(ctx)
 }
 func (r *gatewayRepositoryStub) LoadInstance(context.Context, string) (*models.MCPServerInstance, error) {
@@ -67,6 +73,9 @@ func (r *gatewayRepositoryStub) IdleCandidates(context.Context, time.Duration) (
 	return r.idle, nil
 }
 func (r *gatewayRepositoryStub) ReapIfIdle(ctx context.Context, _ string, _ time.Duration, remove func(context.Context, *models.MCPServerInstance) error) (bool, error) {
+	if r.reapErr != nil {
+		return false, r.reapErr
+	}
 	r.reapCallbacks++
 	return true, remove(ctx, r.instance)
 }
@@ -167,6 +176,96 @@ func TestGatewayRecordsFailedColdStart(t *testing.T) {
 
 	if recorder.Code != http.StatusBadGateway || repository.failed != 1 || repository.started != 0 {
 		t.Fatalf("failed start response=%d failed=%d started=%d", recorder.Code, repository.failed, repository.started)
+	}
+}
+
+// A caller that stepped aside for someone else's cold start has not met a
+// failure, and saying 502 tells it the instance is broken when the truth is
+// that the workload it wants is on its way. The client's own retry is the
+// mechanism that finishes the job, so the answer has to invite one.
+func TestGatewayAnswersAConcurrentStartAsRetryable(t *testing.T) {
+	instanceID := "8ca9f331-9cc9-4a51-9933-27d7bb73860b"
+	repository := &gatewayRepositoryStub{
+		instance: &models.MCPServerInstance{InstanceID: instanceID},
+		lockErr:  ErrStartInProgress,
+	}
+	runtime := &runtimeStub{}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/mcp/"+instanceID+"/mcp", nil)
+	request.Header.Set("X-AgentArea-Manager-Authorization", "Bearer "+testGatewaySecret)
+
+	testGateway(t, repository, runtime).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("response = %d, want %d for a start already under way", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if recorder.Header().Get("Retry-After") == "" {
+		t.Error("no Retry-After: the caller is being asked to retry without being told when")
+	}
+	// The other caller owns this start; touching the runtime or the failure
+	// counter here would report a cold start that never happened.
+	if runtime.ensured != 0 || repository.failed != 0 {
+		t.Fatalf("stepped-aside caller acted on the workload: ensured=%d failed=%d", runtime.ensured, repository.failed)
+	}
+}
+
+// Retirement contends for the same lifecycle lock as a cold start, so it can now
+// be told to stand down. That is a conflict the caller should retry, not the
+// hard failure the default branch reports — and logging it as an error would
+// page someone over an instance that was merely busy.
+func TestGatewayRetirementAsksToRetryWhenAStartHoldsTheInstance(t *testing.T) {
+	instanceID := "8ca9f331-9cc9-4a51-9933-27d7bb73860b"
+	repository := &gatewayRepositoryStub{
+		instance:  &models.MCPServerInstance{InstanceID: instanceID},
+		retireErr: ErrStartInProgress,
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodDelete, "/mcp/"+instanceID, nil)
+	request.Header.Set("X-AgentArea-Manager-Authorization", "Bearer "+testGatewaySecret)
+
+	testGateway(t, repository, &runtimeStub{}).RetireHTTP(recorder, request)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("response = %d, want %d while a start holds the instance", recorder.Code, http.StatusConflict)
+	}
+	if recorder.Header().Get("Retry-After") == "" {
+		t.Error("no Retry-After on a conflict the caller is expected to retry")
+	}
+}
+
+// An instance whose cold start is under way is not idle, so declining to reap
+// it is the sweep working, not the sweep failing. Reporting it as a failure
+// would put a recurring warning in front of an operator for a workload that is
+// behaving exactly as intended.
+func TestReaperTreatsAConcurrentStartAsASkipNotAFailure(t *testing.T) {
+	instanceID := "8ca9f331-9cc9-4a51-9933-27d7bb73860b"
+	repository := &gatewayRepositoryStub{
+		instance: &models.MCPServerInstance{InstanceID: instanceID},
+		idle:     []string{instanceID},
+		reapErr:  ErrStartInProgress,
+	}
+	logs := &bytes.Buffer{}
+	gateway, err := New(repository, &runtimeStub{}, Policy{
+		RequestLeaseTTL: 3 * time.Second,
+		StartupTimeout:  time.Second,
+		IdleTimeout:     time.Minute,
+		SweepInterval:   time.Second,
+		AuthSecret:      testGatewaySecret,
+	}, slog.New(slog.NewTextHandler(logs, nil)), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reaped, err := gateway.Reap(context.Background())
+
+	if err != nil {
+		t.Fatalf("Reap() = %v, want the sweep to carry on past a busy instance", err)
+	}
+	if reaped != 0 {
+		t.Fatalf("reaped = %d, want 0: the instance was starting", reaped)
+	}
+	if strings.Contains(logs.String(), "Failed to reap") {
+		t.Errorf("a start in progress was logged as a reap failure: %s", logs.String())
 	}
 }
 

--- a/agentarea-mcp-manager/internal/mcpgateway/repository.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/repository.go
@@ -15,10 +15,31 @@ import (
 var ErrInstanceNotFound = errors.New("MCP instance not found")
 var ErrInstanceBusy = errors.New("MCP instance has active requests")
 
+// ErrStartInProgress reports that another caller holds the instance lifecycle
+// and this one declined to queue behind it. It is a retry signal, not a
+// failure: the start it stepped aside for is the one this caller wanted.
+var ErrStartInProgress = errors.New("MCP instance start already in progress")
+
 const (
 	maxGatewayDatabaseConns     = 16
 	maxGatewayIdleDatabaseConns = 4
 	gatewayDatabaseConnLifetime = 30 * time.Minute
+
+	// A caller that cannot take the lifecycle lock inside this budget hands its
+	// pooled connection back instead of camping on it until the startup timeout.
+	//
+	// Waiting callers used to hold one connection each for the whole cold start.
+	// A client retrying a slow start faster than the start could finish then
+	// filled the pool with waiters, and the one caller actually holding the lock
+	// could no longer obtain the second connection its critical section needs —
+	// so it timed out and handed the lock to a waiter whose budget was already
+	// spent. Bounding the wait keeps a connection parked for two seconds rather
+	// than five minutes, which is what makes that pile-up impossible.
+	//
+	// The budget is long enough that the warm path, where the section is a few
+	// milliseconds of bookkeeping, never trips it.
+	instanceLockWait         = 2 * time.Second
+	instanceLockPollInterval = 25 * time.Millisecond
 )
 
 type SQLRepository struct {
@@ -65,13 +86,45 @@ func (r *SQLRepository) WithInstanceLock(ctx context.Context, instanceID string,
 		return err
 	}
 	defer conn.Close()
-	if _, err := conn.ExecContext(ctx, `SELECT pg_advisory_lock(hashtextextended($1, 0))`, instanceID); err != nil {
+	acquired, err := acquireInstanceLock(ctx, conn, instanceID)
+	if err != nil {
 		return fmt.Errorf("lock MCP instance lifecycle: %w", err)
+	}
+	if !acquired {
+		return ErrStartInProgress
 	}
 	defer func() {
 		_, _ = conn.ExecContext(context.Background(), `SELECT pg_advisory_unlock(hashtextextended($1, 0))`, instanceID)
 	}()
 	return callback(ctx)
+}
+
+// acquireInstanceLock polls pg_try_advisory_lock rather than blocking in
+// pg_advisory_lock, so the wait is bounded by instanceLockWait instead of by the
+// caller's context. Reporting "someone else is starting this" costs one
+// connection for two seconds; blocking cost one for the whole cold start.
+func acquireInstanceLock(ctx context.Context, conn *sql.Conn, instanceID string) (bool, error) {
+	deadline := time.Now().Add(instanceLockWait)
+	for {
+		var acquired bool
+		if err := conn.QueryRowContext(ctx,
+			`SELECT pg_try_advisory_lock(hashtextextended($1, 0))`, instanceID).Scan(&acquired); err != nil {
+			return false, err
+		}
+		if acquired {
+			return true, nil
+		}
+		if !time.Now().Before(deadline) {
+			return false, nil
+		}
+		timer := time.NewTimer(instanceLockPollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false, ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func (r *SQLRepository) LoadInstance(ctx context.Context, instanceID string) (*models.MCPServerInstance, error) {

--- a/agentarea-mcp-manager/internal/mcpgateway/repository_pool_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/repository_pool_test.go
@@ -1,0 +1,80 @@
+package mcpgateway
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// The lifecycle lock is held on a pooled connection for the whole cold start,
+// and the work it guards — LoadInstance, MarkStarting, MarkReadyAndBeginRequest
+// — needs a second connection from that same bounded pool. That combination
+// deadlocked production on 2026-08-27: one instance failed to become ready, its
+// caller retried every 10s against a 5m start, and within minutes every
+// connection in the pool was parked inside pg_advisory_lock. The one caller
+// holding the lock could never obtain its second connection, so it timed out at
+// the deadline and handed the lock to a waiter with no budget left. No cold
+// start ever ran again — for any instance, because the pool is shared even
+// though the lock is per instance.
+//
+// These tests reproduce that shape with a small pool. They need advisory locks
+// and a connection pool, not the runtime tables, so they build the repository
+// directly instead of going through OpenSQLRepository's schema probe.
+func poolTestRepository(t *testing.T, maxOpenConns int) (*SQLRepository, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("pgx", testDSN(t))
+	if err != nil {
+		t.Fatalf("opening test database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(maxOpenConns)
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("connecting to test database: %v", err)
+	}
+	return &SQLRepository{db: db}, db
+}
+
+func TestWithInstanceLockLetsTheLockHolderReachTheDatabase(t *testing.T) {
+	const (
+		poolSize = 4
+		callers  = 8
+	)
+	repository, db := poolTestRepository(t, poolSize)
+
+	// More callers than connections, all demanding the same instance: the shape
+	// a retrying client produces against a slow cold start.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	var completed atomic.Int32
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := repository.WithInstanceLock(ctx, "pool-starvation-instance", func(lockCtx context.Context) error {
+				// The second pooled connection the real callback takes.
+				var one int
+				if err := db.QueryRowContext(lockCtx, `SELECT 1`).Scan(&one); err != nil {
+					return err
+				}
+				// Stand in for a cold start that outlives the caller's patience.
+				time.Sleep(300 * time.Millisecond)
+				return nil
+			})
+			if err == nil {
+				completed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if completed.Load() == 0 {
+		t.Fatal("no caller completed its critical section: the lock holder starved waiting for a connection every other caller was holding")
+	}
+}

--- a/agentarea-mcp-manager/internal/mcpgateway/runtime.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/runtime.go
@@ -103,7 +103,18 @@ func (r *ProviderRuntime) EnsureReady(ctx context.Context, instance *models.MCPS
 			}
 			select {
 			case <-ctx.Done():
-				return "", r.cleanupFailedStart(instance, ctx.Err())
+				// The gateway allows a start exactly StartupTimeout, which is
+				// also this loop's deadline, so this branch — not the timer
+				// below — is the one production takes. Report the same last
+				// state the timer would: without it the log says only that time
+				// ran out, and the workload has already been cleaned up by the
+				// time anyone could go and look at it.
+				if statusErr != nil {
+					return "", r.cleanupFailedStart(instance,
+						fmt.Errorf("MCP instance did not become ready: %w", errors.Join(ctx.Err(), statusErr)))
+				}
+				return "", r.cleanupFailedStart(instance,
+					fmt.Errorf("MCP instance did not become ready; last state %q: %w", status.Status, ctx.Err()))
 			case <-deadline.C:
 				if statusErr != nil {
 					return "", r.cleanupFailedStart(instance, fmt.Errorf("MCP instance did not become ready: %w", statusErr))

--- a/agentarea-mcp-manager/internal/mcpgateway/runtime_test.go
+++ b/agentarea-mcp-manager/internal/mcpgateway/runtime_test.go
@@ -229,6 +229,35 @@ func TestColdStartAbandonedByTheGatewayCleansUpTheWorkload(t *testing.T) {
 	}
 }
 
+// The gateway gives a cold start exactly StartupTimeout, and the runtime uses
+// the same value for its readiness deadline, so in production the context
+// almost always expires first. That branch used to return a bare
+// "context deadline exceeded" and throw away the one fact worth having: what
+// the workload was doing when time ran out. An operator reading the log then
+// cannot tell a workload still pulling its image from one that came up and
+// died, and has to go to the host to find out.
+func TestAbandonedColdStartReportsTheStateTheWorkloadWasLeftIn(t *testing.T) {
+	backend := &runtimeBackendStub{statuses: []statusReply{
+		{err: backends.ErrInstanceNotFound},
+		{status: "pending"},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+
+	_, err := testProviderRuntime(t, backend, &runtimeProviderStub{}, time.Minute).
+		EnsureReady(ctx, dockerInstance())
+
+	if err == nil {
+		t.Fatal("an abandoned activation reported success")
+	}
+	if !strings.Contains(err.Error(), "pending") {
+		t.Errorf("error = %q, want it to name the last state the workload reached", err.Error())
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %q, want it to still identify itself as the deadline expiring", err.Error())
+	}
+}
+
 // TestStatusErrorDuringStartCleansUpTheWorkload covers the other half of the
 // leak: the failure arrives as an unreadable status rather than a timeout.
 func TestStatusErrorDuringStartCleansUpTheWorkload(t *testing.T) {

--- a/docs/self-host/mcp-data-plane.md
+++ b/docs/self-host/mcp-data-plane.md
@@ -74,6 +74,35 @@ Setting `url` switches the backend; you do not set `BACKEND_TYPE` yourself. All
 three fields go together — a partial set stops the render rather than quietly
 running containers in the cluster after you asked for them elsewhere.
 
+The hostname above is an example. `203.0.113.10` is a documentation address from
+RFC 5737 and resolves nowhere — substitute your host's own name or address.
+
+### When the hop is already private
+
+The public TLS name exists because the token travels on the wire. If the control
+plane reaches the host over a network that is already private — a cloud provider's
+internal network, WireGuard, an SSH tunnel — there is no public name to certify,
+and the data plane is addressed directly:
+
+```yaml
+mcpManager:
+  dataPlane:
+    url: "http://10.0.0.10:8090"
+```
+
+The manager refuses a plain-`http` data plane unless you also say the hop is
+private, so this arrangement cannot happen by accident:
+
+```
+MCP_DATAPLANE_ALLOW_INSECURE=true
+```
+
+Both topologies are supported, and which one a deployment uses is not visible
+from the outside: **a private deployment has no public data-plane hostname at
+all**, so probing one tells you nothing. Check `MCP_DATAPLANE_URL` on the manager
+for the address actually in use, and reach it from inside the network the manager
+sits in — see [Verifying it](#verifying-it).
+
 The manager proves the host is reachable and the token accepted at startup, so a
 wrong value fails the rollout instead of surfacing later as a broken tool call.
 
@@ -108,6 +137,23 @@ Any client that speaks MCP Streamable HTTP and can send a bearer token works the
 same way.
 
 ## Verifying it
+
+Run these from where the control plane runs, not from your workstation. A data
+plane on a private hop is unreachable from anywhere else by design, and a host
+firewalled to one region refuses everyone outside it — in both cases a probe from
+a laptop times out on a healthy host. From a control-plane cluster:
+
+```bash
+kubectl -n agentarea exec deploy/agentarea-app-backend -- \
+  curl -s "$MCP_DATAPLANE_URL/healthz"
+```
+
+`/healthz` is the one unauthenticated route; it answers `{"agent_id":"…","status":"ok"}`
+and settles whether the process is up before you look at anything else. Take
+`$MCP_DATAPLANE_URL` from the manager's own environment rather than from this
+page — the address here is an example.
+
+Then exercise the authenticated path:
 
 ```bash
 curl -sN -X POST \

--- a/docs/serverless-mcp.md
+++ b/docs/serverless-mcp.md
@@ -20,7 +20,16 @@ than defects to work around.
 **The first call after an idle period pays a cold start.** How long depends
 entirely on the server: a small published image starts in a second or two, while
 a `uvx`/`npx` server that clones and installs on boot can take a minute or more.
-The call waits for provisioning rather than failing.
+That call waits for provisioning rather than failing.
+
+Calls that arrive while a start is already under way do not queue behind it.
+They are answered `503` with a `Retry-After`, and the retry lands on the
+workload the first call is bringing up. Queueing them instead would hold a
+database connection each for the whole cold start, so a client retrying faster
+than a slow start could finish would fill the manager's connection pool — taking
+the connection the start itself still needs and stalling every instance, not
+just the one being started. A client that honours `Retry-After` sees a slower
+first call; one that treats `503` as fatal needs its own retry.
 
 **Creating a connection no longer verifies it immediately.** Verification is
 what starts the container and lists its tools, so deferring the start defers the
@@ -157,7 +166,9 @@ first time.
 Sweeping is serialised with a Postgres advisory lock, so running more than one
 manager replica does not mean more than one sweeper. If a manager dies
 mid-sweep, its lock is released with its connection — there is nothing to clear
-by hand.
+by hand. An instance that began starting between being listed as idle and being
+reclaimed holds that lock, so the sweep leaves it and moves on; the next sweep
+sees it as it now is.
 
 ## Verifying it works
 


### PR DESCRIPTION
## What happened

On 2026-08-27 the MCP gateway stopped serving **every** instance. The trigger was one instance that stopped becoming ready; the outage was a connection-pool deadlock in `mcpgateway`.

`WithInstanceLock` takes a connection from the gateway's 16-connection pool and holds it inside `pg_advisory_lock` for the whole cold start. The work under the lock — `LoadInstance`, `MarkStarting`, `MarkReadyAndBeginRequest` — needs a **second** connection from that same pool.

The Python verifier retries every 10s (`verification.py:31-32`) while the gateway allows a start 5 minutes and deliberately detaches it from the caller's context. 300s ÷ 10s ≈ 30 concurrent requests against a pool of 16. All connections end up parked in `pg_advisory_lock`; the one caller that *holds* the lock can never obtain its second connection, times out, and hands the lock to a waiter whose budget is already spent. Forward progress stops for every instance, because the lock is per instance but the pool is shared.

Observed live in production:

```
client_addr  | wait_event | count |    min_wait     |    max_wait
10.244.1.204 | advisory   |   15  | 00:00:13.99     | 00:03:44.06
```

15 of 16 connections blocked, 46 x `load MCP instance: context deadline exceeded` at exactly 300.00s latency, and no container creation attempted at all.

## The fix

Take the lock with `pg_try_advisory_lock` inside a 2s budget and return `ErrStartInProgress` rather than queueing. A waiter now costs one connection for two seconds instead of five minutes, so the lock holder can always reach the database. The warm path — a few milliseconds of bookkeeping — never trips the budget.

The new error is mapped at each call site:

| Path | Before | After |
|---|---|---|
| Gateway request | `502` "unavailable" | `503` + `Retry-After` — nothing failed, and the retry completes the start |
| Retirement | `502` + error log | `409` + `Retry-After`, already retryable in `service.py:821` |
| Idle sweep | warning per sweep | skip; the next sweep sees the instance as it is |

## Two gaps this incident exposed

**Secrets on an unauthenticated route.** `GET /instances/:id` and `GET /instances` returned the workload's resolved environment. Anything that could reach the manager's service could read every instance's credentials — API keys, tokens, a Telegram session string that is by itself full account access. Stripped at the API boundary. The service is `ClusterIP` with no ingress, so exposure was cluster-internal, but it undid the secret manager for any in-cluster caller.

**The readiness failure was unreadable.** The gateway allows a start exactly `StartupTimeout`, which is also the runtime's readiness deadline, so the context branch is the one production takes — and it discarded the last state the workload reached. Every real failure logged only `context deadline exceeded`. It now names the state, while still identifying itself as the deadline expiring.

## Known remaining surface

`/containers/*` exposes `models.Container.Environment` the same way. Those routes mount only for the Docker backend and need a live `container.Manager` to test, so they are left for a follow-up rather than changed without a test.

## Tests

Written test-first, each watched fail for the right reason:

- `TestWithInstanceLockLetsTheLockHolderReachTheDatabase` — reproduces the deadlock against a real Postgres with a small pool: 8 callers, one instance, callback taking a second connection. **Before: 20s of total deadlock, zero completions. After: 4.4s, passes.**
- `TestGatewayAnswersAConcurrentStartAsRetryable`
- `TestGatewayRetirementAsksToRetryWhenAStartHoldsTheInstance`
- `TestReaperTreatsAConcurrentStartAsASkipNotAFailure`
- `TestAbandonedColdStartReportsTheStateTheWorkloadWasLeftIn`
- `TestGetInstanceDoesNotDiscloseTheInstanceEnvironment`, `TestListInstancesDoesNotDiscloseInstanceEnvironments`

Verified with `go vet ./...`, the full module suite, and the schema-backed gateway tests run against a migrated database with `MCP_GATEWAY_REQUIRE_DB=1` so nothing skipped silently. `golangci-lint` clean on both changed packages.

## Docs

- `docs/serverless-mcp.md` — "The call waits for provisioning rather than failing" is no longer true for concurrent callers; corrected, with the reason.
- `docs/self-host/mcp-data-plane.md` — documented the private-hop topology (`MCP_DATAPLANE_ALLOW_INSECURE`), which is what production actually runs and which the page omitted entirely. Noted that the example host is an RFC 5737 address, and that a data plane must be probed from inside the network — from outside, a healthy one looks dead.

## What this does *not* fix

The instance that triggered the outage still does not come up, and the reason is outside this repository: **Telegram is not reachable from the deployment's network.** From a pod in the cluster, all three MTProto DC addresses and both `core.telegram.org` / `api.telegram.org` time out with the TCP connection never establishing, while `api.github.com`, `registry.npmjs.org` and `pypi.org` answer from the same pod in ~60ms. That matches the workload's symptom exactly: the container starts, never binds its port, and exits by itself after ~105s — the shape of a Telegram client exhausting its connect retries across every DC.

So this PR does not restore that instance. What it does is stop one unreachable dependency from taking the entire gateway — all 21 instances — down with it.
