### PR TITLE
Stop an unreadable credential taking down the triggers page

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/triggers.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/triggers.py
@@ -286,14 +286,24 @@ def _check_triggers_availability():
 
 
 async def _has_credentials(secret_manager: Any, trigger: Any, trigger_id: UUID) -> bool:
-    """Check if channel credentials exist for a trigger."""
+    """Check if channel credentials exist for a trigger.
+
+    Presence only — the value is never read, so a credential this deployment can
+    no longer decrypt still reports as configured. And because this is one
+    display flag on the response, a store that cannot answer at all costs the
+    flag, not the trigger: reading a trigger used to fail outright whenever its
+    credential had become unreadable.
+    """
     channel_type = "generic"
     if hasattr(trigger, "webhook_type"):
         wt = trigger.webhook_type
         channel_type = wt.value if hasattr(wt, "value") else str(wt)
     secret_name = f"channel_cred:{channel_type}:{trigger_id}"
-    raw = await secret_manager.get_secret(secret_name)
-    return raw is not None
+    try:
+        return await secret_manager.has_secret(secret_name)
+    except Exception as e:
+        logger.warning(f"Could not resolve channel credentials for trigger {trigger_id}: {e}")
+        return False
 
 
 # API Endpoints

--- a/agentarea-platform/apps/api/tests/test_triggers_api_simple.py
+++ b/agentarea-platform/apps/api/tests/test_triggers_api_simple.py
@@ -13,6 +13,7 @@ from agentarea_api.api.deps.services import (
 from agentarea_api.api.v1.a2a_auth import require_a2a_execute_auth
 from agentarea_api.main import app
 from agentarea_common.auth.dependencies import get_user_context
+from agentarea_common.infrastructure.secret_manager import BaseSecretManager
 from fastapi.testclient import TestClient
 
 
@@ -108,6 +109,73 @@ def create_mock_trigger():
     mock_trigger.data_extractor = None
     mock_trigger.has_channel_credentials = False
     return mock_trigger
+
+
+class UnreadableSecretManager(BaseSecretManager):
+    """A store that still holds the credential but can no longer read it.
+
+    What a rotated ``SECRET_MANAGER_ENCRYPTION_KEY`` leaves behind: the row is
+    still there, its ciphertext no longer decrypts. Deliberately does not
+    override ``has_secret``, so the presence check falls back to reading the
+    value — the worst case a backend can put the endpoint in.
+    """
+
+    async def get_secret(self, secret_name: str) -> str | None:
+        raise ValueError("Failed to decrypt secret. Key may have changed.")
+
+    async def set_secret(self, secret_name: str, secret_value: str) -> None:
+        raise AssertionError("reading a trigger must not write secrets")
+
+    async def delete_secret(self, secret_name: str) -> bool:
+        raise AssertionError("reading a trigger must not delete secrets")
+
+    def external_ref(self, secret_name: str) -> str | None:
+        return None
+
+
+@pytest.fixture
+def unreadable_secrets():
+    """Point the API at a secret store whose values cannot be read."""
+
+    async def _override():
+        return UnreadableSecretManager()
+
+    app.dependency_overrides[get_secret_manager] = _override
+    yield
+    app.dependency_overrides.pop(get_secret_manager, None)
+
+
+class TestTriggerCredentialFlagFailures:
+    """A credential that cannot be read must not take the trigger down.
+
+    ``has_channel_credentials`` is a display flag. Resolving it used to decrypt
+    the stored credential, so one unreadable secret turned every read of that
+    trigger into a 500 — which the webapp surfaced as "Failed to load triggers".
+    """
+
+    def test_get_trigger_survives_unreadable_credential(
+        self, client, mock_trigger_service, unreadable_secrets
+    ):
+        mock_trigger = create_mock_trigger()
+        mock_trigger.webhook_type = "telegram"
+        mock_trigger_service.get_trigger.return_value = mock_trigger
+
+        response = client.get(f"/v1/triggers/{mock_trigger.id}")
+
+        assert response.status_code == 200
+        assert response.json()["has_channel_credentials"] is False
+
+    def test_list_triggers_survives_unreadable_credential(
+        self, client, mock_trigger_service, unreadable_secrets
+    ):
+        mock_trigger = create_mock_trigger()
+        mock_trigger.webhook_type = "telegram"
+        mock_trigger_service.list_triggers.return_value = [mock_trigger]
+
+        response = client.get("/v1/triggers/")
+
+        assert response.status_code == 200
+        assert len(response.json()) == 1
 
 
 class TestTriggersAPISimple:

--- a/agentarea-platform/libs/common/agentarea_common/infrastructure/secret_manager.py
+++ b/agentarea-platform/libs/common/agentarea_common/infrastructure/secret_manager.py
@@ -19,6 +19,18 @@ class BaseSecretManager(ABC):
         deletion as a no-op and quietly kept the credential.
         """
 
+    async def has_secret(self, secret_name: str) -> bool:
+        """Whether a value is stored under this name.
+
+        Concrete on purpose: every backend can answer it by reading the value,
+        so no implementation is forced to write this. But a presence check has
+        no business needing the plaintext — a backend that can answer without
+        producing it should override, or a credential that has become
+        unreadable (a rotated key, an unreachable store) turns "does this exist"
+        into an error.
+        """
+        return await self.get_secret(secret_name) is not None
+
     @abstractmethod
     def external_ref(self, secret_name: str) -> str | None:
         """Where this backend keeps the value, or None if the catalog row holds it.

--- a/agentarea-platform/libs/secrets/agentarea_secrets/database_secret_manager.py
+++ b/agentarea-platform/libs/secrets/agentarea_secrets/database_secret_manager.py
@@ -147,6 +147,31 @@ class DatabaseSecretManager(BaseSecretManager):
             )
             raise
 
