### PR TITLE
Drop the explanatory blurb above the secrets table

### DIFF
--- a/agentarea-webapp/src/app/(main)/secrets/components/SecretsData.tsx
+++ b/agentarea-webapp/src/app/(main)/secrets/components/SecretsData.tsx
@@ -32,16 +32,8 @@ export async function SecretsData() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-sm font-medium">Workspace secrets</h2>
-          <p className="text-sm text-muted-foreground">
-            Every credential this workspace holds. Values are encrypted and
-            never shown again once saved. The ones marked managed belong to a
-            connection and are changed there; your own can be reused across
-            several connections, and rotating one updates all of them at once.
-          </p>
-        </div>
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-sm font-medium">Workspace secrets</h2>
         <CreateSecretDialog />
       </div>
 


### PR DESCRIPTION
The paragraph above the table explained what "managed" means, that values are encrypted, and that rotating a shared secret updates every connection using it.

That copy was written when the page listed only user-created secrets, so most workspaces saw an empty table and the prose was all there was. #365 changed that: the table now shows the credentials themselves, with a **Managed** badge and a **Belongs to** column naming the owning connection. The text now restates what is already on screen, one line above it.

Removes the paragraph and centres the heading against the create button, now that the header is a single line.

No behaviour change; no other copy referenced it.