### PR TITLE
fix(auth): grant registered audience for MCP OAuth

### DIFF
--- a/agentarea-webapp/src/app/auth/consent/oauth-audience.test.ts
+++ b/agentarea-webapp/src/app/auth/consent/oauth-audience.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { grantedAccessTokenAudience } from "./oauth-audience";
+
+describe("grantedAccessTokenAudience", () => {
+  it("grants the audience requested by the authorization client", () => {
+    expect(
+      grantedAccessTokenAudience(
+        ["https://api.agentarea.ru/client-mcp/client-id"],
+        ["https://api.agentarea.ru"]
+      )
+    ).toEqual(["https://api.agentarea.ru/client-mcp/client-id"]);
+  });
+
+  it("falls back to the registered audience when Hydra ignores the resource parameter", () => {
+    expect(
+      grantedAccessTokenAudience([], ["https://api.agentarea.ru"])
+    ).toEqual(["https://api.agentarea.ru"]);
+  });
+
+  it("does not invent an audience when neither source provides one", () => {
+    expect(grantedAccessTokenAudience(undefined, undefined)).toEqual([]);
+  });
+});

--- a/agentarea-webapp/src/app/auth/consent/oauth-audience.ts
+++ b/agentarea-webapp/src/app/auth/consent/oauth-audience.ts
@@ -1,0 +1,8 @@
+export function grantedAccessTokenAudience(
+  requestedAudience: string[] | undefined,
+  clientAudience: string[] | undefined
+): string[] {
+  return requestedAudience && requestedAudience.length > 0
+    ? requestedAudience
+    : clientAudience || [];
+}

--- a/agentarea-webapp/src/app/auth/consent/page.tsx
+++ b/agentarea-webapp/src/app/auth/consent/page.tsx
@@ -8,11 +8,16 @@ import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { AuthLayout } from "@/components/auth/auth-layout";
+import { grantedAccessTokenAudience } from "./oauth-audience";
 
 const KNOWN_SCOPES = ["openid", "profile", "email", "offline_access"] as const;
 
 interface ConsentRequest {
-  client?: { client_name?: string; client_id?: string };
+  client?: {
+    client_name?: string;
+    client_id?: string;
+    audience?: string[];
+  };
   requested_scope?: string[];
   requested_access_token_audience?: string[];
   subject?: string;
@@ -62,8 +67,10 @@ export default function ConsentPage() {
               "profile",
               "email",
             ],
-            grant_access_token_audience:
-              consentRequest?.requested_access_token_audience || [],
+            grant_access_token_audience: grantedAccessTokenAudience(
+              consentRequest?.requested_access_token_audience,
+              consentRequest?.client?.audience
+            ),
             session: {
               id_token: {
                 email: consentRequest?.subject || "",


### PR DESCRIPTION
## Summary
- fall back to the DCR client's registered audience when Hydra 2.3 ignores the RFC 8707 resource parameter
- keep an explicitly requested access-token audience authoritative
- add regression coverage for requested, fallback, and absent audiences

## Production evidence
- Codex DCR and authorization-code flow completed successfully
- issued JWT had correct scopes but an empty aud claim
- the protected MCP endpoint rejected that token with HTTP 401
- the registered Hydra client already carries the validated API audience

## Verification
- Vitest: 3 passed
- TypeScript type-check passed
- ESLint passed for changed files