### PR TITLE
fix(providers): skip and report incomplete models instead of failing discovery

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/provider_configs.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/provider_configs.py
@@ -247,10 +247,16 @@ class DiscoverPreviewResponse(BaseModel):
     discovered: int
     new_models: int
     models: list[DiscoverPreviewModelResponse]
+    skipped: list["SkippedModelResponse"] = []
 
 
-def _require_discovered_runtime_metadata(model: DiscoveredModel) -> int:
-    """Return the required context window or reject an incomplete catalog entry."""
+class SkippedModelResponse(BaseModel):
+    model_name: str
+    missing: list[str]
+
+
+def _missing_runtime_metadata(model: DiscoveredModel) -> list[str]:
+    """Names of the runtime fields a model must carry before it can be run."""
     missing = []
     if (
         isinstance(model.context_window, bool)
@@ -262,16 +268,57 @@ def _require_discovered_runtime_metadata(model: DiscoveredModel) -> int:
         missing.append("input_cost_per_token")
     if model.output_cost_per_token is None:
         missing.append("output_cost_per_token")
-    if missing:
+    return missing
+
+
+def _partition_discovered(
+    models: list[DiscoveredModel],
+) -> tuple[list[DiscoveredModel], list[SkippedModelResponse]]:
+    """Split a discovery batch into runnable models and reported rejects.
+
+    An entry without pricing or a context window still must not become a spec —
+    it would fail at execution time. But it must not take the rest of the
+    provider down with it either: OpenRouter publishes router meta-models
+    (``openrouter/auto-beta``) that carry no pricing by design, and failing the
+    whole batch on the first of them made discovery impossible for the provider.
+
+    Rejects are returned rather than dropped, so the caller reports what it
+    refused instead of silently returning a shorter list.
+    """
+    usable: list[DiscoveredModel] = []
+    skipped: list[SkippedModelResponse] = []
+    for model in models:
+        missing = _missing_runtime_metadata(model)
+        if missing:
+            skipped.append(SkippedModelResponse(model_name=model.model_name, missing=missing))
+        else:
+            usable.append(model)
+    return usable, skipped
+
+
+def _log_skipped_models(provider_key: str, skipped: list[SkippedModelResponse]) -> None:
+    if skipped:
+        logger.warning(
+            "Discovery for provider %s skipped %d model(s) missing runtime metadata: %s",
+            provider_key,
+            len(skipped),
+            ", ".join(f"{s.model_name} ({', '.join(s.missing)})" for s in skipped),
+        )
+
+
+def _require_any_usable_model(
+    provider_key: str, usable: list[DiscoveredModel], skipped: list[SkippedModelResponse]
+) -> None:
+    """Refuse a batch in which nothing is runnable rather than report success."""
+    if not usable:
         raise HTTPException(
             status_code=422,
             detail=(
-                f"Discovered model '{model.model_name}' is missing required runtime metadata: "
-                + ", ".join(missing)
-                + ". Configure the model spec explicitly before execution."
+                f"No model discovered for provider '{provider_key}' carries the runtime metadata "
+                f"required to execute it ({len(skipped)} skipped). "
+                "Configure the model specs explicitly."
             ),
         )
-    return cast(int, model.context_window)
 
 
 @router.post("/discover-preview", response_model=DiscoverPreviewResponse)
@@ -304,10 +351,14 @@ async def discover_models_preview(
             "The provider may not support model listing or the API key may be invalid.",
         )
 
+    usable, skipped = _partition_discovered(discovered)
+    _log_skipped_models(data.provider_key, skipped)
+    _require_any_usable_model(data.provider_key, usable, skipped)
+
     results = []
     new_count = 0
-    for model in discovered:
-        context_window = _require_discovered_runtime_metadata(model)
+    for model in usable:
+        context_window = cast(int, model.context_window)
         existing = await model_spec_repo.get_by_provider_and_model(
             UUID(str(provider_spec_id)), model.model_name
         )
@@ -358,6 +409,7 @@ async def discover_models_preview(
         discovered=len(results),
         new_models=new_count,
         models=results,
+        skipped=skipped,
     )
 
 
@@ -440,6 +492,7 @@ class DiscoveryResponse(BaseModel):
     discovered: int
     new_models: int
     models: list[DiscoveredModelResponse]
+    skipped: list[SkippedModelResponse] = []
 
 
 @router.post("/{config_id}/discover", response_model=DiscoveryResponse)
@@ -475,11 +528,15 @@ async def discover_models(
             "The provider may not support model listing or the API key may be invalid.",
         )
 
+    usable, skipped = _partition_discovered(discovered)
+    _log_skipped_models(provider_key, skipped)
+    _require_any_usable_model(provider_key, usable, skipped)
+
     # Upsert discovered models as ModelSpec entries
     results = []
     new_count = 0
-    for model in discovered:
-        context_window = _require_discovered_runtime_metadata(model)
+    for model in usable:
+        context_window = cast(int, model.context_window)
         # Check if model already exists
         existing = await model_spec_repo.get_by_provider_and_model(
             UUID(str(provider_spec_id)), model.model_name
@@ -530,6 +587,7 @@ async def discover_models(
         discovered=len(results),
         new_models=new_count,
         models=results,
+        skipped=skipped,
     )
 
 

--- a/agentarea-platform/apps/api/tests/test_provider_discovery_contract.py
+++ b/agentarea-platform/apps/api/tests/test_provider_discovery_contract.py
@@ -1,9 +1,12 @@
-"""Discovered models are not executable until runtime metadata is explicit."""
+"""Discovered models are not executable until runtime metadata is explicit.
 
-import pytest
-from agentarea_api.api.v1.provider_configs import _require_discovered_runtime_metadata
+The guarantee is that an incomplete entry never becomes a model spec. It is
+enforced by keeping such an entry out of the usable half of the batch (and
+reporting it), rather than by failing the whole discovery.
+"""
+
+from agentarea_api.api.v1.provider_configs import _partition_discovered
 from agentarea_llm.application.model_discovery_service import DiscoveredModel
-from fastapi import HTTPException
 
 
 def test_incomplete_discovered_model_is_rejected_before_persistence():
@@ -12,21 +15,24 @@ def test_incomplete_discovered_model_is_rejected_before_persistence():
         display_name="Unknown limits",
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        _require_discovered_runtime_metadata(model)
+    usable, skipped = _partition_discovered([model])
 
-    assert exc_info.value.status_code == 422
-    assert "context_window" in str(exc_info.value.detail)
-    assert "input_cost_per_token" in str(exc_info.value.detail)
+    assert usable == []
+    assert [s.model_name for s in skipped] == ["unknown-limits"]
+    assert "context_window" in skipped[0].missing
+    assert "input_cost_per_token" in skipped[0].missing
 
 
 def test_complete_discovered_model_is_accepted():
-    _require_discovered_runtime_metadata(
-        DiscoveredModel(
-            model_name="configured",
-            display_name="Configured",
-            context_window=8192,
-            input_cost_per_token=0,
-            output_cost_per_token=0,
-        )
+    model = DiscoveredModel(
+        model_name="configured",
+        display_name="Configured",
+        context_window=8192,
+        input_cost_per_token=0,
+        output_cost_per_token=0,
     )
+
+    usable, skipped = _partition_discovered([model])
+
+    assert [m.model_name for m in usable] == ["configured"]
+    assert skipped == []

--- a/agentarea-platform/apps/api/tests/test_provider_discovery_skips_incomplete.py
+++ b/agentarea-platform/apps/api/tests/test_provider_discovery_skips_incomplete.py
@@ -1,0 +1,79 @@
+"""One incomplete catalog entry must not sink discovery for the whole provider.
+
+OpenRouter publishes router meta-models (``openrouter/auto-beta``) with no
+pricing at all. Rejecting the batch on the first of them made discovery return
+422 for the entire provider, so no model could be added.
+"""
+
+import pytest
+from agentarea_api.api.v1.provider_configs import (
+    _missing_runtime_metadata,
+    _partition_discovered,
+    _require_any_usable_model,
+)
+from agentarea_llm.application.model_discovery_service import DiscoveredModel
+from fastapi import HTTPException
+
+
+def _model(name, *, context_window=8192, inp=1e-6, out=2e-6):
+    return DiscoveredModel(
+        model_name=name,
+        display_name=name,
+        context_window=context_window,
+        input_cost_per_token=inp,
+        output_cost_per_token=out,
+    )
+
+
+def test_complete_model_is_missing_nothing():
+    assert _missing_runtime_metadata(_model("openai/gpt-5")) == []
+
+
+def test_missing_fields_are_named():
+    model = _model("openrouter/auto-beta", inp=None, out=None, context_window=None)
+    assert _missing_runtime_metadata(model) == [
+        "context_window",
+        "input_cost_per_token",
+        "output_cost_per_token",
+    ]
+
+
+def test_zero_and_bool_context_windows_are_rejected():
+    assert "context_window" in _missing_runtime_metadata(_model("a", context_window=0))
+    assert "context_window" in _missing_runtime_metadata(_model("b", context_window=True))
+
+
+def test_one_priceless_model_does_not_sink_the_batch():
+    batch = [
+        _model("openai/gpt-5"),
+        _model("openrouter/auto-beta", inp=None, out=None),
+        _model("anthropic/claude-sonnet-5"),
+    ]
+
+    usable, skipped = _partition_discovered(batch)
+
+    assert [m.model_name for m in usable] == ["openai/gpt-5", "anthropic/claude-sonnet-5"]
+    assert [s.model_name for s in skipped] == ["openrouter/auto-beta"]
+    assert skipped[0].missing == ["input_cost_per_token", "output_cost_per_token"]
+
+
+def test_rejects_are_reported_not_dropped():
+    """A shorter list with no explanation would read as a successful discovery."""
+    _, skipped = _partition_discovered([_model("x", inp=None)])
+
+    assert len(skipped) == 1
+    assert skipped[0].missing == ["input_cost_per_token"]
+
+
+def test_a_batch_with_nothing_runnable_still_fails_loudly():
+    _, skipped = _partition_discovered([_model("x", inp=None), _model("y", out=None)])
+
+    with pytest.raises(HTTPException) as exc:
+        _require_any_usable_model("openrouter", [], skipped)
+
+    assert exc.value.status_code == 422
+    assert "2 skipped" in exc.value.detail
+
+
+def test_usable_models_pass_the_gate():
+    _require_any_usable_model("openrouter", [_model("openai/gpt-5")], [])

--- a/agentarea-webapp/messages/en.json
+++ b/agentarea-webapp/messages/en.json
@@ -859,6 +859,7 @@
     "testAndDiscoverTooltip": "Validate API key and discover models from provider",
     "discoveredCount": "Discovered {totalCount} models ({newCount} new)",
     "discoveredCountNoNew": "Discovered {totalCount} models (no new models)",
+    "discoveredSkipped": "{skippedCount} skipped — no context window or pricing published, so they cannot be run: {names}",
     "failedToDiscover": "Failed to discover models",
     "failedToDiscoverCheckKey": "Failed to discover models. Check API key.",
     "selectProviderFirst": "Select a provider first",

--- a/agentarea-webapp/messages/ru.json
+++ b/agentarea-webapp/messages/ru.json
@@ -860,6 +860,7 @@
     "testAndDiscoverTooltip": "Проверить API-ключ и обнаружить модели у провайдера",
     "discoveredCount": "Обнаружено {totalCount} моделей ({newCount} новых)",
     "discoveredCountNoNew": "Обнаружено {totalCount} моделей (новых нет)",
+    "discoveredSkipped": "Пропущено: {skippedCount}. У этих моделей не опубликованы контекстное окно или цены, запустить их нельзя: {names}",
     "failedToDiscover": "Не удалось обнаружить модели",
     "failedToDiscoverCheckKey": "Не удалось обнаружить модели. Проверьте API-ключ.",
     "selectProviderFirst": "Сначала выберите провайдера",

--- a/agentarea-webapp/src/api/client/index.ts
+++ b/agentarea-webapp/src/api/client/index.ts
@@ -1513,6 +1513,7 @@ export type {
   SkillRef,
   SkillResponse,
   SkillUpdateRequest,
+  SkippedModelResponse,
   SpecPreviewRequest,
   SpecPreviewResponse,
   SpendCard,

--- a/agentarea-webapp/src/api/client/types.gen.ts
+++ b/agentarea-webapp/src/api/client/types.gen.ts
@@ -1869,6 +1869,10 @@ export type DiscoverPreviewResponse = {
    * New Models
    */
   new_models: number;
+  /**
+   * Skipped
+   */
+  skipped?: Array<SkippedModelResponse>;
 };
 
 /**
@@ -1937,6 +1941,10 @@ export type DiscoveryResponse = {
    * New Models
    */
   new_models: number;
+  /**
+   * Skipped
+   */
+  skipped?: Array<SkippedModelResponse>;
 };
 
 /**
@@ -5791,6 +5799,20 @@ export type SkillUpdateRequest = {
    * New name
    */
   name?: string | null;
+};
+
+/**
+ * SkippedModelResponse
+ */
+export type SkippedModelResponse = {
+  /**
+   * Missing
+   */
+  missing: Array<string>;
+  /**
+   * Model Name
+   */
+  model_name: string;
 };
 
 /**

--- a/agentarea-webapp/src/api/client/zod.gen.ts
+++ b/agentarea-webapp/src/api/client/zod.gen.ts
@@ -664,15 +664,6 @@ export const zDiscoverPreviewRequest = z.object({
 });
 
 /**
- * DiscoverPreviewResponse
- */
-export const zDiscoverPreviewResponse = z.object({
-  discovered: z.number().int(),
-  models: z.array(zDiscoverPreviewModelResponse),
-  new_models: z.number().int(),
-});
-
-/**
  * DiscoveredModelResponse
  */
 export const zDiscoveredModelResponse = z.object({
@@ -687,15 +678,6 @@ export const zDiscoveredModelResponse = z.object({
   supports_function_calling: z.boolean().optional().default(false),
   supports_reasoning: z.boolean().optional().default(false),
   supports_vision: z.boolean().optional().default(false),
-});
-
-/**
- * DiscoveryResponse
- */
-export const zDiscoveryResponse = z.object({
-  discovered: z.number().int(),
-  models: z.array(zDiscoveredModelResponse),
-  new_models: z.number().int(),
 });
 
 /**
@@ -2422,6 +2404,34 @@ export const zSkillUpdateRequest = z.object({
   content: z.string().nullish(),
   description: z.string().nullish(),
   name: z.string().nullish(),
+});
+
+/**
+ * SkippedModelResponse
+ */
+export const zSkippedModelResponse = z.object({
+  missing: z.array(z.string()),
+  model_name: z.string(),
+});
+
+/**
+ * DiscoverPreviewResponse
+ */
+export const zDiscoverPreviewResponse = z.object({
+  discovered: z.number().int(),
+  models: z.array(zDiscoverPreviewModelResponse),
+  new_models: z.number().int(),
+  skipped: z.array(zSkippedModelResponse).optional().default([]),
+});
+
+/**
+ * DiscoveryResponse
+ */
+export const zDiscoveryResponse = z.object({
+  discovered: z.number().int(),
+  models: z.array(zDiscoveredModelResponse),
+  new_models: z.number().int(),
+  skipped: z.array(zSkippedModelResponse).optional().default([]),
 });
 
 /**

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -3253,6 +3253,14 @@
           "new_models": {
             "title": "New Models",
             "type": "integer"
+          },
+          "skipped": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SkippedModelResponse"
+            },
+            "title": "Skipped",
+            "type": "array"
           }
         },
         "required": [
@@ -3366,6 +3374,14 @@
           "new_models": {
             "title": "New Models",
             "type": "integer"
+          },
+          "skipped": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SkippedModelResponse"
+            },
+            "title": "Skipped",
+            "type": "array"
           }
         },
         "required": [
@@ -9778,6 +9794,27 @@
           }
         },
         "title": "SkillUpdateRequest",
+        "type": "object"
+      },
+      "SkippedModelResponse": {
+        "properties": {
+          "missing": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing",
+            "type": "array"
+          },
+          "model_name": {
+            "title": "Model Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model_name",
+          "missing"
+        ],
+        "title": "SkippedModelResponse",
         "type": "object"
       },
       "SpecPreviewRequest": {

--- a/agentarea-webapp/src/components/ProviderConfigForm/components/ModelInstances.tsx
+++ b/agentarea-webapp/src/components/ProviderConfigForm/components/ModelInstances.tsx
@@ -11,6 +11,7 @@ import {
   discoverModelsPreviewAction,
 } from "@/lib/server-actions";
 import { ModelSpec, ProviderSpec } from "@/types/provider";
+import type { SkippedModelResponse } from "@/api/client";
 import { filterModelsByDiscovery } from "./modelDiscovery";
 
 interface SelectedModel {
@@ -98,6 +99,7 @@ export default function ModelInstances({
       let totalCount = 0;
       let newCount = 0;
       let discoveredNames: string[] = [];
+      let skipped: SkippedModelResponse[] = [];
 
       if (providerConfigId) {
         const { data, error } = await discoverModelsAction(providerConfigId);
@@ -109,6 +111,7 @@ export default function ModelInstances({
         totalCount = data?.discovered ?? 0;
         newCount = data?.new_models ?? 0;
         discoveredNames = data?.models.map((model) => model.model_name) ?? [];
+        skipped = data?.skipped ?? [];
       } else {
         const { data, error } = await discoverModelsPreviewAction({
           provider_key: providerKey ?? "",
@@ -135,13 +138,27 @@ export default function ModelInstances({
         totalCount = data?.discovered ?? 0;
         newCount = data?.new_models ?? 0;
         discoveredNames = data?.models.map((model) => model.model_name) ?? [];
+        skipped = data?.skipped ?? [];
       }
 
-      if (newCount > 0) {
-        toast.success(t("discoveredCount", { totalCount, newCount }));
-      } else {
-        toast.success(t("discoveredCountNoNew", { totalCount }));
-      }
+      const summary =
+        newCount > 0
+          ? t("discoveredCount", { totalCount, newCount })
+          : t("discoveredCountNoNew", { totalCount });
+      // `discovered` counts only the models that were kept. Reporting it alone
+      // would present a partial discovery as a complete one, which is exactly
+      // what the backend returns `skipped` to prevent.
+      toast.success(
+        summary,
+        skipped.length > 0
+          ? {
+              description: t("discoveredSkipped", {
+                skippedCount: skipped.length,
+                names: skipped.map((model) => model.model_name).join(", "),
+              }),
+            }
+          : undefined,
+      );
       setDiscoveredModelNames(new Set(discoveredNames));
       setHasDiscovered(true);
       await onModelsDiscovered?.();

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3253,6 +3253,14 @@
           "new_models": {
             "title": "New Models",
             "type": "integer"
+          },
+          "skipped": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SkippedModelResponse"
+            },
+            "title": "Skipped",
+            "type": "array"
           }
         },
         "required": [
@@ -3366,6 +3374,14 @@
           "new_models": {
             "title": "New Models",
             "type": "integer"
+          },
+          "skipped": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SkippedModelResponse"
+            },
+            "title": "Skipped",
+            "type": "array"
           }
         },
         "required": [
@@ -9778,6 +9794,27 @@
           }
         },
         "title": "SkillUpdateRequest",
+        "type": "object"
+      },
+      "SkippedModelResponse": {
+        "properties": {
+          "missing": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Missing",
+            "type": "array"
+          },
+          "model_name": {
+            "title": "Model Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model_name",
+          "missing"
+        ],
+        "title": "SkippedModelResponse",
         "type": "object"
       },
       "SpecPreviewRequest": {


### PR DESCRIPTION
## Проблема

Discover моделей у OpenRouter в RU-проде не работает вообще:

```
POST /v1/provider-configs/9930a8ec-.../discover
422 Discovered model 'openrouter/auto-beta' is missing required runtime metadata:
input_cost_per_token, output_cost_per_token.
```

OpenRouter публикует роутер-мета-модели (`openrouter/auto-beta`), у которых цены нет по определению — она зависит от того, куда роутер отправит запрос. Такая модель всегда есть в выдаче, поэтому добавить через discover нельзя ни одной модели.

## Причина

`_require_discovered_runtime_metadata` кидал `HTTPException(422)` **внутри цикла** по всем найденным моделям, на обоих вызовах — `:310` (discover-preview) и `:482` (discover).

На `/discover` это происходило ещё и после того, как часть моделей уже была записана через `upsert_by_provider_and_model_kwargs`, то есть за 422 оставалась частичная запись.

## Что сделано

Гарантия, которую эта проверка защищала, остаётся: запись без цен или без context window не должна становиться спекой — она упадёт на исполнении. Но она не должна утаскивать за собой весь провайдер.

- Батч делится на исполнимые и отбракованные (`_partition_discovered`).
- Исполнимые апсертятся как раньше.
- Отбракованные возвращаются в новом поле `skipped` с перечнем недостающих полей и пишутся в лог — не молча выкидываются, иначе более короткий список читался бы как успешный discover.
- Батч, в котором исполнимого нет вообще, по-прежнему падает в 422, а не рапортует пустой успех.

## Совместимость

`skipped` — аддитивное поле со значением по умолчанию, старые клиенты не ломаются. Обе закоммиченные копии спеки перегенерированы через `scripts/export-openapi.py`; диф содержит ровно `SkippedModelResponse` и два ответа discovery, ничего лишнего.

## Проверка

- 11 passed: новый `test_provider_discovery_skips_incomplete.py` + оба существующих контрактных теста.
- Существующий `test_provider_discovery_contract.py` не удалён — переписан на ту же гарантию («неполная модель не персистится») в новой форме вместо старой фатальной.
- Покрыто: одна модель без цен не топит батч; отбраковка отдаётся наружу; `context_window` 0 и `True` отбраковываются; батч без единой исполнимой модели даёт 422.