### PR TITLE
Make dashboard authentication failures explicit and workspace-correct

### DIFF
--- a/agentarea-webapp/src/lib/__tests__/auth-session.test.ts
+++ b/agentarea-webapp/src/lib/__tests__/auth-session.test.ts
@@ -5,8 +5,13 @@ describe("isProtectedRoute", () => {
   it.each([
     ["/agents", true],
     ["/agents/123", true],
+    ["/dashboard", true],
+    ["/budgets", true],
+    ["/members", true],
     ["/", false],
     ["/auth/login", false],
+    ["/error", false],
+    ["/500/details", false],
     ["/agentsfoo", true],
     ["/settings/profile", true],
   ])("marks %s as %s", (pathname, expected) => {

--- a/agentarea-webapp/src/lib/api-dashboard.test.ts
+++ b/agentarea-webapp/src/lib/api-dashboard.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getAgentOverview,
+  getDashboard,
+  getWorkspaceSettings,
+  updateWorkspaceSettings,
+} from "./api-dashboard";
+
+const { getAuthToken, workspaceSlugHeaders } = vi.hoisted(() => ({
+  getAuthToken: vi.fn(),
+  workspaceSlugHeaders: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/env", () => ({ env: { API_URL: "https://api.example.test" } }));
+vi.mock("./getAuthToken", () => ({ getAuthToken }));
+vi.mock("./workspace-request", () => ({ workspaceSlugHeaders }));
+
+describe("dashboard API client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAuthToken.mockResolvedValue("test-token");
+    workspaceSlugHeaders.mockResolvedValue({
+      "x-workspace-slug": "team-workspace",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+  });
+
+  it("fails before calling the API when Kratos does not issue a token", async () => {
+    getAuthToken.mockResolvedValue(null);
+
+    await expect(getDashboard()).rejects.toThrow("No auth token available");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(workspaceSlugHeaders).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["dashboard", () => getDashboard()],
+    ["workspace settings", () => getWorkspaceSettings()],
+    ["agent overview", () => getAgentOverview("agent/id")],
+    ["workspace settings update", () => updateWorkspaceSettings(25)],
+  ])(
+    "scopes the %s request to the active workspace",
+    async (_name, request) => {
+      await request();
+
+      const [, init] = vi.mocked(fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer test-token");
+      expect(headers.get("X-Workspace-Slug")).toBe("team-workspace");
+    }
+  );
+});

--- a/agentarea-webapp/src/lib/api-dashboard.ts
+++ b/agentarea-webapp/src/lib/api-dashboard.ts
@@ -1,10 +1,9 @@
-// Dashboard fetcher. Uses direct fetch with the auth token because the
-// generated openapi schema may not yet include /v1/workspace/dashboard.
-// Once the schema is regenerated, this can move into api-factory.ts.
+// Dashboard-specific fetcher for server-only callers.
 
 import "server-only";
 import { env } from "@/env";
 import { getAuthToken } from "./getAuthToken";
+import { workspaceSlugHeaders } from "./workspace-request";
 
 export type DashboardSpend = {
   today_usd: number;
@@ -95,10 +94,19 @@ export type WorkspaceSettings = {
 
 async function authedFetch(path: string, init?: RequestInit) {
   const token = await getAuthToken();
-  const headers = new Headers(init?.headers);
-  if (token) {
-    headers.set("Authorization", `Bearer ${token}`);
+  if (!token) {
+    throw new Error(`[Dashboard Client] ${path} - No auth token available`);
   }
+
+  const headers = new Headers(init?.headers);
+  headers.set("Authorization", `Bearer ${token}`);
+
+  for (const [name, value] of Object.entries(await workspaceSlugHeaders())) {
+    if (!headers.has(name)) {
+      headers.set(name, value);
+    }
+  }
+
   if (init?.body && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }

--- a/agentarea-webapp/src/lib/auth-session.ts
+++ b/agentarea-webapp/src/lib/auth-session.ts
@@ -10,40 +10,21 @@
 
 import { KRATOS_WHOAMI_TIMEOUT_MS } from "./server-timeouts";
 
-/**
- * Route prefixes that require an authenticated session.
- *
- * This is the single source of truth shared by the middleware gate
- * (src/proxy.ts) and the client shell (ConditionalLayout.tsx).
- */
-export const PROTECTED_ROUTE_PREFIXES: string[] = [
-  "/workplace",
-  "/agents",
-  "/tasks",
-  "/connections",
-  "/settings",
-  "/admin",
-  "/skills",
-  "/triggers",
-  "/inbox",
-  "/projects",
-  "/network",
-];
+const PUBLIC_ROUTE_PREFIXES = ["/auth", "/error", "/404", "/500"];
 
 /**
  * True when the pathname falls under a protected route prefix.
  *
- * Semantics are identical to the original
- * `PROTECTED_ROUTES.some(r => pathname.startsWith(r))`: a prefix match.
- * Note this means "/agentsfoo" matches "/agents" (startsWith), which preserves
- * the prior behavior exactly.
+ * Every page except the landing and auth/error surfaces belongs to the
+ * authenticated app shell. Keeping a public allowlist prevents new `(main)`
+ * routes from silently bypassing the tokenization gate.
  */
 export function isProtectedRoute(pathname: string): boolean {
-  return PROTECTED_ROUTE_PREFIXES.some(
-    (prefix) =>
-      pathname === prefix ||
-      pathname.startsWith(`${prefix}/`) ||
-      pathname.startsWith(prefix)
+  return (
+    pathname !== "/" &&
+    !PUBLIC_ROUTE_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+    )
   );
 }
 
@@ -81,17 +62,17 @@ export async function hasLiveSession(
 
     if (!response.ok) {
       // A dead/expired session is an expected outcome, not an error.
-      console.warn(
-        "[auth-session] whoami non-ok response:",
-        response.status
-      );
+      console.warn("[auth-session] whoami non-ok response:", response.status);
       return false;
     }
 
     const data = await response.json();
     return Boolean(data?.tokenized);
   } catch (error) {
-    console.error("[auth-session] whoami request failed:", (error as Error)?.name ?? "unknown");
+    console.error(
+      "[auth-session] whoami request failed:",
+      (error as Error)?.name ?? "unknown"
+    );
     return false;
   }
 }

--- a/agentarea-webapp/tests/e2e/scenario-13-audit-dashboard.real.spec.ts
+++ b/agentarea-webapp/tests/e2e/scenario-13-audit-dashboard.real.spec.ts
@@ -5,7 +5,12 @@ import {
   installBrowserSession,
   type AuthedUser,
 } from "./helpers/real-stack";
-import { deleteAgent, gotoCommitted, runRealStack, seedAgent } from "./helpers/scenarios";
+import {
+  deleteAgent,
+  gotoCommitted,
+  runRealStack,
+  seedAgent,
+} from "./helpers/scenarios";
 
 test.describe("Scenario 13 MP - inspect audit and dashboard activity", () => {
   test.skip(!runRealStack, "Set PLAYWRIGHT_REAL_STACK=1");
@@ -34,13 +39,24 @@ test.describe("Scenario 13 MP - inspect audit and dashboard activity", () => {
     // the agent -> an `agent.create` event), and it is DURABLE: still present
     // after a reload (not stream-only). This is the actual FR being verified.
     await gotoCommitted(page, "/settings/audit");
-    await expect(page.getByText("agent.create").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("agent.create").first()).toBeVisible({
+      timeout: 15_000,
+    });
     await page.reload({ waitUntil: "commit" });
-    await expect(page.getByText("agent.create").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("agent.create").first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     await gotoCommitted(page, "/dashboard");
-    await expect(page.getByText("Dashboard").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Dashboard").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText(/^\$[\d,.]+$/).first()).toBeVisible({
+      timeout: 15_000,
+    });
     await gotoCommitted(page, "/settings/audit");
-    await expect(page.getByText("agent.create").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("agent.create").first()).toBeVisible({
+      timeout: 15_000,
+    });
   });
 });


### PR DESCRIPTION
## Why

Kratos tokenization failures were hidden as backend 401s because the dashboard client sent a request without Authorization. The same hand-written client also omitted X-Workspace-Slug, and /dashboard could bypass the server tokenization gate.

## What changed

- fail before the backend request when Kratos returns no JWT
- attach the validated active workspace slug to all dashboard/settings/overview calls
- protect all application routes by default through a public-route allowlist
- make the real dashboard scenario wait for loaded spend data, not just the page heading

## Verification

- pnpm test: 138 passed
- pnpm run lint
- pnpm run build
- pnpm type-check
- production JWT/dashboard smoke after the RU signer correction: tokenization 200, dashboard 200