### PR TITLE
Order the category facets alphabetically, with "other" last

### DIFF
--- a/agentarea-platform/libs/registry/agentarea_registry/infrastructure/repository.py
+++ b/agentarea-platform/libs/registry/agentarea_registry/infrastructure/repository.py
@@ -12,7 +12,7 @@ from typing import Any
 from uuid import UUID
 
 from agentarea_common.auth.context import UserContext
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -31,6 +31,11 @@ CATALOG_SORTS: dict[str, Any] = {
     "name": lambda: (RegistryItem.sort_key.asc(), RegistryItem.id.asc()),
 }
 DEFAULT_CATALOG_SORT = "featured"
+
+# The category sources fall back to when they can't classify an entry. It is a
+# bucket, not a peer category, so the facet list sorts it last rather than
+# letting it land mid-alphabet or -- as ordering by size did -- near the top.
+FALLBACK_CATEGORY = "other"
 
 
 class RegistryRepository:
@@ -244,6 +249,12 @@ class RegistryItemRepository:
         Deliberately ignores any active category filter -- the sidebar has to
         keep showing the other categories you could switch to. Uncategorised
         items are left out rather than collected into a bucket nothing selects.
+
+        Ordered alphabetically, with the fallback bucket last. Ordering by size
+        put each category wherever its count happened to land, so finding a
+        known one meant reading the whole list -- and the counts are flat
+        enough (most categories hold one or two entries) that size conveyed
+        nothing to begin with.
         """
         conditions = self._browse_filter(registry_type, q, category=None)
         query = (
@@ -251,7 +262,10 @@ class RegistryItemRepository:
             .join(Registry, RegistryItem.registry_id == Registry.id)
             .where(*conditions, RegistryItem.category.is_not(None))
             .group_by(RegistryItem.category)
-            .order_by(func.count().desc(), RegistryItem.category.asc())
+            .order_by(
+                case((RegistryItem.category == FALLBACK_CATEGORY, 1), else_=0),
+                RegistryItem.category.asc(),
+            )
         )
         rows = (await self.session.execute(query)).all()
         return [(value, count) for value, count in rows]

--- a/agentarea-platform/libs/registry/tests/test_registry_item_browse.py
+++ b/agentarea-platform/libs/registry/tests/test_registry_item_browse.py
@@ -205,10 +205,40 @@ class TestCategoryCounts:
         counts = await item_repo.category_counts("skills")
         assert all(value is not None for value, _ in counts)
 
-    async def test_ordered_by_count_then_name(self, db_session, item_repo, catalog):
+    async def test_ordered_alphabetically_so_the_list_is_scannable(self, db_session, item_repo, catalog):
+        # Ordering by count put a category wherever its size happened to land,
+        # so finding a known one meant reading the whole sidebar. The counts are
+        # flat anyway (most categories hold one or two items), so size bought
+        # nothing.
         a, _ = catalog
         await _item(item_repo, a, "6", "six", tags=["category:alpha"])
-        assert await item_repo.category_counts("skills") == [("data", 2), ("alpha", 1), ("other", 1)]
+        assert await item_repo.category_counts("skills") == [
+            ("alpha", 1),
+            ("data", 2),
+            ("other", 1),
+        ]
+
+    async def test_the_fallback_bucket_sorts_last_however_big_it_is(self, db_session, item_repo, catalog):
+        # "other" is where the source puts what it couldn't classify -- a
+        # fallback, not a peer. Alphabetically it would land mid-list, and by
+        # size it sat near the top; neither is where it belongs.
+        a, _ = catalog
+        for n in range(5):
+            await _item(item_repo, a, f"pad-{n}", f"pad {n}", tags=["category:other"])
+        counts = await item_repo.category_counts("skills")
+        assert counts[-1][0] == "other"
+        assert counts[-1][1] == 6
+        assert [value for value, _ in counts] == ["data", "other"]
+
+    async def test_a_category_named_like_the_fallback_is_not_demoted(self, db_session, item_repo, catalog):
+        # Only the exact fallback value is special; "other-tools" is a category.
+        a, _ = catalog
+        await _item(item_repo, a, "7", "seven", tags=["category:other-tools"])
+        assert [v for v, _ in await item_repo.category_counts("skills")] == [
+            "data",
+            "other-tools",
+            "other",
+        ]
 
     async def test_counts_respect_the_search_query(self, item_repo, catalog):
         assert await item_repo.category_counts("skills", q="two") == [("data", 1)]


### PR DESCRIPTION
Follow-up to #364: the category sidebar reads as jumbled.

## Why

Facets were ordered by size (`count DESC, name ASC`) — a rule carried over unchanged from the old client-side computation. Two problems:

**Size conveys nothing here.** The counts in the active catalogs are flat, so ordering by them is effectively arbitrary:

| type | entries | categories | shape |
|---|---|---|---|
| skills | 130 | 13 | one big, then a tail of 1-item categories |
| agents | 10 | 9 | **eight of nine hold a single entry** |
| bundles | 10 | 7 | five of seven hold a single entry |
| mcp_servers | 102 | 0 | no categories at all — sidebar never appears |

With counts that flat the tie-break does the real work, so the list came out as "one item at the top, then alphabetical" — which reads as no order at all. And when sizes *do* differ, a category lands wherever its count puts it, so finding a known one means scanning everything.

**`other` is not a peer category.** It's where sources put what they couldn't classify. At 23 of the skill catalog's 130 entries it sat second, above every real category.

This only became visible with #364's server-side counts. Before, facets were computed from the loaded page, so the sidebar showed a handful of categories and reshuffled as infinite scroll appended — the jumble was hidden behind a worse bug.

## What changes

`category_counts()` orders `case(category = 'other' → 1, else 0), category ASC`. Only the exact fallback value is demoted, so a real category named `other-tools` keeps its alphabetical place.

Real catalogs, before → after:

```
skills   was:  development(32), other(23), design(19), data(17), testing(11), ...
         now:  agent(2), analysis(1), creative(1), data(17), design(19),
               development(32), devops(4), documents(10), product(1),
               productivity(8), security(1), testing(11), other(23)

agents   was:  productivity(2), content(1), data(1), devops(1), ...
         now:  content(1), data(1), devops(1), engineering(1), product(1),
               productivity(2), research(1), seo(1), support(1)

bundles  was:  marketing(3), productivity(2), data(1), engineering(1), ...
         now:  data(1), engineering(1), marketing(3), productivity(2),
               research(1), sales(1), support(1)
```

Deliberately **not** collapsing a long tail behind "Show more": 13 categories is the largest active list, and for agents/bundles it would hide nearly everything. The full skill catalog (73 categories) is disabled in `data/registry-sources.yaml`; worth revisiting if it is ever switched on.

## Not fixed here

`mcp_servers` carries no `agentarea:category` on any of its 102 entries, so the Connections tab never shows a facet sidebar. That's a gap in the catalog source, not in this code.

## Verification

Backend only — no API surface change (response shape identical, ordering differs), so no client or spec regeneration. `make test`: 987 passed, 8 skipped, 0 failed. `ruff check` and `ruff format --check` clean. Three new tests cover alphabetical order, the fallback sorting last however big it gets, and a lookalike category not being demoted.

Ordering is still unverified in a browser against live data — same caveat as #364.


https://claude.ai/code/session_01RuMvPwof8A4dDnKKFxQKUN
