### PR TITLE
Drop the Star History chart from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,6 @@ Licensed under the Apache License 2.0 — see [LICENSE.md](LICENSE.md) for detai
 
 <div align="center">
 
-### ⭐ Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=agentarea/agentarea&type=Date)](https://star-history.com/#agentarea/agentarea&Date)
-
----
-
 **[⭐ Star us on GitHub](https://github.com/agentarea/agentarea) • [📖 Read the Docs](https://docs.agentarea.ai) • [💬 Join Discord](https://discord.gg/5tduPwheYQ) • [🐦 Follow on Twitter](https://twitter.com/agentarea_hq)**
 
 Made with ❤️ by the AgentArea community


### PR DESCRIPTION
Removes the Star History section (heading + chart embed) and its trailing divider from the README footer. The links line and the rest of the footer are unchanged.


https://claude.ai/code/session_01Mjt8n7kF3skLBnGPQG6eZJ
