### PR TITLE
fix(llm): request usage for governed streaming calls

### DIFF
--- a/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/models/llm_model.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/agentarea_agents_sdk/models/llm_model.py
@@ -804,6 +804,11 @@ class LLMModel:
             # Build parameters for streaming
             params = self._build_litellm_params(request)
             params["stream"] = True
+            # OpenAI-compatible providers emit token usage in a trailing,
+            # choices-less chunk only when explicitly requested. Without it,
+            # governed workflows must fail closed because neither token nor
+            # cost limits can be enforced.
+            params["stream_options"] = {"include_usage": True}
 
             logger.info(f"Starting streaming LLM call for model {params['model']}")
 

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_llm_openai_stream_usage.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_llm_openai_stream_usage.py
@@ -132,7 +132,6 @@ async def test_litellm_stream_requests_and_preserves_usage(monkeypatch):
     model = LLMModel(
         provider_type="openrouter",
         model_name="vendor/new-model",
-        api_key="test-key",
         input_cost_per_token=0.001,
         output_cost_per_token=0.002,
     )

--- a/agentarea-platform/libs/agentarea-agents-sdk/tests/test_llm_openai_stream_usage.py
+++ b/agentarea-platform/libs/agentarea-agents-sdk/tests/test_llm_openai_stream_usage.py
@@ -1,6 +1,7 @@
 """OpenAI-compatible streaming usage/cost accounting."""
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -85,3 +86,66 @@ async def test_usage_only_final_chunk_is_not_dropped(monkeypatch):
     assert chunks[-1].usage.total_tokens == 15
     assert chunks[-1].cost == pytest.approx(0.02)
     assert _Client.last_json["stream_options"] == {"include_usage": True}
+
+
+class _LiteLLMStream:
+    def __init__(self):
+        self._chunks = iter(
+            [
+                SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="hello"))],
+                    _hidden_params={},
+                ),
+                SimpleNamespace(
+                    choices=[],
+                    usage=SimpleNamespace(
+                        prompt_tokens=10,
+                        completion_tokens=5,
+                        total_tokens=15,
+                    ),
+                    _hidden_params={},
+                ),
+            ]
+        )
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._chunks)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+@pytest.mark.asyncio
+async def test_litellm_stream_requests_and_preserves_usage(monkeypatch):
+    from agentarea_agents_sdk.models import llm_model as module
+
+    captured = {}
+
+    async def fake_acompletion(**params):
+        captured.update(params)
+        return _LiteLLMStream()
+
+    monkeypatch.setattr(module.litellm, "acompletion", fake_acompletion)
+    model = LLMModel(
+        provider_type="openrouter",
+        model_name="vendor/new-model",
+        api_key="test-key",
+        input_cost_per_token=0.001,
+        output_cost_per_token=0.002,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in model.ainvoke_stream(
+            LLMRequest(messages=[{"role": "user", "content": "hi"}])
+        )
+    ]
+
+    assert captured["stream_options"] == {"include_usage": True}
+    assert chunks[0].content == "hello"
+    assert chunks[-1].usage is not None
+    assert chunks[-1].usage.total_tokens == 15
+    assert chunks[-1].cost == pytest.approx(0.02)


### PR DESCRIPTION
## Summary
- request the terminal usage chunk on the LiteLLM streaming path
- preserve fail-closed token and cost governance for OpenRouter and other OpenAI-compatible providers
- add a regression test for a choices-less final usage chunk

## Production finding
A real GPT-5.6 Luna task completed at the provider but failed inside AgentArea because the stream had no usage data. The non-streaming model test did not expose this.

## Verification
- agentarea-agents-sdk: 287 passed, 14 skipped
- targeted stream accounting tests: 2 passed
- Ruff check and format: passed