### PR TITLE
test: align task event scoping with active workspace

### DIFF
--- a/agentarea-platform/libs/tasks/tests/unit/test_task_event_repository_scoping.py
+++ b/agentarea-platform/libs/tasks/tests/unit/test_task_event_repository_scoping.py
@@ -65,7 +65,7 @@ class TestListForTaskIsWorkspaceScoped:
         assert "task_events.event_type" in sql
 
     @pytest.mark.asyncio
-    async def test_membership_widens_to_an_in_clause_not_to_everything(self):
+    async def test_membership_does_not_widen_active_workspace_scope(self):
         session = _capturing_session()
         context = UserContext(
             user_id="alice",
@@ -77,7 +77,8 @@ class TestListForTaskIsWorkspaceScoped:
         await repo.list_for_task(uuid4())
 
         sql = _sql(session.execute.await_args.args[0])
-        assert "task_events.workspace_id IN" in sql
+        assert "task_events.workspace_id =" in sql
+        assert "task_events.workspace_id IN" not in sql
 
     @pytest.mark.asyncio
     async def test_returns_events_and_total(self):


### PR DESCRIPTION
## Summary
- update the task-event regression test after active-workspace isolation landed
- assert memberships do not widen repository reads to every accessible workspace

## Verification
- `make test`: 3044 passed, 57 skipped
- targeted workspace-scoping suite: 42 passed
- Ruff: passed