### PR TITLE
fix(execution): pair completion calls before follow-ups

### DIFF
--- a/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
+++ b/agentarea-platform/libs/execution/agentarea_execution/workflows/agent_execution_workflow.py
@@ -2418,6 +2418,36 @@ class AgentExecutionWorkflow:
             self._append_validation_feedback(completion_call, validation)
             return
 
+        # An explicit completion function call is already present in the
+        # conversation as an assistant message. Pair it before the workflow
+        # waits for another chat turn; otherwise OpenAI-compatible providers
+        # reject the next follow-up because its history contains an unresolved
+        # function call. Implicit text completion synthesizes a ToolCall only
+        # for local control flow, so it must not gain an orphan tool message.
+        call_is_in_history = any(
+            call.get("id") == completion_call.id
+            for message in self.state.messages
+            for call in (message.tool_calls or [])
+            if isinstance(call, dict)
+        )
+        if call_is_in_history:
+            self.state.messages.append(
+                Message(
+                    role="tool",
+                    name="completion",
+                    tool_call_id=completion_call.id,
+                    content=json.dumps(
+                        {
+                            "status": "completed",
+                            "result": result_text,
+                            "artifacts": declared_paths,
+                        },
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                )
+            )
+
         self.state.success = True
         self.state.final_response = result_text
         self.state.status = ExecutionStatus.COMPLETED

--- a/agentarea-platform/libs/execution/tests/unit/test_validation_gate_workflow.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_validation_gate_workflow.py
@@ -134,6 +134,67 @@ async def test_explicit_empty_artifacts_is_a_valid_completion_contract() -> None
 
 
 @pytest.mark.asyncio
+async def test_successful_explicit_completion_is_paired_for_follow_up_history() -> None:
+    instance = _workflow()
+    completion = _completion_with({"result": "done", "artifacts": []})
+    instance.state.messages.append(
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[{"id": completion.id, "type": "function", "function": completion.function}],
+        )
+    )
+    instance._validate_completion_artifacts = AsyncMock(
+        return_value=ArtifactValidationResult(state="passed", generation=1)
+    )
+
+    with (
+        patch(
+            "agentarea_execution.workflows.agent_execution_workflow.workflow.execute_activity",
+            new=AsyncMock(),
+        ),
+        patch(
+            "agentarea_execution.workflows.agent_execution_workflow.workflow.logger",
+            new=Mock(),
+        ),
+    ):
+        await instance._handle_task_completion(completion)
+
+    paired_result = instance.state.messages[-1]
+    assert paired_result.role == "tool"
+    assert paired_result.name == "completion"
+    assert paired_result.tool_call_id == completion.id
+    assert json.loads(paired_result.content) == {
+        "status": "completed",
+        "result": "done",
+        "artifacts": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_implicit_completion_does_not_append_orphan_tool_result() -> None:
+    instance = _workflow()
+    completion = _completion_with({"result": "done", "artifacts": []})
+    instance._validate_completion_artifacts = AsyncMock(
+        return_value=ArtifactValidationResult(state="passed", generation=1)
+    )
+
+    with (
+        patch(
+            "agentarea_execution.workflows.agent_execution_workflow.workflow.execute_activity",
+            new=AsyncMock(),
+        ),
+        patch(
+            "agentarea_execution.workflows.agent_execution_workflow.workflow.logger",
+            new=Mock(),
+        ),
+    ):
+        await instance._handle_task_completion(completion)
+
+    assert instance.state.messages == []
+
+
+@pytest.mark.asyncio
 async def test_failed_validation_returns_tool_feedback_for_two_repairs() -> None:
     instance = _workflow()
     completion = _completion()


### PR DESCRIPTION
## Summary
- append a matching tool result for successful explicit completion calls before entering the conversational follow-up window
- avoid adding orphan tool results for implicit text completion
- cover both explicit and implicit completion history behavior

## Production symptom
A third Telegram turn failed through OpenRouter with `No tool output found for function call` because the prior successful `completion` call remained unpaired in history.

## Validation
- execution unit suite: 393 passed
- Ruff check and format clean
- Pyright: 0 errors