### PR TITLE
fix(auth): register MCP clients for advertised scopes

### DIFF
--- a/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_oauth_as.py
@@ -49,7 +49,7 @@ class _Settings:
         HYDRA_PUBLIC_URL = HYDRA
         HYDRA_ADMIN_URL = HYDRA_ADMIN
         HYDRA_BROWSER_URL = HYDRA
-        MCP_OAUTH_SCOPES = "openid offline_access"
+        MCP_OAUTH_SCOPES = "openid offline_access offline"
 
 
 class _FakeResponse:
@@ -294,6 +294,14 @@ class TestDynamicClientRegistration:
         assert "refresh_token" in sent["grant_types"]
         assert "authorization_code" in sent["grant_types"]
         assert "offline_access" in sent["scope"].split()
+        assert "offline" in sent["scope"].split()
+
+    def test_default_scope_covers_every_advertised_hydra_scope(self, hydra):
+        """Codex requests the advertised set, which Hydra validates per client."""
+        hydra.post("/oauth2/register", json={"client_name": "Codex"})
+
+        registered = set(_FakeAsyncClient.sent[-1]["scope"].split())
+        assert set(HYDRA_DOC["scopes_supported"]) <= registered
 
     def test_respects_grant_types_the_client_asked_for(self, hydra):
         hydra.post(

--- a/agentarea-platform/libs/common/agentarea_common/config/mcp.py
+++ b/agentarea-platform/libs/common/agentarea_common/config/mcp.py
@@ -30,7 +30,11 @@ class MCPSettings(BaseAppSettings):
     # refused outright, so a deployment that does not run Hydra is unaffected
     # while one that does must declare which audience it accepts.
     HYDRA_AUDIENCE: str | None = None
-    MCP_OAUTH_SCOPES: str = "openid offline_access"
+    # Hydra advertises both the standard ``offline_access`` scope and its
+    # legacy ``offline`` alias. OAuth clients such as Codex request the full
+    # advertised set, so DCR clients must be registered for both or Hydra
+    # rejects authorization with ``invalid_scope`` before login begins.
+    MCP_OAUTH_SCOPES: str = "openid offline_access offline"
     # Allow OpenAPI connections to reach localhost/private IPs (self-hosted deployments)
     ALLOW_PRIVATE_URLS: bool = False
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -38,7 +38,7 @@ services:
       - HYDRA_PUBLIC_URL=http://hydra:4444
       - HYDRA_ADMIN_URL=http://hydra:4445
       - HYDRA_BROWSER_URL=http://localhost:4444
-      - MCP_OAUTH_SCOPES=openid offline_access
+      - MCP_OAUTH_SCOPES=openid offline_access offline
       # Public API base URL (used in OAuth AS metadata and WWW-Authenticate)
       - API_BASE_URL=http://localhost:8000
       # Kratos JWT authentication


### PR DESCRIPTION
## Summary
- include Hydras advertised `offline` compatibility scope in MCP DCR clients
- keep development configuration aligned
- add a regression test that every advertised Hydra scope is granted to default DCR clients

## Why
Codex discovers `offline_access offline openid` from Hydra and requests the full set. DCR clients were registered only for `offline_access openid`, so Hydra rejected authorization with `invalid_scope` before login.

## Verification
- `uv run --project agentarea-platform pytest agentarea-platform/apps/api/tests/test_mcp_oauth_as.py -q` (22 passed)