### PR TITLE
fix(skills): page the skill catalog in SQL instead of loading all of it

### DIFF
--- a/agentarea-platform/libs/agents/agentarea_agents/application/skill_service.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/application/skill_service.py
@@ -18,6 +18,7 @@ from agentarea_agents.domain.skill_models import Skill, SkillMember, SkillSource
 from agentarea_agents.infrastructure.catalog_skill_repository import (
     CatalogSkillItem,
     CatalogSkillRepository,
+    CatalogSkillSummary,
 )
 from agentarea_agents.infrastructure.github_skill_importer import (
     GitHubSkillImporter,
@@ -71,6 +72,29 @@ def _project_catalog_skill(item: CatalogSkillItem) -> Skill:
         updated_at=item.updated_at,
     )
     # Read-only catalog projection markers consumed by the API DTO.
+    skill.is_catalog = True  # type: ignore[attr-defined]
+    skill.update_available = False  # type: ignore[attr-defined]
+    return skill
+
+
+def _project_catalog_summary(row: CatalogSkillSummary) -> Skill:
+    """Project a catalog list row into a transient, read-only ``Skill``.
+
+    List rows carry metadata only: ``SkillResponse`` has no content field, so
+    the body is left unset rather than read out of the catalog.
+    """
+    skill = Skill(
+        id=UUID(row.id),
+        name=row.name,
+        slug=generate_slug(row.name),
+        description=row.description,
+        source_type=row.source_type,
+        source_url=row.source_url,
+        network_scope=row.network_scope,
+        registry_item_id=row.id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
     skill.is_catalog = True  # type: ignore[attr-defined]
     skill.update_available = False  # type: ignore[attr-defined]
     return skill
@@ -481,58 +505,51 @@ class SkillService:
     ) -> tuple[list[Skill], int]:
         """List skills with pagination metadata, merging catalog projections.
 
-        Tenant rows and read-only catalog projections are merged into a single
-        ordered list (tenant rows first), then paginated in memory. Forked
-        catalog items are shadowed by their tenant copy. The optional filters are
-        applied to projections too so the merged view stays consistent.
+        The merged view is tenant rows first, then read-only catalog
+        projections; forked catalog items are shadowed by their tenant copy.
+        Both halves are filtered and paginated in SQL — the catalog is global
+        and large, so it must never be materialized per request.
         """
         repo = self._get_repository()
