### PR TITLE
fix(governance): an empty tool allowlist must not be widenable

### DIFF
--- a/agentarea-platform/libs/common/agentarea_common/auth/tool_authorization.py
+++ b/agentarea-platform/libs/common/agentarea_common/auth/tool_authorization.py
@@ -64,10 +64,15 @@ def decide_tool_policy(
 
     Default-allow: this function only ever judges a tool the agent is already
     composed with (that is why it is being asked about), so composition is the
-    allow. Policy subtracts from it — a ``denied`` match, or a non-empty
-    ``allowed`` allowlist the tool falls outside of, or an approval requirement.
-    An absent/empty allowlist is "no allowlist in use", not "deny everything";
-    restriction is expressed by composing fewer tools or by DENY rules.
+    allow. Policy subtracts from it — a ``denied`` match, or an ``allowed``
+    allowlist the tool falls outside of, or an approval requirement.
+
+    An *absent* allowlist is "no allowlist in use"; an *empty* one is "no tool
+    is permitted". They are distinct values all the way down: the resolver
+    treats ``[]`` as a narrowing a lower scope may not widen, and
+    ``to_json_dict`` drops ``None`` while keeping ``[]``. Testing truthiness
+    here would collapse them again and make the strictest allowlist the one
+    that restricts nothing.
     """
     tools = (effective_policy or {}).get("tools") or {}
 
@@ -79,7 +84,7 @@ def decide_tool_policy(
         )
 
     allowed = tools.get("allowed")
-    if allowed and not _matches_any(tool_name, allowed):
+    if allowed is not None and not _matches_any(tool_name, allowed):
         return ToolAuthorizationDecision(
             ToolAuthorizationAction.DENY,
             f"tool '{tool_name}' is not permitted by the policy allowlist",

--- a/agentarea-platform/libs/common/tests/test_tool_authorization.py
+++ b/agentarea-platform/libs/common/tests/test_tool_authorization.py
@@ -47,6 +47,25 @@ def test_a_non_empty_allowlist_still_restricts():
     assert decide_tool_policy(policy, "shell_exec").action is ToolAuthorizationAction.DENY
 
 
+def test_an_absent_allowlist_restricts_nothing():
+    """``to_json_dict`` drops ``allowed=None``, so the key is simply missing."""
+    policy = {"tools": {"denied": []}}
+
+    assert decide_tool_policy(policy, "shell_exec").action is ToolAuthorizationAction.ALLOW
+
+
+def test_an_empty_allowlist_permits_no_tool():
+    """``[]`` is the strictest allowlist, not the absence of one.
+
+    Testing truthiness here made the empty allowlist permit every tool, which
+    silently undid the one setting a policy author can use to say "no tools".
+    """
+    policy = {"tools": {"allowed": [], "denied": []}}
+
+    assert decide_tool_policy(policy, "web_search").action is ToolAuthorizationAction.DENY
+    assert decide_tool_policy(policy, "shell_exec").action is ToolAuthorizationAction.DENY
+
+
 # --- authorize_tool_invocation: the request-shaped policy verdict ---------------
 
 

--- a/agentarea-platform/libs/execution/tests/unit/test_tool_policy_decision.py
+++ b/agentarea-platform/libs/execution/tests/unit/test_tool_policy_decision.py
@@ -22,10 +22,13 @@ def test_absent_allowlist_allows():
     assert decide_tool_action({"tools": {"allowed": None}}, "shell") is ToolAction.ALLOW
 
 
-def test_empty_allowlist_allows():
-    # An empty allowlist is "no allowlist in use", not "deny everything" —
-    # restriction is expressed by composing fewer tools or by DENY rules.
-    assert decide_tool_action({"tools": {"allowed": []}}, "anything") is ToolAction.ALLOW
+def test_empty_allowlist_denies():
+    # `[]` is the strictest allowlist, not the absence of one. Reading it as
+    # "no allowlist in use" was an escalation: the resolver merges `allowed`
+    # with `is not None`, so an agent scope setting `[]` REPLACES a workspace
+    # allowlist — and an allow-all reading then turned that replacement into
+    # "every tool", widening the very list it was supposed to narrow.
+    assert decide_tool_action({"tools": {"allowed": []}}, "anything") is ToolAction.DENY
 
 
 def test_denied_tool_is_denied_others_allowed():

--- a/agentarea-platform/libs/governance/agentarea_governance/domain/policies.py
+++ b/agentarea-platform/libs/governance/agentarea_governance/domain/policies.py
@@ -387,7 +387,10 @@ class PolicyResolver:
     def _validate_tools(self, higher: ToolsPolicy | None, lower: ToolsPolicy | None) -> None:
         if not higher or not lower:
             return
-        if higher.allowed and lower.allowed:
+        # `None` means the scope declares no allowlist; `[]` means it permits no
+        # tool at all. Testing truthiness conflated the two and let the strictest
+        # setting be the one a lower scope could override.
+        if higher.allowed is not None and lower.allowed is not None:
             for pattern in lower.allowed:
                 if not any(_pattern_is_within(pattern, parent) for parent in higher.allowed):
                     raise PolicyValidationError("tools.allowed cannot widen higher-scope allowlist")

--- a/agentarea-platform/libs/governance/agentarea_governance/domain/policies.py
+++ b/agentarea-platform/libs/governance/agentarea_governance/domain/policies.py
@@ -274,8 +274,11 @@ class EffectivePolicy(PolicyDocument):
             state["execution_limits"] = self.execution.model_dump(exclude_none=True)
 
         if self.tools:
+            # `None` (no allowlist) and `[]` (no tool permitted) are opposite
+            # settings; collapsing them here would republish the conflation the
+            # resolver and the tool PDP both avoid.
             state["tools_config"] = {
-                "allowed": self.tools.allowed or [],
+                "allowed": self.tools.allowed,
                 "denied": self.tools.denied,
             }
 

--- a/agentarea-platform/libs/governance/tests/test_policies.py
+++ b/agentarea-platform/libs/governance/tests/test_policies.py
@@ -1,6 +1,10 @@
 """Tests for typed governance policy resolution."""
 
 import pytest
+from agentarea_common.auth.tool_authorization import (
+    ToolAuthorizationAction,
+    decide_tool_policy,
+)
 from agentarea_governance.domain.policies import (
     ApprovalPolicy,
     BudgetPolicy,
@@ -446,3 +450,59 @@ def test_a_lower_scope_may_still_narrow_to_the_empty_allowlist():
     )
 
     assert effective.tools.allowed == []
+
+
+def test_the_empty_allowlist_reaches_the_tool_pdp_as_deny_all():
+    """The narrowing has to survive serialization, or it protects nothing.
+
+    ``to_json_dict`` is what the task carries into execution, and
+    ``decide_tool_policy`` is the single runtime PDP that reads it. Testing the
+    resolver alone would pass while every tool still ran.
+    """
+    effective = PolicyResolver().resolve([PolicyDocument(tools=ToolsPolicy(allowed=[]))])
+
+    snapshot = effective.to_json_dict()
+
+    assert snapshot["tools"]["allowed"] == []
+    assert decide_tool_policy(snapshot, "web_search").action is ToolAuthorizationAction.DENY
+
+
+def test_no_allowlist_reaches_the_tool_pdp_as_allow_all():
+    effective = PolicyResolver().resolve([PolicyDocument(tools=ToolsPolicy(denied=["payment_*"]))])
+
+    snapshot = effective.to_json_dict()
+
+    assert "allowed" not in snapshot["tools"]
+    assert decide_tool_policy(snapshot, "web_search").action is ToolAuthorizationAction.ALLOW
+    assert decide_tool_policy(snapshot, "payment_charge").action is ToolAuthorizationAction.DENY
+
+
+def test_narrowing_to_the_empty_allowlist_does_not_widen_the_parent():
+    """The escalation the empty-allowlist reading created, end to end.
+
+    ``_merge_tools`` replaces ``allowed`` whenever the lower scope sets it, so
+    an agent scope of ``[]`` drops the workspace's ``github_*``. If the PDP then
+    read ``[]`` as "no allowlist", that narrowing would hand the agent every
+    tool instead of none.
+    """
+    effective = PolicyResolver().resolve(
+        [
+            PolicyDocument(tools=ToolsPolicy(allowed=["github_*"])),
+            PolicyDocument(tools=ToolsPolicy(allowed=[])),
+        ]
+    )
+
+    snapshot = effective.to_json_dict()
+
+    assert decide_tool_policy(snapshot, "shell_exec").action is ToolAuthorizationAction.DENY
+    assert decide_tool_policy(snapshot, "github_issue_create").action is (
+        ToolAuthorizationAction.DENY
+    )
+
+
+def test_execution_state_keeps_no_allowlist_distinct_from_the_empty_one():
+    no_allowlist = PolicyResolver().resolve([PolicyDocument(tools=ToolsPolicy(denied=["a_*"]))])
+    deny_all = PolicyResolver().resolve([PolicyDocument(tools=ToolsPolicy(allowed=[]))])
+
+    assert no_allowlist.to_execution_state()["tools_config"]["allowed"] is None
+    assert deny_all.to_execution_state()["tools_config"]["allowed"] == []

--- a/agentarea-platform/libs/governance/tests/test_policies.py
+++ b/agentarea-platform/libs/governance/tests/test_policies.py
@@ -407,3 +407,42 @@ def test_policy_validator_exposes_chain_validation_contract():
 
     assert str(effective.budget.monthly_spend_cap_usd) == "50.00"
     assert effective.source_policy_ids == ["workspace-policy", "agent-policy"]
+
+
+def test_empty_allowlist_cannot_be_widened_by_a_lower_scope():
+    """An empty allowlist means "no tool is permitted" and is the strictest setting.
+
+    It must not be the one a lower scope can override. The last layer is the
+    caller-supplied task_policy, so a widenable empty allowlist is an
+    escalation path, not just a merge quirk.
+    """
+    with pytest.raises(PolicyValidationError):
+        PolicyResolver().resolve(
+            [
+                PolicyDocument(tools=ToolsPolicy(allowed=[], denied=[])),
+                PolicyDocument(tools=ToolsPolicy(allowed=["github_*"], denied=[])),
+            ]
+        )
+
+
+def test_empty_allowlist_survives_a_lower_scope_that_sets_none():
+    effective = PolicyResolver().resolve(
+        [
+            PolicyDocument(tools=ToolsPolicy(allowed=[], denied=[])),
+            PolicyDocument(tools=ToolsPolicy(denied=["payment_*"])),
+        ]
+    )
+
+    assert effective.tools.allowed == []
+    assert effective.tools.denied == ["payment_*"]
+
+
+def test_a_lower_scope_may_still_narrow_to_the_empty_allowlist():
+    effective = PolicyResolver().resolve(
+        [
+            PolicyDocument(tools=ToolsPolicy(allowed=["github_*"], denied=[])),
+            PolicyDocument(tools=ToolsPolicy(allowed=[], denied=[])),
+        ]
+    )
+
+    assert effective.tools.allowed == []


### PR DESCRIPTION
## Проблема

`_validate_tools` проверял расширение allowlist по истинности:

```python
if higher.allowed and lower.allowed:
```

Но `None` и `[]` здесь значат разное. `None` — «этот scope не объявляет allowlist», `[]` — «этот scope не разрешает ни одного тула». Пустой список ложен, поэтому проверка для него **не выполнялась вовсе**, а `_merge_tools` затем брал список нижнего слоя дословно (там сравнение с `is not None`).

Получается, самая строгая выразимая настройка — единственная, которую нижний слой мог переопределить:

```
higher=['a'] lower=['a','b']  -> PolicyValidationError   (верно)
higher=[]    lower=['a','b']  -> allowed=['a','b']       (эскалация)
```

## Почему это достижимо снаружи

Последний слой резолвера — `task_policy` (`resolver_adapter.py:85-87`), а он приходит **от вызывающего** при создании задачи: `agents_tasks.py:93`, прокидывается на `:642`, `:699`, `:831`, `:852`, `:917`, `:939`.

То есть workspace-, agent- или user-scope, прижатый к пустому allowlist, расширяется тем, кто отправляет задачу.

## Что сделано

Сравнение с `is not None` — пустой allowlist ведёт себя как потолок, которым и является: каждый паттерн нижнего слоя проверяется против пустого множества родителей и отклоняется.

Сужение до `[]` снизу продолжает работать, и нижний слой без своего allowlist по-прежнему наследует верхний — оба случая закрыты тестами.

## Проверка

- `libs/governance/tests` — 275 passed; `apps/api/tests/test_governance_policy_api.py` — 18 passed.
- Новый тест на эскалацию падает на старом коде.
- Найдено при ревью дизайна авторизации триггеров: резолвер — тот самый слой, на котором держится «отключить тул X пользователю Y», поэтому расширяемый потолок подрывает ровно ту защиту, ради которой он существует.