### PR TITLE
fix(clients): resolve a client-MCP bundle by client id, not by caller workspace

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/client_mcp.py
@@ -29,6 +29,10 @@ class ClientAccessDeniedError(Exception):
     """Raised when the authenticated principal lacks `use` on the target client."""
 
 
+class ClientNotFoundError(Exception):
+    """Raised when the client id in the path matches no client."""
+
+
 async def _authorize_client_access(user_ctx, client_id: str) -> None:
     """Enforce that the authenticated principal may use this client's bundle.
 
@@ -84,25 +88,40 @@ def _tool_cache() -> RedisToolListCache:
 
 async def _resolve_client_scope(
     client_id: str,
-) -> tuple[MCPAggregatorProxy | None, dict]:
+) -> tuple[MCPAggregatorProxy, dict]:
     """Resolve a client's MCP instance proxy and skill registry.
 
-    The set is exactly the client's own attachments. Returns
-    ``(proxy, skill_registry)``; proxy is None only when the client does not
-    exist.
+    The client is addressed by its own id: the MCP auth path starts every caller
+    on their personal workspace and only moves when an X-Workspace-Slug header
+    is present, which a harness pointed at ``mcp_endpoint_url`` never sends. A
+    workspace-scoped lookup therefore found nothing and the harness was handed
+    an empty tool list. Access is decided by the ReBAC `use` relation below;
+    the client's own workspace is what scopes its attachments.
+
+    Raises:
+        ClientNotFoundError: If no client matches the id.
+        ClientAccessDeniedError: If the principal may not use the client.
     """
     from agentarea_agents_sdk.skills.skill_catalog_builder import SkillEntry
     from agentarea_api.tools.base import platform_read_context
+    from agentarea_common.auth.context import UserContext
+    from agentarea_common.base.repository_factory import RepositoryFactory
     from agentarea_mcp.application.service import MCPServerInstanceService
     from agentarea_mcp.infrastructure.client_repository import ClientRepository
 
-    async with platform_read_context() as (session, user_ctx, repo_factory, broker, secret):
+    async with platform_read_context() as (session, user_ctx, _factory, broker, secret):
         client_repo = ClientRepository(session, user_ctx)
-        client = await client_repo.get_by_id(client_id)
+        client = await client_repo.get_by_id_any_workspace(client_id)
         if client is None:
-            return None, {}
+            raise ClientNotFoundError(client_id)
 
         await _authorize_client_access(user_ctx, client_id)
+
+        # Resolve the client's attachments in the workspace that owns them.
+        repo_factory = RepositoryFactory(
+            session,
+            UserContext(user_id=user_ctx.user_id, workspace_id=client.workspace_id),
+        )
 
         namespaces = await client_repo.get_instance_namespaces(client_id)
         instances = {str(i.id): i for i in client.mcp_instances}
@@ -185,8 +204,8 @@ async def _list_tools() -> list[Tool]:
         proxy, skill_registry = await _resolve_client_scope(client_id)
     except ClientAccessDeniedError:
         raise ValueError("Not authorized for this client") from None
-    if proxy is None:
-        return []
+    except ClientNotFoundError:
+        raise ValueError("Client not found") from None
     tools = [
         Tool(name=t["name"], description=t["description"], inputSchema=t["inputSchema"])
         for t in await proxy.list_namespaced_tools()
@@ -205,8 +224,8 @@ async def _call_tool(name: str, arguments: dict) -> list[TextContent]:
         proxy, skill_registry = await _resolve_client_scope(client_id)
     except ClientAccessDeniedError:
         raise ValueError("Not authorized for this client") from None
-    if proxy is None:
-        raise ValueError("Client not found")
+    except ClientNotFoundError:
+        raise ValueError("Client not found") from None
 
     if name == "activate_skill":
         from agentarea_agents_sdk.skills.skill_toolset import SkillActivationTool

--- a/agentarea-platform/apps/api/tests/test_client_mcp_authorization.py
+++ b/agentarea-platform/apps/api/tests/test_client_mcp_authorization.py
@@ -78,3 +78,61 @@ class TestTransportSecurity:
             client_mcp_server.settings.transport_security.enable_dns_rebinding_protection
             is platform.settings.transport_security.enable_dns_rebinding_protection
         )
+
+
+class TestClientResolution:
+    """A client is addressed by its own id, not by the caller's current workspace.
+
+    The MCP auth path starts every caller on their personal workspace and only
+    switches when an X-Workspace-Slug header is present. A harness connecting to
+    the ``mcp_endpoint_url`` the API hands out sends no such header, so a
+    workspace-scoped lookup silently found nothing and the harness was served an
+    empty tool list with HTTP 200. Access is decided by the ReBAC `use` relation
+    in ``_authorize_client_access``, not by which workspace the caller happens to
+    be sitting in.
+    """
+
+    def test_lookup_is_not_filtered_by_the_callers_workspace(self):
+        from unittest.mock import MagicMock
+
+        import agentarea_agents.domain.skill_models  # noqa: F401  (registers the mapper)
+        from agentarea_common.auth.context import UserContext
+        from agentarea_mcp.infrastructure.client_repository import ClientRepository
+        from sqlalchemy.dialects import postgresql
+
+        repo = ClientRepository(MagicMock(), UserContext(user_id="u1", workspace_id="personal"))
+        query = repo.build_get_by_id_query(CLIENT_ID, any_workspace=True)
+        where = str(query.compile(dialect=postgresql.dialect())).split("WHERE", 1)[1]
+
+        assert "workspace_id" not in where
+
+    def test_workspace_scoped_lookup_still_filters(self):
+        from unittest.mock import MagicMock
+
+        import agentarea_agents.domain.skill_models  # noqa: F401  (registers the mapper)
+        from agentarea_common.auth.context import UserContext
+        from agentarea_mcp.infrastructure.client_repository import ClientRepository
+        from sqlalchemy.dialects import postgresql
+
+        repo = ClientRepository(MagicMock(), UserContext(user_id="u1", workspace_id="personal"))
+        query = repo.build_get_by_id_query(CLIENT_ID, any_workspace=False)
+        where = str(query.compile(dialect=postgresql.dialect())).split("WHERE", 1)[1]
+
+        assert "workspace_id" in where
+
+
+@pytest.mark.asyncio
+async def test_list_tools_reports_an_unknown_client_instead_of_returning_none(monkeypatch):
+    """An unresolvable client must not look like a client with no tools."""
+    from agentarea_api.api.v1 import client_mcp
+
+    async def _missing(_client_id):
+        raise client_mcp.ClientNotFoundError(CLIENT_ID)
+
+    monkeypatch.setattr(client_mcp, "_resolve_client_scope", _missing)
+    token = client_mcp._client_id_var.set(CLIENT_ID)
+    try:
+        with pytest.raises(ValueError, match="not found"):
+            await client_mcp._list_tools()
+    finally:
+        client_mcp._client_id_var.reset(token)

--- a/agentarea-platform/libs/mcp/agentarea_mcp/infrastructure/client_repository.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/infrastructure/client_repository.py
@@ -22,17 +22,28 @@ class ClientRepository(WorkspaceScopedRepository[Client]):
     def __init__(self, session: AsyncSession, user_context: UserContext):
         super().__init__(session, Client, user_context)
 
-    async def get_by_id(self, id: UUID | str, creator_scoped: bool = False) -> Client | None:  # type: ignore[override]
-        query = (
-            select(Client)
-            .where(Client.id == id)
-            .where(self._get_workspace_filter())
-            .options(
-                selectinload(Client.skills),
-                selectinload(Client.mcp_instances),
-            )
+    def build_get_by_id_query(self, id: UUID | str, *, any_workspace: bool = False):
+        """Build the by-id lookup, optionally without the workspace filter.
+
+        ``any_workspace`` is for callers that address a client by its own id and
+        gate access on the ReBAC `use` relation instead of workspace membership
+        (the client-scoped MCP endpoint). Everything else stays workspace-scoped.
+        """
+        query = select(Client).where(Client.id == id)
+        if not any_workspace:
+            query = query.where(self._get_workspace_filter())
+        return query.options(
+            selectinload(Client.skills),
+            selectinload(Client.mcp_instances),
         )
-        result = await self.session.execute(query)
+
+    async def get_by_id(self, id: UUID | str, creator_scoped: bool = False) -> Client | None:  # type: ignore[override]
+        result = await self.session.execute(self.build_get_by_id_query(id))
+        return result.scalar_one_or_none()
+
+    async def get_by_id_any_workspace(self, id: UUID | str) -> Client | None:
+        """Resolve a client by id regardless of the caller's current workspace."""
+        result = await self.session.execute(self.build_get_by_id_query(id, any_workspace=True))
         return result.scalar_one_or_none()
 
     async def list_all(


### PR DESCRIPTION
## Проблема

Харнесс, подключённый по тому `mcp_endpoint_url`, который отдаёт сам API, получает пустой список тулов:

```
POST /client-mcp/80be63cd-...                          -> {"tools":[]}   HTTP 200
POST /client-mcp/80be63cd-...  + X-Workspace-Slug: aadocs -> 6 тулов       HTTP 200
```

Ни ошибки, ни объяснения — 200 и ноль тулов. При этом `GET /v1/clients/{id}` показывает и привязанный MCP-инстанс (Excalidraw), и скилл.

## Причина

`_resolve_client_scope` искал клиента через workspace-scoped репозиторий. А MCP-аутентификация стартует любого вызывающего на его личном воркспейсе и переключается только при наличии заголовка:

```python
# libs/agentarea-agents-sdk/.../mcp_server/auth.py:214
user_context = UserContext(
    user_id=auth_result.token.user_id,
    workspace_id=auth_result.token.user_id,
)
```

`mcp_endpoint_url` никакого воркспейса не несёт, и положить заголовок в конфиг харнесса некуда. Поэтому lookup промахивался, хендлер возвращал `(None, {})`, а `list_tools` превращал это в пустой список с 200.

## Что сделано

Клиент здесь адресуется собственным id, а доступ и так решается ReBAC-отношением `use` в `_authorize_client_access` — workspace-фильтр воротами не был, он был случайностью.

- Поиск клиента идёт по id независимо от воркспейса вызывающего (`get_by_id_any_workspace`, отдельный явный метод — обычный `get_by_id` остаётся scoped).
- Авторизация не менялась.
- Инстансы и скиллы клиента резолвятся в **его** воркспейсе.
- Ненайденный клиент больше не выглядит как клиент без тулов: `list_tools` кидает `Client not found`, как `call_tool` делал всегда.

## Проверка

- `test_client_mcp_authorization.py` + `test_clients_toolset.py` — 13 passed; `libs/mcp/tests` — 213 passed.
- Новые тесты: WHERE в unscoped-запросе не содержит `workspace_id`, в обычном — содержит; `list_tools` на неизвестном клиенте кидает ошибку.