-        # Pull the full tenant set so we can dedup catalog items against forks
-        # and paginate the merged view consistently.
-        tenant_skills = await repo.list_all()
-        projections = await self._catalog_projections(tenant_skills)
-
-        merged = [*tenant_skills, *projections]
-        merged = self._filter_skills(
-            merged,
+        tenant_page, tenant_total = await repo.list_paginated(
+            limit=limit,
+            offset=offset,
             search=search,
             source_type=source_type,
             network_scope=network_scope,
             from_registry=from_registry,
         )
-        total = len(merged)
-        page = merged[offset : offset + limit]
-        return page, total
+        await self._flag_outdated_forks(tenant_page)
 
-    @staticmethod
-    def _filter_skills(
-        skills: list[Skill],
-        *,
-        search: str | None,
-        source_type: str | None,
-        network_scope: str | None,
-        from_registry: bool | None,
-    ) -> list[Skill]:
-        """Apply list filters to a merged tenant + catalog skill list."""
-        result = skills
-        if search:
-            term = search.strip().lower()
-            result = [
-                s
-                for s in result
-                if term in (s.name or "").lower()
-                or term in (s.description or "").lower()
-                or term in (s.source_url or "").lower()
-            ]
-        if source_type:
-            result = [s for s in result if s.source_type == source_type]
-        if network_scope:
-            result = [s for s in result if s.network_scope == network_scope]
-        if from_registry is True:
-            result = [s for s in result if getattr(s, "registry_item_id", None) is not None]
-        elif from_registry is False:
-            result = [s for s in result if getattr(s, "registry_item_id", None) is None]
-        return result
+        # Catalog items are registry-backed by definition, so an explicit
+        # "not from a registry" filter excludes the whole catalog half.
+        if from_registry is False:
+            return tenant_page, tenant_total
+
+        catalog_rows, catalog_total = await self._get_catalog_repository().list_page(
+            limit=max(0, limit - len(tenant_page)),
+            offset=max(0, offset - tenant_total),
+            exclude_item_ids=await repo.list_registry_item_ids(),
+            search=search,
+            source_type=source_type,
+            network_scope=network_scope,
+        )
+        page = [*tenant_page, *(_project_catalog_summary(row) for row in catalog_rows)]
+        return page, tenant_total + catalog_total
+
+    async def _flag_outdated_forks(self, skills: list[Skill]) -> None:
+        """Mark forked skills on this page whose catalog item moved on."""
+        forked = {str(s.registry_item_id) for s in skills if getattr(s, "registry_item_id", None)}
+        if not forked:
+            return
+        versions = await self._get_catalog_repository().versions_for(forked)
+        for skill in skills:
+            item_id = getattr(skill, "registry_item_id", None)
+            if item_id is None:
+                continue
+            catalog_version, installed_version = versions.get(str(item_id), (None, None))
+            if catalog_version and catalog_version != installed_version:
+                skill.update_available = True  # type: ignore[attr-defined]
 
     async def get_with_catalog(self, skill_id: UUID | str) -> Skill | None:
         """Get a tenant skill by id, falling back to a catalog projection.

--- a/agentarea-platform/libs/agents/agentarea_agents/infrastructure/catalog_skill_repository.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/infrastructure/catalog_skill_repository.py
@@ -13,13 +13,14 @@ every tenant reads the same built-in skill definitions with no workspace filter.
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
 from agentarea_common.auth.context import UserContext
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -33,6 +34,27 @@ class CatalogSkillItem:
     version: str | None
     spec: dict[str, Any]
     installed_entity_id: str | None
+    installed_version: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CatalogSkillSummary:
+    """List-view row for a catalog skill: metadata only, never the skill body.
+
+    ``SkillResponse`` does not carry skill content, so the list read path reads
+    the handful of scalar keys it needs out of ``spec`` in SQL instead of
+    loading every item's full JSONB definition into the API process.
+    """
+
+    id: str
+    name: str
+    description: str | None
+    version: str | None
+    source_type: str
+    source_url: str | None
+    network_scope: str
     installed_version: str | None
     created_at: datetime
     updated_at: datetime
@@ -61,6 +83,106 @@ class CatalogSkillRepository:
         )
         result = await self.session.execute(query, {"workspace_id": self.user_context.workspace_id})
         return [self._row_to_item(row) for row in result.fetchall()]
+
+    async def list_page(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        exclude_item_ids: Collection[str],
+        search: str | None = None,
+        source_type: str | None = None,
+        network_scope: str | None = None,
+    ) -> tuple[list[CatalogSkillSummary], int]:
+        """Page the catalog in SQL, returning ``(rows, total_matching)``.
+
+        ``exclude_item_ids`` drops items the workspace has already forked, so
+        the tenant copy shadows them exactly as the merged list expects.
+        """
+        where = ["r.registry_type = 'skills'"]
+        params: dict[str, Any] = {"workspace_id": self.user_context.workspace_id}
+
+        if exclude_item_ids:
+            where.append("ri.id::text NOT IN :exclude_ids")
+            params["exclude_ids"] = tuple(str(i) for i in exclude_item_ids)
+        if search:
+            where.append(
+                "(ri.name ILIKE :search OR ri.description ILIKE :search "
+                "OR ri.spec->>'source_url' ILIKE :search)"
+            )
+            params["search"] = f"%{search.strip()}%"
+        if source_type:
+            where.append("COALESCE(ri.spec->>'source_type', 'content') = :source_type")
+            params["source_type"] = source_type
+        if network_scope:
+            where.append("COALESCE(ri.spec->>'network_scope', 'private') = :network_scope")
+            params["network_scope"] = network_scope
+
+        where_sql = " AND ".join(where)
+        joins = (
+            "FROM registry_items ri "
+            "JOIN registries r ON r.id = ri.registry_id "
+            "LEFT JOIN registry_item_installs rii "
+            "  ON rii.registry_item_id = ri.id "
+            " AND rii.workspace_id = :workspace_id "
+            f"WHERE {where_sql}"
+        )
+
+        count_stmt = self._bind(text(f"SELECT COUNT(*) {joins}"), params)
+        total = (await self.session.execute(count_stmt, params)).scalar_one()
+
+        rows_stmt = self._bind(
+            text(
+                "SELECT ri.id, ri.name, "
+                "COALESCE(ri.description, ri.spec->>'description') AS description, "
+                "ri.version, "
+                "COALESCE(ri.spec->>'source_type', 'content') AS source_type, "
+                "ri.spec->>'source_url' AS source_url, "
+                "COALESCE(ri.spec->>'network_scope', 'private') AS network_scope, "
+                "rii.installed_version, ri.created_at, ri.updated_at "
+                f"{joins} "
+                "ORDER BY ri.name, ri.id "
+                "LIMIT :limit OFFSET :offset"
+            ),
+            params,
+        )
+        result = await self.session.execute(rows_stmt, {**params, "limit": limit, "offset": offset})
+        return [self._row_to_summary(row) for row in result.fetchall()], total
+
+    async def versions_for(
+        self, item_ids: Collection[str]
+    ) -> dict[str, tuple[str | None, str | None]]:
+        """Map catalog item id to ``(catalog_version, installed_version)``.
+
+        Used to flag an already-forked tenant skill as out of date without
+        reading the rest of the catalog.
+        """
+        if not item_ids:
+            return {}
+        stmt = text(
+            "SELECT ri.id, ri.version, rii.installed_version "
+            "FROM registry_items ri "
+            "JOIN registries r ON r.id = ri.registry_id "
+            "LEFT JOIN registry_item_installs rii "
+            "  ON rii.registry_item_id = ri.id "
+            " AND rii.workspace_id = :workspace_id "
+            "WHERE r.registry_type = 'skills' AND ri.id::text IN :item_ids"
+        ).bindparams(bindparam("item_ids", expanding=True))
+        result = await self.session.execute(
+            stmt,
+            {
+                "workspace_id": self.user_context.workspace_id,
+                "item_ids": tuple(str(i) for i in item_ids),
+            },
+        )
+        return {str(row.id): (row.version, row.installed_version) for row in result.fetchall()}
+
+    @staticmethod
+    def _bind(stmt: Any, params: dict[str, Any]) -> Any:
+        """Mark the id-exclusion parameter as expanding when it is present."""
+        if "exclude_ids" in params:
+            return stmt.bindparams(bindparam("exclude_ids", expanding=True))
+        return stmt
 
     async def get_item(self, item_id: str) -> CatalogSkillItem | None:
         """Get a single catalog skill item by its registry-item id."""
@@ -106,6 +228,22 @@ class CatalogSkillRepository:
                 "item_id": item_id,
                 "workspace_id": self.user_context.workspace_id,
             },
+        )
+
+    @staticmethod
+    def _row_to_summary(row: Any) -> CatalogSkillSummary:
+        created_at = row.created_at or row.updated_at or datetime.utcnow()
+        return CatalogSkillSummary(
+            id=str(row.id),
+            name=row.name,
+            description=row.description,
+            version=row.version,
+            source_type=row.source_type,
+            source_url=row.source_url,
+            network_scope=row.network_scope,
+            installed_version=row.installed_version,
+            created_at=created_at,
+            updated_at=row.updated_at or created_at,
         )
 
     @staticmethod

--- a/agentarea-platform/libs/agents/agentarea_agents/infrastructure/catalog_skill_repository.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/infrastructure/catalog_skill_repository.py
@@ -106,8 +106,12 @@ class CatalogSkillRepository:
             where.append("ri.id::text NOT IN :exclude_ids")
             params["exclude_ids"] = tuple(str(i) for i in exclude_item_ids)
         if search:
+            # Search the same description the row projects, or an item whose
+            # description lives only in `spec` is unfindable by the very text
+            # the list shows for it.
             where.append(
-                "(ri.name ILIKE :search OR ri.description ILIKE :search "
+                "(ri.name ILIKE :search "
+                "OR COALESCE(ri.description, ri.spec->>'description') ILIKE :search "
                 "OR ri.spec->>'source_url' ILIKE :search)"
             )
             params["search"] = f"%{search.strip()}%"

--- a/agentarea-platform/libs/agents/agentarea_agents/infrastructure/skill_repository.py
+++ b/agentarea-platform/libs/agents/agentarea_agents/infrastructure/skill_repository.py
@@ -64,6 +64,16 @@ class SkillRepository(WorkspaceScopedRepository[Skill]):
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
+    async def list_registry_item_ids(self) -> list[str]:
+        """List the catalog item ids this workspace has already forked."""
+        query = (
+            select(self.model_class.registry_item_id)
+            .where(self.model_class.registry_item_id.is_not(None))
+            .where(self._get_workspace_filter())
+        )
+        result = await self.session.execute(query)
+        return [str(row) for row in result.scalars().all()]
+
     async def get_with_agents(self, skill_id: UUID | str) -> Skill | None:
         """Get a skill with its associated agents loaded.
 

--- a/agentarea-platform/libs/agents/tests/test_catalog_skills.py
+++ b/agentarea-platform/libs/agents/tests/test_catalog_skills.py
@@ -18,6 +18,7 @@ from agentarea_agents.domain.skill_models import Skill
 from agentarea_agents.infrastructure.catalog_skill_repository import (
     CatalogSkillItem,
     CatalogSkillRepository,
+    CatalogSkillSummary,
 )
 from agentarea_common.auth.context import UserContext
 
@@ -44,6 +45,31 @@ class FakeSkillRepo:
 
     async def list_all(self):
         return list(self._skills)
+
+    async def list_paginated(
+        self,
+        limit,
+        offset,
+        search=None,
+        source_type=None,
+        network_scope=None,
+        from_registry=None,
+    ):
+        rows = list(self._skills)
+        if search:
+            rows = [s for s in rows if search.lower() in (s.name or "").lower()]
+        if source_type:
+            rows = [s for s in rows if s.source_type == source_type]
+        if from_registry is True:
+            rows = [s for s in rows if getattr(s, "registry_item_id", None)]
+        elif from_registry is False:
+            rows = [s for s in rows if not getattr(s, "registry_item_id", None)]
+        return rows[offset : offset + limit], len(rows)
+
+    async def list_registry_item_ids(self):
+        return [
+            str(s.registry_item_id) for s in self._skills if getattr(s, "registry_item_id", None)
+        ]
 
     async def get_by_id(self, _id):
         return next((s for s in self._skills if str(s.id) == str(_id)), None)
@@ -80,9 +106,56 @@ class FakeCatalogRepo:
     def __init__(self, items=None):
         self._items = items or []
         self.installed = []
+        self.list_items_calls = 0
+        self.page_calls = []
 
     async def list_items(self):
+        self.list_items_calls += 1
         return list(self._items)
+
+    def _visible(self, exclude_item_ids, search, source_type, network_scope):
+        excluded = {str(i) for i in exclude_item_ids}
+        rows = [i for i in self._items if i.id not in excluded]
+        if search:
+            rows = [i for i in rows if search.lower() in (i.name or "").lower()]
+        if source_type:
+            rows = [i for i in rows if (i.spec or {}).get("source_type") == source_type]
+        if network_scope:
+            rows = [i for i in rows if (i.spec or {}).get("network_scope") == network_scope]
+        return rows
+
+    async def list_page(
+        self,
+        *,
+        limit,
+        offset,
+        exclude_item_ids,
+        search=None,
+        source_type=None,
+        network_scope=None,
+    ):
+        self.page_calls.append({"limit": limit, "offset": offset})
+        rows = self._visible(exclude_item_ids, search, source_type, network_scope)
+        page = [
+            CatalogSkillSummary(
+                id=i.id,
+                name=i.name,
+                description=i.description,
+                version=i.version,
+                source_type=(i.spec or {}).get("source_type") or "content",
+                source_url=(i.spec or {}).get("source_url"),
+                network_scope=(i.spec or {}).get("network_scope") or "private",
+                installed_version=i.installed_version,
+                created_at=i.created_at,
+                updated_at=i.updated_at,
+            )
+            for i in rows[offset : offset + limit]
+        ]
+        return page, len(rows)
+
+    async def versions_for(self, item_ids):
+        wanted = {str(i) for i in item_ids}
+        return {i.id: (i.version, i.installed_version) for i in self._items if i.id in wanted}
 
     async def get_item(self, item_id):
         return next((i for i in self._items if i.id == item_id), None)
@@ -321,3 +394,84 @@ async def test_isolation_built_in_visible_custom_from_other_workspace_not():
     assert item_builtin.id in ids
     # No foreign custom skill leaked in (only the catalog projection is present).
     assert len(result) == 1
+
+
+async def test_list_paginated_never_scans_the_whole_catalog():
+    """The list read path must page the catalog in SQL, not load every item.
+
+    Regression guard: loading all catalog items (each carrying its full spec)
+    on every request is what made /v1/skills time out on a real catalog.
+    """
+    items = [_item(name=f"Builtin {n}") for n in range(5)]
+    catalog = FakeCatalogRepo(items)
+    svc = _service(FakeSkillRepo(), catalog)
+
+    page, total = await svc.list_paginated(limit=2, offset=0)
+
+    assert catalog.list_items_calls == 0
+    assert catalog.page_calls == [{"limit": 2, "offset": 0}]
+    assert len(page) == 2
+    assert total == 5
+
+
+async def test_list_paginated_pages_across_tenant_then_catalog():
+    tenant = Skill(id=uuid4(), name="Tenant one", slug="tenant-one", source_type="content")
+    catalog_items = [_item(name=f"Builtin {n}") for n in range(3)]
+    svc = _service(FakeSkillRepo([tenant]), FakeCatalogRepo(catalog_items))
+
+    first, total = await svc.list_paginated(limit=2, offset=0)
+    assert total == 4
+    assert [s.name for s in first] == ["Tenant one", "Builtin 0"]
+
+    second, total = await svc.list_paginated(limit=2, offset=2)
+    assert total == 4
+    assert [s.name for s in second] == ["Builtin 1", "Builtin 2"]
+
+
+async def test_list_paginated_shadows_forked_catalog_items():
+    forked_item = _item(name="Forked", version="1", installed_version="1")
+    other_item = _item(name="Unforked")
+    tenant_copy = Skill(
+        id=uuid4(),
+        name="Forked copy",
+        slug="forked-copy",
+        source_type="content",
+        registry_item_id=forked_item.id,
+    )
+    catalog = FakeCatalogRepo([forked_item, other_item])
+    svc = _service(FakeSkillRepo([tenant_copy]), catalog)
+
+    page, total = await svc.list_paginated(limit=10, offset=0)
+
+    ids = [str(s.id) for s in page]
+    assert forked_item.id not in ids
+    assert other_item.id in ids
+    assert total == 2
+
+
+async def test_list_paginated_flags_update_available_on_returned_page():
+    forked_item = _item(name="Forked", version="2", installed_version="1")
+    tenant_copy = Skill(
+        id=uuid4(),
+        name="Forked copy",
+        slug="forked-copy",
+        source_type="content",
+        registry_item_id=forked_item.id,
+    )
+    svc = _service(FakeSkillRepo([tenant_copy]), FakeCatalogRepo([forked_item]))
+
+    page, _ = await svc.list_paginated(limit=10, offset=0)
+
+    assert getattr(page[0], "update_available", False) is True
+
+
+async def test_list_paginated_from_registry_false_skips_the_catalog():
+    catalog = FakeCatalogRepo([_item(name="Builtin")])
+    svc = _service(FakeSkillRepo(), catalog)
+
+    page, total = await svc.list_paginated(limit=10, offset=0, from_registry=False)
+
+    assert page == []
+    assert total == 0
+    assert catalog.page_calls == []
+    assert catalog.list_items_calls == 0


### PR DESCRIPTION
## Проблема

`GET /v1/skills` отдаёт **504 ровно на 15с** (лимит gateway) во всех воркспейсах RU-прода — воспроизводится 3/3, `?limit=1` не помогает. Списка скиллов в продукте сейчас просто нет.

```
/v1/skills                  HTTP 504  15.10s
/v1/skills?limit=1          HTTP 504  15.06s
/v1/skills  (agentarea ws)  HTTP 504  15.15s
/v1/skills/<id>             HTTP 200   0.10s   <- одиночный GET быстрый
```

## Причина

`SkillService.list_paginated` тянул `repo.list_all()` плюс **весь** каталог через `_catalog_projections` → `CatalogSkillRepository.list_items()`, где `SELECT` включает `ri.spec` — полный JSONB с телом скилла. Фильтрация и пагинация делались уже в Python.

В проде это 1900 caталожных скиллов (46 реестров, 2210 items всего). В бюджет gateway не укладывается, и заодно выедает пул соединений — из-за чего соседние ручки (`/v1/mcp-server-instances/`) периодически отвечают по 12.9с.

При этом `SkillResponse` **не содержит** `content` — тело читалось и выбрасывалось. А `SkillRepository.list_paginated` уже делал всё правильно в SQL (фильтры, LIMIT/OFFSET, `defer(content)`) — сервис его просто не вызывал.

## Что сделано

Обе половины объединённого списка пагинируются в SQL:

- тенантные строки — через существующий `SkillRepository.list_paginated`;
- каталожные — через новый `CatalogSkillRepository.list_page`, который фильтрует и режет страницу в SQL и достаёт только скалярные ключи из `spec` (`source_type`, `source_url`, `network_scope`), без тела;
- уже форкнутые items исключаются прямо в запросе (`exclude_item_ids`);
- `update_available` считается точечным `versions_for` только по форкам на текущей странице.

Новый `CatalogSkillSummary` отделён от `CatalogSkillItem`, чтобы «строка списка без тела» была явной, а не молча недозаполненным объектом.

Семантика слияния не менялась: тенантные строки первыми, затем каталог, форки затеняют каталожный оригинал, фильтры применяются к обеим половинам.

## Проверка

- `libs/agents/tests` — 254 passed; `apps/api/tests/test_skills_api.py` + `test_skill_members.py` — 21 passed.
- Добавлены тесты на пагинацию через границу tenant→catalog, затенение форков, `update_available`, `from_registry=false`.
- Два теста-сторожа падают на старом коде и фиксируют, что полный скан каталога не вернётся (`list_items_calls == 0`).
- Сырой SQL скомпилирован под диалект postgres в обоих ветках (с исключениями и без) — expanding-параметры разворачиваются корректно.