### PR TITLE
fix(mcp): restart runtime after config changes

### DIFF
--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
@@ -623,6 +623,7 @@ class MCPServerInstanceService:
         patch = payload.model_dump(exclude_unset=True)
 
         update_kwargs: dict[str, Any] = {}
+        instance: MCPServerInstance | None = None
         if "name" in patch:
             update_kwargs["name"] = patch["name"]
         if "description" in patch:
@@ -635,10 +636,35 @@ class MCPServerInstanceService:
                 cleaned_spec, secret_env_vars = await self._extract_secrets_from_spec(
                     json_spec, instance.server_spec_id
                 )
+                # Transport belongs to the original connection and is immutable
+                # through this DTO. Preserve it while replacing the editable
+                # instance configuration; otherwise every legitimate PATCH drops
+                # ``type`` (and URL endpoints) merely because callers are forbidden
+                # from sending those fields back.
+                for field in INSTANCE_TRANSPORT_FIELDS:
+                    if field in (instance.json_spec or {}):
+                        cleaned_spec.setdefault(field, instance.json_spec[field])
                 masked_placeholders = {SECRET_MASKED_VALUE, "\u2022" * 6}
                 real_secrets = {
                     k: v for k, v in secret_env_vars.items() if v not in masked_placeholders
                 }
+                runtime_config_changed = cleaned_spec != (instance.json_spec or {}) or bool(
+                    real_secrets
+                )
+                if runtime_config_changed:
+                    transport_spec = await self._get_transport_spec_for_instance(instance)
+                    if transport_spec.get("type", "docker") in (
+                        "docker",
+                        "command",
+                        "kubernetes",
+                    ):
+                        # A running MCP process cannot observe changed environment,
+                        # command, or rotated secrets. Retire it before persisting
+                        # the new desired state; the next demand then cold-starts
+                        # from that state. If retirement fails, no configuration or
+                        # secret mutation has happened and the old runtime remains
+                        # an honest representation of the stored configuration.
+                        await self._retire_runtime_before_mutation(instance.id)
                 if real_secrets:
                     await self.env_service.set_instance_environment(id, real_secrets)
                     logger.info(
@@ -805,7 +831,7 @@ class MCPServerInstanceService:
 
         transport_spec = await self._get_transport_spec_for_instance(instance)
         if transport_spec.get("type", "docker") in ("docker", "command", "kubernetes"):
-            await self._retire_runtime_before_delete(instance.id)
+            await self._retire_runtime_before_mutation(instance.id)
 
         deleted = await self.repository.delete(id)
         if deleted:
@@ -814,7 +840,7 @@ class MCPServerInstanceService:
             await self.event_broker.publish(MCPServerInstanceDeleted(instance_id=instance.id))
         return deleted
 
-    async def _retire_runtime_before_delete(self, instance_id: UUID) -> None:
+    async def _retire_runtime_before_mutation(self, instance_id: UUID) -> None:
         settings = get_settings().mcp
         url = settings.manager_retire_url(instance_id)
         headers = settings.manager_gateway_headers()

--- a/agentarea-platform/libs/mcp/tests/test_service_and_api.py
+++ b/agentarea-platform/libs/mcp/tests/test_service_and_api.py
@@ -11,7 +11,11 @@ from agentarea_mcp.application.service import (
 )
 from agentarea_mcp.domain.mpc_server_instance_model import MCPServerInstance
 from agentarea_mcp.domain.verification_types import DEFAULT_VERIFICATION
-from agentarea_mcp.schemas.dto import MCPServerCreate, MCPServerInstanceCreate
+from agentarea_mcp.schemas.dto import (
+    MCPServerCreate,
+    MCPServerInstanceCreate,
+    MCPServerInstanceUpdate,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -87,6 +91,16 @@ def _make_service(
     repo.create = create
     repo.delete = delete
 
+    async def update(id_, **kwargs):
+        instance = instances.get(str(id_))
+        if instance is None:
+            return None
+        for key, value in kwargs.items():
+            setattr(instance, key, value)
+        return instance
+
+    repo.update = AsyncMock(side_effect=update)
+
     repo_factory = MagicMock()
     repo_factory.create_repository = MagicMock(return_value=repo)
 
@@ -144,6 +158,70 @@ class _RetireClient:
     async def delete(self, url: str, *, headers: dict[str, str]):
         self.calls.append((url, headers))
         return _RetireResponse(self.statuses.pop(0))
+
+
+@pytest.mark.asyncio
+async def test_update_container_config_retires_runtime_before_persisting_change():
+    instance = _make_instance("docker")
+    instance.json_spec = {"type": "docker", "environment": {"MODE": "old"}}
+    svc = _make_service({str(instance.id): instance})
+
+    async def retire_before_mutation(_instance_id):
+        assert svc.repository.update.await_count == 0
+        assert svc.env_service.set_instance_environment.await_count == 0
+
+    svc._retire_runtime_before_mutation = AsyncMock(side_effect=retire_before_mutation)
+
+    updated = await svc.update_instance(
+        instance.id,
+        MCPServerInstanceUpdate(json_spec={"environment": {"MODE": "new"}}),
+    )
+
+    assert updated is instance
+    svc._retire_runtime_before_mutation.assert_awaited_once_with(instance.id)
+    svc.repository.update.assert_awaited_once_with(
+        instance.id,
+        json_spec={"type": "docker", "environment": {"MODE": "new"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_url_instance_does_not_retire_runtime():
+    instance = _make_instance("url")
+    svc = _make_service({str(instance.id): instance})
+    svc._retire_runtime_before_mutation = AsyncMock()
+
+    await svc.update_instance(
+        instance.id,
+        MCPServerInstanceUpdate(json_spec={"headers": {"X-Tenant": "new"}}),
+    )
+
+    svc._retire_runtime_before_mutation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_secret_rotation_retires_runtime_even_when_public_spec_is_unchanged():
+    instance = _make_instance("docker")
+    instance.json_spec = {"type": "docker", "env_vars": ["TOKEN"], "environment": {}}
+    svc = _make_service({str(instance.id): instance})
+    server_spec = await svc.mcp_server_repository.get_server_by_id(instance.server_spec_id)
+    server_spec.env_schema = [{"name": "TOKEN", "isSecret": True}]
+    svc._retire_runtime_before_mutation = AsyncMock()
+
+    await svc.update_instance(
+        instance.id,
+        MCPServerInstanceUpdate(
+            json_spec={
+                "env_vars": ["TOKEN"],
+                "environment": {"TOKEN": "rotated"},
+            }
+        ),
+    )
+
+    svc._retire_runtime_before_mutation.assert_awaited_once_with(instance.id)
+    svc.env_service.set_instance_environment.assert_awaited_once_with(
+        instance.id, {"TOKEN": "rotated"}
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- retire container-backed MCP runtimes before persisting changed instance configuration
- cold-start the next request with the updated environment or rotated secrets
- preserve immutable transport fields during instance PATCH

## Validation
- `pytest libs/mcp/tests -q` (216 passed)
- `ruff check` and `ruff format --check` on changed files
- `pyright libs/mcp/agentarea_mcp/application/service.py` (0 errors)