+    async def has_secret(self, secret_name: str) -> bool:
+        """Whether this workspace stores a value under this name.
+
+        Answered from the row, never from the plaintext. Deriving it from
+        ``get_secret`` meant a ciphertext this key can no longer open — or a row
+        pointing at an external store — turned "is a credential configured"
+        into an error, and callers that only wanted the flag failed with it.
+        """
+        try:
+            result = await self.session.execute(
+                select(EncryptedSecret.id).where(
+                    EncryptedSecret.workspace_id == self.workspace_id,
+                    EncryptedSecret.secret_name == secret_name,
+                )
+            )
+            return result.scalar_one_or_none() is not None
+
+        except Exception as exc:
+            logger.error(
+                "Failed to check for secret in workspace %s (%s)",
+                self.workspace_id,
+                type(exc).__name__,
+            )
+            raise
+
     async def set_secret(self, secret_name: str, secret_value: str) -> None:
         """Set a secret value (create or update).
 

--- a/agentarea-platform/libs/secrets/tests/test_database_secret_manager.py
+++ b/agentarea-platform/libs/secrets/tests/test_database_secret_manager.py
@@ -197,6 +197,93 @@ class TestDatabaseSecretManager:
         assert sensitive_error not in caplog.text
 
     @pytest.mark.asyncio
+    async def test_has_secret_found(self, mock_db_session, test_user_context, encryption_key):
+        """A stored secret reports as present."""
+        manager = DatabaseSecretManager(
+            session=mock_db_session,
+            user_context=test_user_context,
+            encryption_key=encryption_key,
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = uuid4()
+        mock_db_session.execute.return_value = mock_result
+
+        assert await manager.has_secret("openai_api_key") is True
+
+    @pytest.mark.asyncio
+    async def test_has_secret_not_found(self, mock_db_session, test_user_context, encryption_key):
+        """A name with no row reports as absent."""
+        manager = DatabaseSecretManager(
+            session=mock_db_session,
+            user_context=test_user_context,
+            encryption_key=encryption_key,
+        )
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_db_session.execute.return_value = mock_result
+
+        assert await manager.has_secret("nonexistent_key") is False
+
+    @pytest.mark.asyncio
+    async def test_has_secret_does_not_decrypt(self, mock_db_session, test_user_context):
+        """A value this key cannot open is still a value that exists.
+
+        A rotated ``SECRET_MANAGER_ENCRYPTION_KEY`` leaves rows behind that no
+        longer decrypt. Callers that only want to know whether a credential is
+        configured must get an answer, not the read failure.
+        """
+        written_with = Fernet.generate_key().decode("utf-8")
+        read_with = Fernet.generate_key().decode("utf-8")
+
+        author = DatabaseSecretManager(
+            session=mock_db_session,
+            user_context=test_user_context,
+            encryption_key=written_with,
+        )
+        manager = DatabaseSecretManager(
+            session=mock_db_session,
+            user_context=test_user_context,
+            encryption_key=read_with,
+        )
+
+        stale_secret = EncryptedSecret(
+            workspace_id="test-workspace-456",
+            secret_name="channel_cred:telegram:trigger-1",  # noqa: S106 - test fixture
+            encrypted_value=author._encrypt("bot-token"),
+            created_by="test-user-123",
+        )
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = stale_secret
+        mock_db_session.execute.return_value = mock_result
+
+        assert await manager.has_secret(stale_secret.secret_name) is True
+
+        # The value itself is genuinely unreadable — that has not been papered over.
+        with pytest.raises(ValueError, match="Failed to decrypt secret"):
+            await manager.get_secret(stale_secret.secret_name)
+
+    @pytest.mark.asyncio
+    async def test_has_secret_does_not_log_secret_identifier(
+        self, mock_db_session, test_user_context, encryption_key, caplog
+    ):
+        """Checking for a missing secret must not reveal its identifier in logs."""
+        manager = DatabaseSecretManager(
+            session=mock_db_session,
+            user_context=test_user_context,
+            encryption_key=encryption_key,
+        )
+        mock_db_session.execute.side_effect = Exception("boom")
+        secret_name = f"private-{uuid4()}"
+
+        with caplog.at_level(logging.ERROR, logger="agentarea_secrets.database_secret_manager"):
+            with pytest.raises(Exception, match="boom"):
+                await manager.has_secret(secret_name)
+
+        assert secret_name not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_set_secret_creates_new(self, mock_db_session, test_user_context, encryption_key):
         """Test setting a secret that doesn't exist (create)."""
         manager = DatabaseSecretManager(


### PR DESCRIPTION
## What broke

Production, on `/triggers`:

> **Failed to load triggers** — There was a problem loading your automation triggers. Please try again.

The list was fine. The failure was `/triggers/[id]`, which has no `error.tsx` of its own, so its throw bubbled to the list's error boundary and borrowed its message.

Backend log for the actual request:

```
ERROR agentarea_api.api.v1.triggers: Failed to get trigger a7fe1a72-…:
      Failed to decrypt secret. Key may have changed.
GET /v1/triggers/a7fe1a72-… HTTP/1.1" 500 Internal Server Error
```

## Root cause

`_has_credentials` answers one display flag — `has_channel_credentials` — by **fetching and decrypting** the trigger's stored channel credential:

```python
raw = await secret_manager.get_secret(f"channel_cred:{channel_type}:{trigger_id}")
return raw is not None
```

A `channel_cred:*` row in production no longer decrypts under the current `SECRET_MANAGER_ENCRYPTION_KEY`. `_decrypt` raises, the endpoint's blanket `except Exception` maps it to a 500, and the whole trigger becomes unreadable over a boolean the UI uses for a badge. `GET /v1/triggers` runs the same check under `asyncio.gather`, so one bad credential also took down the list endpoint for that workspace.

## Fix

Presence never needed the plaintext.

- `BaseSecretManager.has_secret()` — **concrete**, defaulting to reading the value, so no backend is forced to implement it.
- `DatabaseSecretManager.has_secret()` overrides it with a lookup on `(workspace_id, secret_name)`. A credential this deployment can no longer open now reports as configured, which is the truth, rather than failing the read.
- `_has_credentials` no longer lets the check be fatal: it is one flag on the response, so a store that cannot answer at all — unreachable Infisical, a backend mid-outage — costs the flag, not the trigger.

## Tests

Both layers, both regressions first confirmed failing against the old code with the production symptom (`assert 500 == 200`, same log line):

- `apps/api/tests/` — a secret store that raises on read (and deliberately does *not* override `has_secret`, the worst case a backend can present) still lets `GET /v1/triggers/{id}` and `GET /v1/triggers` return 200.
- `libs/secrets/tests/` — a row encrypted under a rotated key reports present, while `get_secret` still fails on it honestly.

`make test` (the per-merge gate): **995 passed, 8 skipped**, plus **25 passed** in the secrets suite. Ruff clean.

## Not fixed here

1. **The data.** This fixes the crash, not the credential. That Telegram trigger's secret is still unreadable and must be re-entered before it can fire — and it is not alone: of 9 rows in `encrypted_secrets`, 6 fail to decrypt under the live key, including two `provider_config` rows and an MCP instance's Telegram credentials. Worth treating as its own incident.
2. **The misleading message.** `/triggers/[id]` still has no `error.tsx`, so any future failure there will again read as "Failed to load triggers". A one-file frontend follow-up.


https://claude.ai/code/session_015dUs3ZPqHnptGv8CvUCKc3
