### PR TITLE
fix(mcp): return freshly discovered tools

### DIFF
--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/service.py
@@ -773,6 +773,13 @@ class MCPServerInstanceService:
         """
         verification_payload = await self.verify_instance(instance_id)
         instance = await self.repository.get_by_id(instance_id)
+        if instance is not None:
+            # verify() persists discovered tools in its own short-lived session.
+            # get_by_id() may therefore return the already-loaded identity from
+            # this service's session with its pre-verification tools collection.
+            # Refresh only that column so this response reflects the discovery
+            # which just completed, rather than requiring a second HTTP request.
+            await self.repository.session.refresh(instance, attribute_names=["tools"])
         tools = (instance.tools if instance else None) or []
         return {"tools": tools, "verification": verification_payload}
 

--- a/agentarea-platform/libs/mcp/tests/test_service_and_api.py
+++ b/agentarea-platform/libs/mcp/tests/test_service_and_api.py
@@ -695,6 +695,36 @@ class TestServiceVerifyInstance:
         assert result["status"] == "succeeded"
 
 
+class TestServiceDiscoverAndStoreTools:
+    @pytest.mark.asyncio
+    async def test_returns_tools_refreshed_after_separate_verification_session(self):
+        inst = _make_instance("docker")
+        inst.tools = [{"name": "stale_tool"}]
+        svc = _make_service({str(inst.id): inst})
+        fresh_tools = [{"name": "fresh_tool"}]
+
+        async def refresh(instance, *, attribute_names=None):
+            assert attribute_names == ["tools"]
+            instance.tools = fresh_tools
+
+        svc.repository.session.refresh.side_effect = refresh
+        svc.verify_instance = AsyncMock(
+            return_value={
+                "schema_version": 1,
+                "status": "succeeded",
+                "at": "2026-09-07T00:00:00+00:00",
+                "error": None,
+            }
+        )
+
+        result = await svc.discover_and_store_tools(inst.id)
+
+        assert result["tools"] == fresh_tools
+        svc.repository.session.refresh.assert_awaited_once_with(
+            inst, attribute_names=["tools"]
+        )
+
+
 # ---------------------------------------------------------------------------
 # service.execute_tool — all failure paths have populated result
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- refresh the MCP instance tools column after verification writes through its separate DB session
- add a regression test for stale SQLAlchemy identity-map state

## Validation
- `pytest -q -p no:cacheprovider agentarea-platform/libs/mcp/tests` (217 passed)
- `ruff check --no-cache` on changed files
- `pyright agentarea-platform/libs/mcp/agentarea_mcp/application/service.py` (0 errors)