### PR TITLE
fix(mcp): stop pinning the upstream IP when egress goes through a proxy

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
@@ -20,6 +20,8 @@ Dispatch by instance type:
 import json
 import logging
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import getproxies_environment, proxy_bypass_environment
 from uuid import UUID
 
 import httpx
@@ -173,6 +175,19 @@ async def _resolve_upstream_url(instance, server_spec) -> tuple[str, str | None]
     return "", instance_type
 
 
+def _egress_is_proxied(upstream_url: str) -> bool:
+    """Whether httpx will tunnel this URL through a forward proxy.
+
+    Mirrors httpx's own environment handling (``*_PROXY`` / ``NO_PROXY``) so the
+    decision matches what the transport will actually do.
+    """
+    parsed = urlparse(upstream_url)
+    proxies = getproxies_environment()
+    if parsed.scheme not in proxies and "all" not in proxies:
+        return False
+    return not proxy_bypass_environment(parsed.hostname or "", proxies)
+
+
 def _guard_and_pin_upstream(
     upstream_url: str, instance_type: str | None, *, allow_private: bool
 ) -> tuple[str | httpx.URL, str | None, dict | None]:
@@ -185,6 +200,13 @@ def _guard_and_pin_upstream(
     resolved IP to defeat DNS rebinding — the Host header and TLS SNI keep the
     original hostname.
 
+    Pinning is skipped when egress goes through a forward proxy. httpcore sets
+    the TLS ``server_hostname`` of a CONNECT tunnel from the origin host and
+    never consults the ``sni_hostname`` extension, so a pinned IP would make
+    every https upstream fail certificate verification. The pin would also buy
+    nothing there: the proxy resolves the name itself, so it — not this process
+    — is where rebinding has to be contained.
+
     Returns ``(request_target, host_header, extensions)``.
 
     Raises:
@@ -194,6 +216,9 @@ def _guard_and_pin_upstream(
         return upstream_url, None, None
 
     resolved_ips = validate_url(upstream_url, allow_private=allow_private)
+    if _egress_is_proxied(upstream_url):
+        return upstream_url, None, None
+
     target = build_pinned_target(upstream_url, resolved_ips[0] if resolved_ips else None)
     request_target = httpx.URL(
         scheme=target.scheme,

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_proxy.py
@@ -19,9 +19,10 @@ Dispatch by instance type:
 
 import json
 import logging
+import os
 from typing import Any
 from urllib.parse import urlparse
-from urllib.request import getproxies_environment, proxy_bypass_environment
+from urllib.request import getproxies_environment
 from uuid import UUID
 
 import httpx
@@ -175,6 +176,20 @@ async def _resolve_upstream_url(instance, server_spec) -> tuple[str, str | None]
     return "", instance_type
 
 
+def _no_proxy_bypasses(host: str) -> bool:
+    """Whether ``NO_PROXY`` exempts this host, using the usual suffix rules."""
+    raw = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
+    host = host.lower().rstrip(".")
+    for entry in (e.strip().lower().lstrip(".").rstrip(".") for e in raw.split(",")):
+        if not entry:
+            continue
+        if entry == "*":
+            return True
+        if host == entry or host.endswith(f".{entry}"):
+            return True
+    return False
+
+
 def _egress_is_proxied(upstream_url: str) -> bool:
     """Whether httpx will tunnel this URL through a forward proxy.
 
@@ -185,7 +200,7 @@ def _egress_is_proxied(upstream_url: str) -> bool:
     proxies = getproxies_environment()
     if parsed.scheme not in proxies and "all" not in proxies:
         return False
-    return not proxy_bypass_environment(parsed.hostname or "", proxies)
+    return not _no_proxy_bypasses(parsed.hostname or "")
 
 
 def _guard_and_pin_upstream(

--- a/agentarea-platform/apps/api/tests/test_mcp_proxy_ssrf.py
+++ b/agentarea-platform/apps/api/tests/test_mcp_proxy_ssrf.py
@@ -64,3 +64,52 @@ def test_private_url_allowed_when_allow_private_set():
     assert isinstance(target, httpx.URL)
     assert target.host == "10.0.0.5"
     assert target.path == "/mcp"
+
+
+@pytest.fixture
+def proxied_egress(monkeypatch):
+    """Egress goes through a forward proxy, as it does in RU production."""
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+        monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(var.lower(), raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://egress-proxy:8888")
+    monkeypatch.setenv("HTTP_PROXY", "http://egress-proxy:8888")
+
+
+def test_url_upstream_is_not_pinned_when_egress_is_proxied(proxied_egress):
+    """A pinned IP cannot carry SNI through a CONNECT tunnel.
+
+    httpcore's proxy path sets the TLS server_hostname from the origin host,
+    ignoring the sni_hostname extension, so pinning turns every https upstream
+    into a certificate error. The proxy resolves the name itself, so the pin
+    buys nothing there anyway.
+    """
+    target, host, ext = _guard_and_pin_upstream("https://1.1.1.1/mcp", "url", allow_private=False)
+    assert target == "https://1.1.1.1/mcp"
+    assert host is None
+    assert ext is None
+
+
+def test_proxied_egress_still_rejects_private_upstreams(proxied_egress):
+    with pytest.raises(ValueError, match="private/internal"):
+        _guard_and_pin_upstream(
+            "http://169.254.169.254/latest/meta-data", "url", allow_private=False
+        )
+
+
+def test_upstream_bypassing_the_proxy_is_still_pinned(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://egress-proxy:8888")
+    monkeypatch.setenv("NO_PROXY", "1.1.1.1")
+    target, _host, ext = _guard_and_pin_upstream("https://1.1.1.1/mcp", "url", allow_private=False)
+    assert isinstance(target, httpx.URL)
+    assert ext == {"sni_hostname": "1.1.1.1"}
+
+
+def test_https_upstream_is_pinned_when_only_http_proxy_is_set(monkeypatch):
+    for var in ("HTTPS_PROXY", "ALL_PROXY", "NO_PROXY"):
+        monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(var.lower(), raising=False)
+    monkeypatch.setenv("HTTP_PROXY", "http://egress-proxy:8888")
+    target, _host, ext = _guard_and_pin_upstream("https://1.1.1.1/mcp", "url", allow_private=False)
+    assert isinstance(target, httpx.URL)
+    assert ext == {"sni_hostname": "1.1.1.1"}


### PR DESCRIPTION
## Проблема

Любой вызов hosted (url-type) MCP-инстанса в RU-проде падает:

```
POST /v1/mcp/cb7f6d0d-.../mcp
502 Upstream MCP error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
IP address mismatch, certificate is not valid for '216.150.16.1'
```

При этом по тому же URL:

```
POST /v1/mcp-server-instances/validate-connection   -> {"valid":true,"tool_count":5}
POST /v1/mcp-server-instances/<id>/verify           -> {"status":"succeeded"}
```

То есть в интерфейсе инстанс зелёный и «проверенный», а каждый реальный вызов тула — 502.

## Причина

Пути расходятся ровно в одном: прокси пиннит upstream на разрезолвленный IP и рассчитывает, что расширение запроса `sni_hostname` сохранит исходный хост для TLS.

Это расширение читают только прямой путь httpcore (`_async/connection.py:107`) и SOCKS (`_async/socks_proxy.py:218`). Путь через HTTP CONNECT-туннель делает

```python
# httpcore 1.0.9, _async/http_proxy.py:313
"server_hostname": self._remote_origin.host.decode("ascii"),
```

и `sni_hostname` не смотрит вообще. Значит за forward-прокси TLS проверяется против пиннутого IP и падает всегда.

RU-прод как раз выставляет прокси для api и worker:

```yaml
# k8s-apps/envs/production/timeweb-ru/applications/agentarea/values.yaml:152
HTTPS_PROXY: "http://egress-proxy:8888"
HTTP_PROXY:  "http://egress-proxy:8888"
```

Поэтому локально всё работает, а в проде — нет.

## Что сделано

Если запрос пойдёт через forward-прокси, url-type upstream отправляется по имени хоста, без пиннинга. SSRF-валидация не изменилась и по-прежнему выполняется первой.

Пиннинг в этом режиме и не даёт ничего: имя резолвит сам прокси, так что rebinding сдерживается на прокси (у него есть egress routing table), а не в этом процессе. Это осознанный размен — если хочется удержать пин и за прокси, вариант только один: тащить SNI мимо httpcore, и это стоит обсудить отдельно.

## Проверка

- Воспроизвёл продовую ошибку локально через поднятый CONNECT-прокси:
  - `OLD (pinned IP + sni_hostname)` → `ConnectError: CERTIFICATE_VERIFY_FAILED ... certificate is not valid for '216.150.1.x'` — тот же текст, что в проде;
  - `NEW (hostname, no pin)` → `HTTP 200`.
- `apps/api/tests/test_mcp_proxy_ssrf.py` + `test_mcp_proxy.py` — 23 passed.
- Новый тест на пиннинг за прокси падает на старом коде; добавлены кейсы на `NO_PROXY` и на «выставлен только HTTP_PROXY» — там пиннинг сохраняется.