### PR TITLE
fix(mcp): resolve client in accessible workspace

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
@@ -106,7 +106,7 @@ async def _resolve_client_scope(
 
     async with get_database().read_session() as session:
         client_repo = ClientRepository(session, user_ctx)
-        client = await client_repo.get_by_id(client_id)
+        client = await client_repo.get_accessible_by_id(client_id)
         if client is None:
             return None, {}
 

--- a/agentarea-platform/apps/api/tests/test_client_mcp_authorization.py
+++ b/agentarea-platform/apps/api/tests/test_client_mcp_authorization.py
@@ -71,7 +71,7 @@ async def test_client_endpoint_binds_context_to_clients_workspace():
         skills=[],
     )
     client_repository = MagicMock()
-    client_repository.get_by_id = AsyncMock(return_value=client)
+    client_repository.get_accessible_by_id = AsyncMock(return_value=client)
     client_repository.get_instance_namespaces = AsyncMock(return_value={})
 
     session = MagicMock()
@@ -120,8 +120,34 @@ async def test_client_endpoint_binds_context_to_clients_workspace():
 
     assert proxy is not None
     assert skills == {}
+    client_repository.get_accessible_by_id.assert_awaited_once_with(CLIENT_ID)
     assert user_context.workspace_id == "client-workspace"
     get_secret_manager.assert_called_once_with(session=session, user_context=user_context)
+
+
+@pytest.mark.asyncio
+async def test_client_resource_lookup_is_limited_to_accessible_workspaces():
+    """The cross-workspace resource lookup must use only the resolved allowlist."""
+    import agentarea_agents.domain.skill_models  # noqa: F401
+    import agentarea_mcp.domain.mpc_server_instance_model  # noqa: F401
+    from agentarea_mcp.infrastructure.client_repository import ClientRepository
+
+    user_context = SimpleNamespace(
+        user_id="user-1",
+        workspace_id="personal-workspace",
+        accessible_workspaces=["personal-workspace", "client-workspace"],
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+
+    await ClientRepository(session, user_context).get_accessible_by_id(CLIENT_ID)
+
+    statement = session.execute.await_args.args[0]
+    params = statement.compile().params
+    assert CLIENT_ID in params.values()
+    assert ["personal-workspace", "client-workspace"] in params.values()
 
 
 class TestTransportSecurity:

--- a/agentarea-platform/libs/mcp/agentarea_mcp/infrastructure/client_repository.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/infrastructure/client_repository.py
@@ -35,6 +35,27 @@ class ClientRepository(WorkspaceScopedRepository[Client]):
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
+    async def get_accessible_by_id(self, id: UUID | str) -> Client | None:
+        """Resolve a client at the request boundary across authorized workspaces.
+
+        Repository CRUD remains bound to the active workspace. This lookup is
+        reserved for resource-addressed endpoints: it finds the resource only
+        inside the caller's already-resolved workspace allowlist, after which
+        the request binds to the resource workspace before constructing other
+        workspace-scoped dependencies.
+        """
+        accessible = self.user_context.accessible_workspaces or [self.user_context.workspace_id]
+        query = (
+            select(Client)
+            .where(Client.id == id, Client.workspace_id.in_(accessible))
+            .options(
+                selectinload(Client.skills),
+                selectinload(Client.mcp_instances),
+            )
+        )
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
     async def list_all(
         self, limit: int | None = None, offset: int | None = None, **filters
     ) -> list[Client]:  # type: ignore[override]


### PR DESCRIPTION
The client-scoped MCP route still looked up the client in the caller's active (normally personal) workspace before binding to the resource workspace. As a result, OAuth succeeded but `tools/list` was empty for clients stored in an organization workspace.

Resolve the client only across the server-computed accessible workspace allowlist, retain the independent ReBAC `use` check, then bind to the client workspace before constructing secret-backed services.

Validation:
- 31 focused auth/MCP tests passed
- Ruff check and format passed
- Pyright: 0 errors (existing warnings only)
- production reproduction confirmed the pre-fix empty tool list