### PR TITLE
Show real popular catalog picks instead of registry noise

### DIFF
--- a/agentarea-platform/libs/registry/agentarea_registry/application/catalog_facets.py
+++ b/agentarea-platform/libs/registry/agentarea_registry/application/catalog_facets.py
@@ -84,7 +84,14 @@ def _title(registry_type: str, name: str, spec: dict[str, Any], tags: list[Any])
         explicit = _text(spec.get("display_name"))
         if explicit:
             return explicit
-        return _prettify_skill_name(name, _tag_value(tags, _REPO_TAG_PREFIX)) or name
+        original_name = _text(spec.get("original_name"))
+        return (
+            _prettify_skill_name(
+                original_name or name,
+                None if original_name else _tag_value(tags, _REPO_TAG_PREFIX),
+            )
+            or name
+        )
     return name
 
 

--- a/agentarea-platform/libs/registry/agentarea_registry/application/service.py
+++ b/agentarea-platform/libs/registry/agentarea_registry/application/service.py
@@ -870,17 +870,40 @@ class RegistryService:
             name = entry.get("name", "")
             if not name:
                 continue
+            spec = {
+                "source_type": entry.get("source_type", "content"),
+                "content": entry.get("content"),
+                "source_url": entry.get("source_url"),
+            }
+            original_name = entry.get("original_name")
+            if isinstance(original_name, str) and original_name:
+                spec["original_name"] = original_name
+
+            raw_provenance = entry.get("provenance")
+            if isinstance(raw_provenance, dict):
+                provenance = {
+                    key: raw_provenance[key]
+                    for key in (
+                        "repo",
+                        "path",
+                        "branch",
+                        "stars",
+                        "license",
+                        "distribution",
+                        "source",
+                        "duplicate_count",
+                    )
+                    if key in raw_provenance
+                }
+                if provenance:
+                    spec["provenance"] = provenance
             items.append(
                 {
                     "external_id": name,
                     "name": name,
                     "description": entry.get("description"),
                     "version": entry.get("version") or "1.0.0",
-                    "spec": {
-                        "source_type": entry.get("source_type", "content"),
-                        "content": entry.get("content"),
-                        "source_url": entry.get("source_url"),
-                    },
+                    "spec": spec,
                     "tags": entry.get("tags", []),
                 }
             )

--- a/agentarea-platform/libs/registry/tests/test_catalog_facets.py
+++ b/agentarea-platform/libs/registry/tests/test_catalog_facets.py
@@ -14,7 +14,9 @@ from agentarea_registry.application.catalog_facets import derive_facets
 
 class TestCategory:
     def test_bundles_read_category_from_spec_metadata(self):
-        f = derive_facets("bundles", name="Support Desk", spec={"metadata": {"category": "support"}}, tags=[])
+        f = derive_facets(
+            "bundles", name="Support Desk", spec={"metadata": {"category": "support"}}, tags=[]
+        )
         assert f.category == "support"
 
     def test_agents_use_their_first_tag(self):
@@ -23,7 +25,10 @@ class TestCategory:
 
     def test_skills_read_the_category_prefixed_tag(self):
         f = derive_facets(
-            "skills", name="pdf-fill", spec={}, tags=["repo:anthropics-claude-code", "category:other"]
+            "skills",
+            name="pdf-fill",
+            spec={},
+            tags=["repo:anthropics-claude-code", "category:other"],
         )
         assert f.category == "other"
 
@@ -62,7 +67,10 @@ class TestSortKey:
 
     def test_bundles_prefer_display_name(self):
         f = derive_facets(
-            "bundles", name="support-desk", spec={"display_name": "Support Desk", "name": "sd"}, tags=[]
+            "bundles",
+            name="support-desk",
+            spec={"display_name": "Support Desk", "name": "sd"},
+            tags=[],
         )
         assert f.sort_key == "support desk"
 
@@ -87,8 +95,19 @@ class TestSortKey:
         assert f.sort_key == "frontend design"
 
     def test_skills_prefer_an_explicit_display_name(self):
-        f = derive_facets("skills", name="pdf-fill--x--1", spec={"display_name": "PDF Filler"}, tags=[])
+        f = derive_facets(
+            "skills", name="pdf-fill--x--1", spec={"display_name": "PDF Filler"}, tags=[]
+        )
         assert f.sort_key == "pdf filler"
