### PR TITLE
fix(ci): repair the two workflow files that stopped parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,6 @@ jobs:
       
   #     - name: Install uv
   #       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-  with:
-    # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
-    # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
-    version: "0.8.22"
   #       with:
   #         enable-cache: true
   #         cache-dependency-glob: "core/**/pyproject.toml"
@@ -283,10 +279,6 @@ jobs:
       
   #     - name: Install uv
   #       uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-  with:
-    # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
-    # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
-    version: "0.8.22"
   #       with:
   #         enable-cache: true
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,7 +50,6 @@ jobs:
           # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
           # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
           version: "0.8.22"
-          version: "latest"
 
       - name: Cache uv
         uses: actions/cache@v3
@@ -106,7 +105,6 @@ jobs:
           # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
           # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
           version: "0.8.22"
-          version: "latest"
 
       - name: Cache uv
         uses: actions/cache@v3
@@ -204,7 +202,6 @@ jobs:
           # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
           # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
           version: "0.8.22"
-          version: "latest"
 
       - name: Cache uv
         uses: actions/cache@v3
@@ -300,7 +297,6 @@ jobs:
           # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
           # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
           version: "0.8.22"
-          version: "latest"
 
       - name: Run module integration tests
         if: steps.changed.outputs.module == 'true'
@@ -381,7 +377,6 @@ jobs:
           # Pinned: an unpinned setup-uv resolves to whatever uv shipped that day, which
           # is how uv.lock kept getting rewritten. Bump with pyproject required-version.
           version: "0.8.22"
-          version: "latest"
 
       - name: Cache uv
         uses: actions/cache@v3


### PR DESCRIPTION
Pinning uv (#394) landed two malformed edits, and GitHub has refused to run either workflow on `main` since — no jobs, no check runs, just *"this run likely failed because of a workflow file issue"*. Every `main` push from `beb5ea70` onward is affected; the PRs merged after it looked green only because they carried the pre-#394 workflow on their own branch.

## What broke

**`ci.yml`** — the `version:` pin was inserted as *live YAML inside a commented-out job*, leaving two stray `with:` mappings at the `jobs:` level:

```yaml
  #     - name: Install uv
  #       uses: astral-sh/setup-uv@38f3f10... # v4
  with:
    version: "0.8.22"
  #       with:
```

That parses as a job named `with`, which is not a valid job.

**`integration-tests.yml`** — the pin was inserted directly above the pre-existing `version: "latest"`, giving five `with:` blocks a duplicate `version` key. Actions rejects duplicate keys outright; had it not, `"latest"` came second and would have won, so the pin was decorative anyway.

## Fix

Removes the two stray blocks and the five superseded `"latest"` lines. Nothing else changes — 8 deletions in `ci.yml`, 5 in `integration-tests.yml`.

#394's intent is unchanged and now actually applies: all 18 `setup-uv` steps across both files resolve to `0.8.22`.

## Verification

- Both files parse under a **duplicate-key-rejecting** YAML loader (plain `yaml.safe_load` silently keeps the last key, which is why this got through review).
- Every job key checked to carry `runs-on` or `uses`: `ci.yml` 21 jobs, `integration-tests.yml` 5, none invalid.
- No `setup-uv` step left unpinned or pinned to anything but `0.8.22`.

Worth following up separately: nothing in CI validates the workflow files themselves, which is why a change to them could merge while making them unrunnable.