### PR TITLE
Fix cross-workspace repository access

### DIFF
--- a/agentarea-platform/libs/common/agentarea_common/base/workspace_scoped_repository.py
+++ b/agentarea-platform/libs/common/agentarea_common/base/workspace_scoped_repository.py
@@ -33,24 +33,21 @@ class WorkspaceScopedRepository[T]:
         self.resource_type = model_class.__name__.lower().replace("orm", "").replace("model", "")
 
     def _get_workspace_filter(self):
-        """Get the read filter for queries: pure workspace scoping.
+        """Get the read/write filter for the active workspace.
 
-        A row is readable when it belongs to one of the user's accessible
-        workspaces (own workspace + real memberships, resolved by the
-        AuthorizationService during request authentication). A row from another
-        workspace stays hidden.
+        ``accessible_workspaces`` authorizes the request-boundary workspace
+        selection; it must not widen repository queries after that selection.
+        Using every accessible workspace here mixes tenant data for users who
+        belong to multiple organizations and also lets an update issued in one
+        workspace target an object in another workspace by ID.
 
         Built-in/official content is no longer surfaced by a ``source`` column
         OR-branch here (ADR-003): built-in agents/skills and the reference specs
         mcp_servers/model_specs live in the registry catalog and are read
         globally by their catalog repositories, not by this filter.
         """
-        workspaces = self.user_context.accessible_workspaces
         model = cast(Any, self.model_class)
         workspace_col = model.workspace_id
-
-        if workspaces and len(workspaces) > 1:
-            return workspace_col.in_(workspaces)
         return workspace_col == self.user_context.workspace_id
 
     def _get_creator_workspace_filter(self):

--- a/agentarea-platform/libs/common/tests/test_system_entity_visibility.py
+++ b/agentarea-platform/libs/common/tests/test_system_entity_visibility.py
@@ -1,11 +1,12 @@
 """Tests for entity visibility WITHOUT a magic workspace (ADR-003).
 
 There is no longer a ``source`` provenance column on any table: the base
-WorkspaceScopedRepository read filter is pure workspace scoping
-(``workspace_id IN accessible``). Built-in content lives in the registry catalog
+WorkspaceScopedRepository read filter is pure active-workspace scoping.
+Built-in content lives in the registry catalog
 and is read globally by the catalog repositories, not by this filter. A row from
 another workspace always stays hidden.
 """
+
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -74,6 +75,22 @@ def test_no_filter_enumerates_foreign_or_official_rows():
     assert "ws-2" not in compiled
     assert "workspace_custom" not in compiled
     assert "official" not in compiled
+
+
+def test_access_to_multiple_workspaces_does_not_widen_the_active_scope():
+    """Membership authorizes workspace selection, not cross-workspace queries."""
+    session = MagicMock()
+    user_context = UserContext(
+        user_id="user-1",
+        workspace_id="ws-1",
+        accessible_workspaces=["ws-1", "ws-2"],
+    )
+    repo = ProviderConfigRepository(session, user_context)
+
+    compiled = str(repo._get_workspace_filter().compile(compile_kwargs={"literal_binds": True}))
+
+    assert "ws-1" in compiled
+    assert "ws-2" not in compiled
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- enforce the request-selected workspace as the only repository scope
- keep `accessible_workspaces` exclusively as the workspace-selection authorization set
- add regression coverage for users who belong to multiple workspaces

## Security impact
Previously, after a user selected one workspace, repository reads and mutations were filtered by every workspace the user could access. This mixed tenant data in lists and allowed an ID-addressed mutation issued under one workspace context to target an object in another accessible workspace.

## Verification
- `uv run ruff check ...`
- focused repository/visibility suite: 37 passed
- broader `libs/common` suite: 459 passed, 5 skipped, 11 pre-existing test-environment failures (workflow env + async plugin configuration)