+
+    def test_skills_use_the_original_name_before_stripping_repo_suffixes(self):
+        f = derive_facets(
+            "skills",
+            name="fix-facebook-react",
+            spec={"original_name": "fix-facebook-react"},
+            tags=["repo:facebook/react"],
+        )
+        assert f.sort_key == "fix facebook react"
 
     def test_falls_back_to_the_raw_name_when_prettifying_empties_it(self):
         f = derive_facets("skills", name="--owner-repo--9f2a", spec={}, tags=[])

--- a/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
+++ b/agentarea-platform/libs/registry/tests/test_registry_service_catalog.py
@@ -386,6 +386,42 @@ class TestParseDefaultAgents:
         assert "model_id" not in spec
 
 
+class TestParseSkills:
+    def test_preserves_human_name_and_popularity_provenance(self):
+        provenance = {
+            "repo": "anthropics/skills",
+            "path": "skills/pdf/SKILL.md",
+            "stars": 42_500,
+            "license": "Apache-2.0",
+            "distribution": "compatible",
+        }
+
+        items = RegistryService._parse_skills(
+            {
+                "skills": [
+                    {
+                        "name": "pdf--anthropics-skills--abc123",
+                        "original_name": "pdf",
+                        "description": "Create and edit PDF documents.",
+                        "source_url": "https://github.com/anthropics/skills",
+                        "provenance": provenance,
+                        "tags": ["category:documents", "repo:anthropics-skills"],
+                    }
+                ]
+            }
+        )
+
+        assert items[0]["spec"]["original_name"] == "pdf"
+        assert items[0]["spec"]["provenance"] == provenance
+
+    def test_omits_invalid_provenance_instead_of_exposing_source_junk(self):
+        items = RegistryService._parse_skills(
+            {"skills": [{"name": "pdf", "provenance": "not-a-mapping"}]}
+        )
+
+        assert "provenance" not in items[0]["spec"]
+
+
 class TestParseBundles:
     def _bundle(self, **over):
         base = {

--- a/agentarea-webapp/src/app/(main)/bundles/components/__tests__/catalog-data.test.ts
+++ b/agentarea-webapp/src/app/(main)/bundles/components/__tests__/catalog-data.test.ts
@@ -121,6 +121,19 @@ describe("catalog data normalization", () => {
     "skill: explicit display_name wins over generated title"
   );
 
+  assertEqual(
+    normalize(
+      "skills",
+      item({
+        name: "mcp-builder--anthropics-skills--abc123",
+        tags: ["repo:anthropics-skills"],
+        spec: { original_name: "mcp-builder" },
+      })
+    ).title,
+    "MCP Builder",
+    "skill: original name keeps meaningful words and common acronyms"
+  );
+
   // ── server-derived facets win over local re-derivation ──
   // Browsing is filtered, sorted and counted in SQL against the row's stored
   // category/featured columns. If a card re-derived them and disagreed, an item
@@ -129,7 +142,11 @@ describe("catalog data normalization", () => {
   assertEqual(
     normalize(
       "skills",
-      item({ name: "x--y--z", tags: ["category:design"], category: "documents" })
+      item({
+        name: "x--y--z",
+        tags: ["category:design"],
+        category: "documents",
+      })
     ).category,
     "documents",
     "facets: server category wins over the tag-derived one"

--- a/agentarea-webapp/src/app/(main)/bundles/components/catalog-data.ts
+++ b/agentarea-webapp/src/app/(main)/bundles/components/catalog-data.ts
@@ -104,7 +104,10 @@ export function normalizeModelSlug(s: string): string {
 // Tolerant (substring either way) because catalog slugs are bare ("gpt-4o")
 // while real instances are provider-prefixed/variant ("openai/gpt-4o-mini").
 // Non-binding — it only drives a UI suggestion, never a backend choice.
-export function modelNameMatchesPreferred(modelName: string, preferred: string): boolean {
+export function modelNameMatchesPreferred(
+  modelName: string,
+  preferred: string
+): boolean {
   const m = normalizeModelSlug(modelName);
   const p = normalizeModelSlug(preferred);
   if (!m || !p) return false;
@@ -139,7 +142,31 @@ function prettifySkillName(name: string, repo?: string | null): string {
     }
   }
   head = head.replace(/[-_]+/g, " ").trim();
-  return head.replace(/\b\w/g, (c) => c.toUpperCase()) || name;
+  const acronyms = new Set([
+    "api",
+    "csv",
+    "docx",
+    "html",
+    "json",
+    "mcp",
+    "pdf",
+    "pptx",
+    "seo",
+    "sql",
+    "ui",
+    "ux",
+    "xlsx",
+  ]);
+  return (
+    head
+      .split(" ")
+      .map((word) =>
+        acronyms.has(word.toLowerCase())
+          ? word.toUpperCase()
+          : word.charAt(0).toUpperCase() + word.slice(1)
+      )
+      .join(" ") || name
+  );
 }
 
 export function normalize(type: CatalogType, item: RegistryItem): CatalogEntry {
@@ -178,7 +205,9 @@ export function normalize(type: CatalogType, item: RegistryItem): CatalogEntry {
       ...base,
       title: str(spec.display_name) || str(spec.name) || item.name,
       category: serverCategory ?? str(meta?.category),
-      integrations: arr(spec.mcps).map((m) => String(m.name ?? "")).filter(Boolean),
+      integrations: arr(spec.mcps)
+        .map((m) => String(m.name ?? ""))
+        .filter(Boolean),
       meta: counts,
     };
   }
@@ -202,11 +231,19 @@ export function normalize(type: CatalogType, item: RegistryItem): CatalogEntry {
     // tags. Show the repo as the card fact (the "content" source_type is noise);
     // use it to strip the repo from the generated title too.
     const tagVal = (prefix: string) =>
-      (item.tags ?? []).find((t) => t.startsWith(prefix))?.slice(prefix.length) ?? null;
+      (item.tags ?? [])
+        .find((t) => t.startsWith(prefix))
+        ?.slice(prefix.length) ?? null;
     const repo = tagVal("repo:");
+    const originalName = str(spec.original_name);
     return {
       ...base,
-      title: str(spec.display_name) ?? prettifySkillName(item.name, repo),
+      title:
+        str(spec.display_name) ??
+        prettifySkillName(
+          originalName ?? item.name,
+          originalName ? null : repo
+        ),
       category: serverCategory ?? tagVal("category:"),
       integrations: [],
       meta: repo ? [repo] : [],
@@ -216,7 +253,9 @@ export function normalize(type: CatalogType, item: RegistryItem): CatalogEntry {
   // source provides it (agentarea:category); transport (streamable-http,
   // command, sse…) is "how it connects", not a category, so we don't facet on it.
   const conn = str(spec.connection_type) ?? str(spec.transport) ?? "url";
-  const rawMeta = (spec.raw_spec as RawSpec | undefined)?.metadata as RawSpec | undefined;
+  const rawMeta = (spec.raw_spec as RawSpec | undefined)?.metadata as
+    | RawSpec
+    | undefined;
   return {
     ...base,
     title: item.name,

--- a/agentarea-webapp/src/components/CatalogSuggestions.tsx
+++ b/agentarea-webapp/src/components/CatalogSuggestions.tsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EntityIcon, type EntityKind } from "@/lib/entity-icons";
 import {
   listCatalogSuggestionsAction,
   type CatalogSuggestionItem,
@@ -13,24 +15,20 @@ import {
 // A few catalog picks shown on an otherwise-empty type page, so users can add
 // something in one click instead of facing a dead-end "Browse catalog" button.
 // Clicking a card opens that item's detail in Explore (where Connect/Install
-// lives). "Suggested" picks are curated in the catalog data
-// (agentarea:suggested); otherwise we fall back to the first few items.
+// lives). Skills come from the small curated registry and are ranked by the
+// source repository's popularity. Other types use the catalog's featured sort.
 
 type CatalogType = "bundles" | "agents" | "skills" | "mcp_servers";
 
-type RawSpec = Record<string, unknown>;
-
-function iconOf(spec: RawSpec | undefined): string | null {
-  if (!spec) return null;
-  const raw = (spec.raw_spec as RawSpec | undefined) ?? spec;
-  const icons = Array.isArray(raw.icons) ? (raw.icons as RawSpec[]) : [];
-  const src = icons[0]?.src;
-  return typeof src === "string" && src ? src : null;
+function entityKind(type: CatalogType): EntityKind {
+  if (type === "agents") return "agent";
+  if (type === "mcp_servers") return "mcp";
+  return "skill";
 }
 
 export default function CatalogSuggestions({
   type,
-  label = "Popular",
+  label,
   max = 6,
 }: {
   type: CatalogType;
@@ -38,15 +36,25 @@ export default function CatalogSuggestions({
   max?: number;
 }) {
   const [items, setItems] = useState<CatalogSuggestionItem[]>([]);
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+  const heading =
+    label ?? (type === "skills" ? "Popular skills" : "Recommended");
 
   useEffect(() => {
     let cancelled = false;
+    setState("loading");
     (async () => {
       try {
         const suggestions = await listCatalogSuggestionsAction(type, max);
-        if (!cancelled) setItems(suggestions);
+        if (!cancelled) {
+          setItems(suggestions);
+          setState("ready");
+        }
       } catch {
-        if (!cancelled) setItems([]);
+        if (!cancelled) {
+          setItems([]);
+          setState("error");
+        }
       }
     })();
     return () => {
@@ -55,39 +63,80 @@ export default function CatalogSuggestions({
   }, [type, max]);
 
   return (
-    <div className="mx-auto mt-2 w-full max-w-2xl">
-      {items.length > 0 && (
-        <>
-          <p className="mb-2 text-center text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-            {label}
-          </p>
+    <div className="mx-auto mt-2 w-full max-w-3xl">
+      <div className="min-h-[174px]">
+        <p className="mb-2 text-center text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {heading}
+        </p>
+        {state === "loading" ? (
+          <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {Array.from({ length: max }, (_, index) => (
+              <div
+                key={index}
+                className="flex min-h-[70px] gap-2.5 rounded-lg border border-border/40 px-3 py-2.5"
+              >
+                <Skeleton className="h-7 w-7 shrink-0" />
+                <div className="min-w-0 flex-1 space-y-2">
+                  <Skeleton className="h-3.5 w-3/4" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : items.length > 0 ? (
           <div className="mb-4 grid grid-cols-2 gap-2 sm:grid-cols-3">
             {items.map((it) => {
-              const icon = iconOf(it.spec);
               return (
                 <Link
                   key={it.id}
                   href={`/explore?type=${type}&item=${it.id}`}
-                  className="flex items-center gap-2 rounded-lg border border-border/60 bg-white px-3 py-2 text-sm transition-shadow hover:shadow-sm dark:bg-zinc-900"
+                  className="flex min-h-[70px] items-start gap-2.5 rounded-lg border border-border/60 bg-white px-3 py-2.5 text-sm transition-all hover:-translate-y-px hover:border-border hover:shadow-sm dark:bg-zinc-900"
                 >
-                  {icon ? (
+                  {it.iconUrl ? (
                     <Image
-                      src={icon}
+                      src={it.iconUrl}
                       alt=""
-                      width={20}
-                      height={20}
-                      className="h-5 w-5 shrink-0 rounded object-contain"
+                      width={28}
+                      height={28}
+                      className="h-7 w-7 shrink-0 rounded-md object-contain"
                     />
                   ) : (
-                    <span className="h-5 w-5 shrink-0 rounded bg-muted" />
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                      <EntityIcon
+                        kind={entityKind(type)}
+                        className="h-3.5 w-3.5"
+                      />
+                    </span>
                   )}
-                  <span className="truncate font-medium">{it.name}</span>
+                  <span className="min-w-0">
+                    <span className="block truncate font-medium">
+                      {it.title}
+                    </span>
+                    {it.description && (
+                      <span className="mt-0.5 line-clamp-2 block text-[11px] leading-4 text-muted-foreground">
+                        {it.description}
+                      </span>
+                    )}
+                    {(it.source || it.popularityLabel) && (
+                      <span className="mt-1 block truncate text-[10px] text-muted-foreground/80">
+                        {[it.source, it.popularityLabel]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </span>
+                    )}
+                  </span>
                 </Link>
               );
             })}
           </div>
-        </>
-      )}
+        ) : (
+          <p className="flex min-h-[132px] items-center justify-center text-xs text-muted-foreground">
+            {state === "error"
+              ? "Catalog recommendations are unavailable right now."
+              : "No catalog recommendations yet."}
+          </p>
+        )}
+      </div>
       <div className="flex justify-center">
         <Button asChild variant="outline">
           <Link href={`/explore?type=${type}`}>

--- a/agentarea-webapp/src/components/catalog-suggestions-actions.test.ts
+++ b/agentarea-webapp/src/components/catalog-suggestions-actions.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listCatalogSuggestionsAction } from "./catalog-suggestions-actions";
+
+const { browseCatalog, listRegistries, listRegistryItems } = vi.hoisted(() => ({
+  browseCatalog: vi.fn(),
+  listRegistries: vi.fn(),
+  listRegistryItems: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/api", () => ({
+  browseCatalog,
+  listRegistries,
+  listRegistryItems,
+}));
+
+const NOW = "2026-09-06T00:00:00Z";
+const REGISTRY_ID = "00000000-0000-4000-8000-000000000001";
+
+function item(
+  id: string,
+  name: string,
+  stars: number,
+  repo: string,
+  description: string
+) {
+  return {
+    id,
+    registry_id: REGISTRY_ID,
+    external_id: name,
+    name,
+    description,
+    version: "1.0.0",
+    spec: {
+      original_name: name.split("--")[0],
+      provenance: { stars, repo },
+      content: "full skill content must not reach the client DTO",
+    },
+    tags: [`repo:${repo.replaceAll("/", "-")}`, "category:development"],
+    installed_entity_id: null,
+    update_available: false,
+    installed_version: null,
+    category: "development",
+    featured: false,
+    created_at: NOW,
+    updated_at: NOW,
+  };
+}
+
+describe("listCatalogSuggestionsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listRegistries.mockResolvedValue({
+      data: [
+        {
+          id: REGISTRY_ID,
+          name: "skills-catalog",
+          description: "Curated skills",
+          registry_type: "skills",
+          source_type: "url",
+          source_url:
+            "https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/skills.json",
+          sync_mode: "manual",
+          is_active: true,
+          last_synced_at: NOW,
+          last_sync_error: null,
+          item_count: 4,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ],
+      error: null,
+    });
+    listRegistryItems.mockResolvedValue({
+      data: [
+        item(
+          "00000000-0000-4000-8000-000000000006",
+          "unknown--popular-repo--feedface",
+          100_000,
+          "popular/repo",
+          "A repository description accidentally imported as a skill."
+        ),
+        item(
+          "00000000-0000-4000-8000-000000000002",
+          "0-autoresearch-skill--openraiser-nanoresearch--deadbeef",
+          12,
+          "openraiser/nanoresearch",
+          "An obscure imported research workflow."
+        ),
+        item(
+          "00000000-0000-4000-8000-000000000003",
+          "frontend-design--anthropics-claude-code--abc123",
+          47_860,
+          "anthropics/claude-code",
+          "Create polished production interfaces."
+        ),
+        item(
+          "00000000-0000-4000-8000-000000000004",
+          "mcp-builder--anthropics-skills--def456",
+          9_200,
+          "anthropics/skills",
+          "Build reliable MCP servers and integrations."
+        ),
+      ],
+      error: null,
+    });
+    browseCatalog.mockResolvedValue({
+      items: [],
+      total: 0,
+      categories: [],
+      error: null,
+    });
+  });
+
+  it("uses one curated registry request and returns popular human-readable DTOs", async () => {
+    const result = await listCatalogSuggestionsAction("skills", 2);
+
+    expect(listRegistries).toHaveBeenCalledOnce();
+    expect(listRegistryItems).toHaveBeenCalledOnce();
+    expect(browseCatalog).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: "00000000-0000-4000-8000-000000000003",
+        title: "Frontend Design",
+        description: "Create polished production interfaces.",
+        iconUrl: null,
+        source: "anthropics/claude-code",
+        popularityLabel: "47.9K stars",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000000004",
+        title: "MCP Builder",
+        description: "Build reliable MCP servers and integrations.",
+        iconUrl: null,
+        source: "anthropics/skills",
+        popularityLabel: "9.2K stars",
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty("spec");
+  });
+
+  it("uses the unified browse endpoint for catalog types without a curated source", async () => {
+    listRegistries.mockResolvedValue({ data: [], error: null });
+    browseCatalog.mockResolvedValue({
+      items: [
+        item(
+          "00000000-0000-4000-8000-000000000005",
+          "Support Agent",
+          0,
+          "agentarea/catalog",
+          "Triage and resolve support requests."
+        ),
+      ],
+      total: 1,
+      categories: [],
+      error: null,
+    });
+
+    const result = await listCatalogSuggestionsAction("agents", 6);
+
+    expect(listRegistryItems).not.toHaveBeenCalled();
+    expect(browseCatalog).toHaveBeenCalledWith({
+      registryType: "agents",
+      sort: "featured",
+      limit: 24,
+      offset: 0,
+    });
+    expect(result[0].title).toBe("Support Agent");
+  });
+});

--- a/agentarea-webapp/src/components/catalog-suggestions-actions.ts
+++ b/agentarea-webapp/src/components/catalog-suggestions-actions.ts
@@ -1,21 +1,29 @@
 "use server";
 
-import type { RegistryItemResponse } from "@/api/client/types.gen";
 import {
   zListRegistriesV1RegistriesGetResponse,
   zListRegistryItemsV1RegistriesRegistryIdItemsGetResponse,
 } from "@/api/client/zod.gen";
-import { listRegistries, listRegistryItems } from "@/lib/api";
 import {
+  normalize,
   TYPE_KEYS,
   type CatalogType,
   type RawSpec,
+  type RegistryItem,
 } from "@/app/(main)/bundles/components/catalog-data";
+import { browseCatalog, listRegistries, listRegistryItems } from "@/lib/api";
 
-export type CatalogSuggestionItem = Pick<
-  RegistryItemResponse,
-  "id" | "name" | "spec"
->;
+const CURATED_SKILLS_SOURCE =
+  "https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/skills.json";
+
+export type CatalogSuggestionItem = {
+  id: string;
+  title: string;
+  description: string;
+  iconUrl: string | null;
+  source: string | null;
+  popularityLabel: string | null;
+};
 
 function errorMessage(error: unknown, fallback: string): string {
   if (!error) return fallback;
@@ -35,11 +43,75 @@ function assertCatalogType(type: CatalogType): CatalogType {
   return type;
 }
 
-function isSuggested(spec: RawSpec | undefined): boolean {
-  const meta = (spec?.raw_spec as RawSpec | undefined)?.metadata as
-    | RawSpec
-    | undefined;
-  return meta?.["agentarea:suggested"] === true;
+function popularity(item: RegistryItem): number {
+  const provenance = item.spec?.provenance as RawSpec | undefined;
+  const exact = provenance?.stars;
+  if (typeof exact === "number" && Number.isFinite(exact) && exact >= 0) {
+    return exact;
+  }
+  const bucket = item.tags
+    .map((tag) => /^stars:(\d+)\+$/.exec(tag)?.[1])
+    .find(Boolean);
+  return bucket ? Number(bucket) : 0;
+}
+
+function formatPopularity(stars: number): string | null {
+  if (stars <= 0) return null;
+  if (stars < 1_000) return `${stars} stars`;
+  const value = stars / 1_000;
+  return `${value >= 100 ? value.toFixed(0) : value.toFixed(1)}K stars`;
+}
+
+function toSuggestions(
+  type: CatalogType,
+  items: RegistryItem[],
+  max: number,
+  rankByPopularity: boolean
+): CatalogSuggestionItem[] {
+  const ranked = items.map((item) => ({
+    item,
+    entry: normalize(type, item),
+    stars: popularity(item),
+  }));
+  if (rankByPopularity) {
+    ranked.sort(
+      (a, b) => b.stars - a.stars || a.entry.title.localeCompare(b.entry.title)
+    );
+  }
+
+  const seen = new Set<string>();
+  const suggestions: CatalogSuggestionItem[] = [];
+  for (const { item, entry, stars } of ranked) {
+    const title = entry.title.trim();
+    const description = entry.description.trim();
+    if (
+      title.toLocaleLowerCase() === "unknown" ||
+      !/\p{L}/u.test(title) ||
+      description.length < 24
+    ) {
+      continue;
+    }
+    const provenance = item.spec?.provenance as RawSpec | undefined;
+    const source =
+      typeof provenance?.repo === "string"
+        ? provenance.repo
+        : type === "skills"
+          ? (entry.meta[0] ?? null)
+          : null;
+    const key = `${title.toLocaleLowerCase()}|${source ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    suggestions.push({
+      id: entry.id,
+      title,
+      description,
+      iconUrl: entry.iconUrl,
+      source,
+      popularityLabel: formatPopularity(stars),
+    });
+    if (suggestions.length === max) break;
+  }
+  return suggestions;
 }
 
 export async function listCatalogSuggestionsAction(
@@ -47,30 +119,51 @@ export async function listCatalogSuggestionsAction(
   max: number
 ): Promise<CatalogSuggestionItem[]> {
   const registryType = assertCatalogType(type);
-  const { data: registriesData, error: registriesError } = await listRegistries({
-    registry_type: registryType,
-    active_only: true,
-  });
-  if (registriesError || !registriesData) {
-    throw new Error(errorMessage(registriesError, "Failed to load registries"));
-  }
-
-  const registries = zListRegistriesV1RegistriesGetResponse.parse(registriesData);
-  const lists = await Promise.all(
-    registries.map(async (registry) => {
-      const { data, error } = await listRegistryItems(registry.id, {
+  if (registryType === "skills") {
+    const { data: registriesData, error: registriesError } =
+      await listRegistries({
+        registry_type: registryType,
+        active_only: true,
+      });
+    if (registriesError || !registriesData) {
+      throw new Error(
+        errorMessage(registriesError, "Failed to load registries")
+      );
+    }
+    const registries =
+      zListRegistriesV1RegistriesGetResponse.parse(registriesData);
+    const curated = registries.find(
+      (registry) => registry.source_url === CURATED_SKILLS_SOURCE
+    );
+    if (curated) {
+      const { data, error } = await listRegistryItems(curated.id, {
         limit: 200,
         offset: 0,
       });
       if (error || !data) {
         throw new Error(errorMessage(error, "Failed to load catalog items"));
       }
-      return zListRegistryItemsV1RegistriesRegistryIdItemsGetResponse.parse(data);
-    })
+      const items =
+        zListRegistryItemsV1RegistriesRegistryIdItemsGetResponse.parse(
+          data
+        ) as RegistryItem[];
+      return toSuggestions(registryType, items, max, true);
+    }
+  }
+
+  const result = await browseCatalog({
+    registryType,
+    sort: "featured",
+    limit: Math.max(max * 4, max),
+    offset: 0,
+  });
+  if (result.error) {
+    throw new Error(errorMessage(result.error, "Failed to load catalog items"));
+  }
+  return toSuggestions(
+    registryType,
+    result.items as RegistryItem[],
+    max,
+    false
   );
-  const all = lists.flat();
-  const suggested = all.filter((item) => isSuggested(item.spec));
-  return (suggested.length ? suggested : all)
-    .slice(0, max)
-    .map((item) => ({ id: item.id, name: item.name, spec: item.spec }));
 }

--- a/charts/agentarea/README.md
+++ b/charts/agentarea/README.md
@@ -481,6 +481,8 @@ The following table lists configurable parameters of the chart and their default
 | registryReconcile.registries[1].source_url | string | `"https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-models.json"` |  |
 | registryReconcile.registries[2].name | string | `"system-mcp-servers"` |  |
 | registryReconcile.registries[2].source_url | string | `"https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/mcp-servers.json"` |  |
+| registryReconcile.registries[3].name | string | `"system-skills-curated"` |  |
+| registryReconcile.registries[3].source_url | string | `"https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/skills.json"` |  |
 | keto.enabled | bool | `false` |  |
 | keto.replicaCount | int | `1` |  |
 | keto.image.repository | string | `"oryd/keto"` |  |

--- a/charts/agentarea/values.yaml
+++ b/charts/agentarea/values.yaml
@@ -1070,9 +1070,8 @@ jobs:
 registryReconcile:
   enabled: true
   # Each entry needs `name` + `source_url`; the catalog type is auto-detected
-  # from the fetched payload. Skills are intentionally NOT seeded by default
-  # (the public skill catalog is ~123k entries across 25 shards); add skill
-  # shards explicitly if you want them.
+  # from the fetched payload. Seed the small official/known-good skills catalog;
+  # the ~123k community mirror remains opt-in and must not drive first-run picks.
   registries:
     - name: system-llm-providers
       source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-providers.json
@@ -1080,6 +1079,8 @@ registryReconcile:
       source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/llm-models.json
     - name: system-mcp-servers
       source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/mcp-servers.json
+    - name: system-skills-curated
+      source_url: https://agentarea-mcp-registry.s3.amazonaws.com/registry/system/skills.json
 
 # Ory Kratos Identity Server
 # Ory Keto (ReBAC) — powers Govern -> Policies -> Access (the relationship graph).

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -3,7 +3,7 @@
 #
 # Mirrors:
 #   .github/workflows/ci.yml             (Python lint+tests, Go lint+tests, webapp lint+build)
-#   .github/workflows/schema-check.yml   (OpenAPI -> schema.d.ts drift)
+#   .github/workflows/schema-check.yml   (backend -> openapi.json -> docs drift)
 #   .github/workflows/frontend-integration.yml (elements-react build + webapp build)
 #   .github/workflows/check-helm-docs.yml (Helm chart README)
 #   .github/workflows/validate-env-templates.yml (Helm env tpl drift)
@@ -66,24 +66,28 @@ if ! should_skip go; then
   ok "Go tests"
 fi
 
-# ── 3. Schema drift (FastAPI -> schema.d.ts) ────────────────────────────────
+# ── 3. Schema drift (FastAPI -> openapi.json -> docs copy) ──────────────────
 if ! should_skip schema; then
   step "OpenAPI schema drift"
   TMP=$(mktemp -d)
   trap 'rm -rf "$TMP"' EXIT
   ( cd agentarea-platform && uv run python ../scripts/export-openapi.py -o "$TMP/openapi.json" ) \
     || fail "OpenAPI export failed"
-  if have npx; then
-    npx --yes openapi-typescript "$TMP/openapi.json" -o "$TMP/schema.d.ts" >/dev/null \
-      || fail "openapi-typescript failed"
-    if ! diff -q agentarea-webapp/src/api/schema.d.ts "$TMP/schema.d.ts" >/dev/null 2>&1; then
-      diff -u agentarea-webapp/src/api/schema.d.ts "$TMP/schema.d.ts" | head -50
-      fail "schema.d.ts is out of date — run: cd agentarea-webapp && pnpm generate:schema"
-    fi
-    ok "Schema drift"
-  else
-    printf '\033[33m⚠ npx not installed — skipping schema check\033[0m\n'
+  jq -S . agentarea-webapp/src/api/openapi.json > "$TMP/committed.json" \
+    || fail "could not normalize committed openapi.json"
+  jq -S . "$TMP/openapi.json" > "$TMP/exported.json" \
+    || fail "could not normalize exported OpenAPI schema"
+  if ! diff -q "$TMP/committed.json" "$TMP/exported.json" >/dev/null 2>&1; then
+    diff -u "$TMP/committed.json" "$TMP/exported.json" | head -100
+    fail "openapi.json is out of date — run: cd agentarea-webapp && pnpm generate:api"
   fi
+  jq -S . docs/api-reference/openapi.json > "$TMP/docs.json" \
+    || fail "could not normalize docs OpenAPI schema"
+  if ! diff -q "$TMP/committed.json" "$TMP/docs.json" >/dev/null 2>&1; then
+    diff -u "$TMP/committed.json" "$TMP/docs.json" | head -50
+    fail "docs OpenAPI copy is out of date — run: cd docs && npm run sync:openapi"
+  fi
+  ok "Schema drift"
 fi
 
 # ── 3b. Webapp lint + build (mirrors webapp-lint, webapp-build, frontend-integration) ──


### PR DESCRIPTION
## Why

The empty-state catalog block called arbitrary alphabetically-first shard rows Popular, rendered internal provenance slugs, fetched up to 200 full items from every registry after hydration, and silently hid failures. Production has 301k skill rows and no featured entries, so names such as `0-autoresearch-skill--...` always won.

## What changed

- preserve whitelisted `original_name` and upstream provenance/stars during skill sync
- rank the curated known-good skills source by real source-repository stars
- normalize titles and common acronyms
- show description, repository and star signal in a small client DTO
- reserve the suggestions layout with skeleton cards and expose an unavailable state
- seed the curated skills source in the product chart defaults
- repair the stale local OpenAPI preflight gate encountered during validation

## Verification

- platform: ruff, format, pyright 0 errors, `make test` 3049 passed
- webapp: 141 tests passed, lint, type-check, production build
- platform api/worker packages build
- Helm lint/render; generated chart docs
- preflight schema/env/chart gates pass