### PR TITLE
fix(ci): make the live-stack fuzz job actually run

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -321,10 +321,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Prepare env file
-        # .env.example is a complete, ready-to-run config (signing JWKS +
-        # encryption key filled). The compose stack reads it via the default
-        # `.env` lookup.
-        run: cp .env.example .env
+        # .env.example carries the non-secret defaults but leaves the Ory
+        # secrets and the Kratos signing key blank on purpose: they are
+        # generated per install and never committed. compose declares them
+        # `${VAR:?}`, which also rejects an empty value, so copying the
+        # example alone leaves the stack unable to start.
+        #
+        # --force is load-bearing: a plain run sees the example's empty
+        # `KRATOS_JWKS_B64=` line, concludes the secrets are already present,
+        # and exits without writing any.
+        run: |
+          cp .env.example .env
+          ./scripts/gen-dev-secrets.sh --force
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -428,6 +428,18 @@ jobs:
           # the runner before, and the app can only be as healthy as its deps.
           docker compose -f docker-compose.yaml -f docker-compose.ci.yaml \
             logs --tail=200 rustfs db app_migrations || true
+          # kratos is one of the three services this job starts and the one the
+          # tests authenticate through, but it was never dumped here — a 500
+          # from its tokenizer was invisible.
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yaml \
+            logs --tail=200 kratos || true
+          # The tokenizer reads the signing key over a bind mount. Show the
+          # ownership on both sides: gen-dev-secrets.sh writes it 0600 as the
+          # runner user, and a bind mount preserves that uid on Linux.
+          ls -l config/auth/kratos/jwks.json || true
+          docker compose -f docker-compose.yaml -f docker-compose.ci.yaml \
+            exec -T kratos sh -c 'id; ls -l /etc/config/kratos/jwks.json; \
+              head -c 32 /etc/config/kratos/jwks.json || echo UNREADABLE' || true
 
       - name: Tear down
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -333,6 +333,12 @@ jobs:
         run: |
           cp .env.example .env
           ./scripts/gen-dev-secrets.sh --force
+          # kratos reads the signing key over a bind mount as uid 10000, while
+          # the runner writes it as uid 1001. 0600 is right on a developer's
+          # machine and unreadable in the container, which surfaced only as a
+          # 500 from /sessions/whoami. This key is generated per run and dies
+          # with the job, so widening it here gives nothing away.
+          chmod 644 config/auth/kratos/jwks.json
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -433,13 +439,6 @@ jobs:
           # from its tokenizer was invisible.
           docker compose -f docker-compose.yaml -f docker-compose.ci.yaml \
             logs --tail=200 kratos || true
-          # The tokenizer reads the signing key over a bind mount. Show the
-          # ownership on both sides: gen-dev-secrets.sh writes it 0600 as the
-          # runner user, and a bind mount preserves that uid on Linux.
-          ls -l config/auth/kratos/jwks.json || true
-          docker compose -f docker-compose.yaml -f docker-compose.ci.yaml \
-            exec -T kratos sh -c 'id; ls -l /etc/config/kratos/jwks.json; \
-              head -c 32 /etc/config/kratos/jwks.json || echo UNREADABLE' || true
 
       - name: Tear down
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -403,10 +403,21 @@ jobs:
           KRATOS_ADMIN_URL: http://localhost:4434
           KRATOS_PUBLIC_URL: http://localhost:4433
         run: |
+          # -rs prints why a module skipped. Both fuzz modules skip themselves
+          # at import when the stack is unreachable, and pytest then exits 5
+          # ("no tests collected") — which reads as an unexplained failure.
+          set +e
           uv run python -m pytest \
             tests/e2e/api/test_openapi_fuzz.py \
             tests/e2e/api/test_stateful_fuzz.py \
-            -m "" -p no:cacheprovider -o addopts="" --tb=short
+            -m "" -p no:cacheprovider -o addopts="" --tb=short -rs
+          status=$?
+          set -e
+          if [ "$status" -eq 5 ]; then
+            echo "::error::The fuzz suite collected nothing: both modules skipped at import (reason above). A silently skipped fuzz suite is indistinguishable from no coverage, so this is a failure, not a pass."
+            exit 1
+          fi
+          exit $status
 
       - name: Stack logs (always)
         if: always()


### PR DESCRIPTION
`OpenAPI fuzz (live stack)` is the only job that boots the real stack. It has been failing for a while, and it turned out to be **three independent faults stacked on top of each other** — each invisible until the one before it was cleared.

## 1. The stack never started

```
required variable KRATOS_SECRETS_COOKIE is missing a value:
KRATOS_SECRETS_COOKIE is required; scripts/install.sh generates it
```

`.env.example` declares `KRATOS_SECRETS_COOKIE` / `_CIPHER` but leaves them **blank on purpose** — generated per install, never committed. compose declares them `${VAR:?…}`, which rejects an *empty* value as well as an unset one. The job only did `cp .env.example .env`, so compose aborted before a container came up. The step's comment claimed the example was *"a complete, ready-to-run config"*, which stopped being true when those keys were emptied — and that comment is why the gap survived.

Fix: run `scripts/gen-dev-secrets.sh`, the generator the compose message points at.

`--force` is load-bearing. The plain path looks for a `KRATOS_JWKS_B64` line, finds the example's *empty* one, reports "already present" and writes nothing — so the obvious one-line fix would have left the job failing identically.

## 2. `exit code 5`, unexplained

With the stack finally up, pytest exited 5 — *"no tests collected"*, not a test failure. Both fuzz modules skip themselves at import, and the run passed no `-rs`, so the reason never printed.

Fix: `-rs`, plus turning exit 5 into a stated error. A fuzz suite that silently skips is indistinguishable from no coverage, so collecting nothing stays a failure rather than quietly becoming a pass.

## 3. kratos could not read its own signing key

That surfaced the real cause — a 500 from `/sessions/whoami?tokenize_as=agentarea_jwt`. Confirmed from inside the container:

```
kratos: unable to open file: /etc/config/kratos/jwks.json: permission denied
host       -rw------- 1 runner runner 242
container  -rw-------  1 1001   1001   242
kratos     uid=10000(ory) gid=101(ory)   ->  UNREADABLE
```

`gen-dev-secrets.sh` writes the key `0600` as the runner (uid 1001); kratos runs as uid 10000 and cannot read it across the bind mount. On macOS the mount maps ownership and this never reproduces, which is why it only ever bit CI.

Fix: `chmod 644` **in the job only**. `0600` stays correct wherever the key is a real credential; this one is generated per run and torn down with the job, so it is widened here rather than in the generator.

## Also

The log step dumped `app`, `rustfs`, `db`, `app_migrations` — but never `kratos`, the one service the tests authenticate through and the one that was failing. Added; that gap is why this took three rounds to see.

## Verification

- `gen-dev-secrets.sh` behaviour reproduced against a copy of `.env.example` in isolation, never touching a real `.env`: plain run → `"already present"` with the secrets still blank; `--force` → all six written plus the JWKS, cipher exactly the 32 chars xchacha20-poly1305 requires.
- Each layer confirmed in CI before the next was addressed: `Start stack` and `Wait for API + Kratos to be ready` went green at step 1; the skip reason appeared at step 2; the permission error was read out of the container at step 3.
- Workflow re-checked with the duplicate-key-rejecting loader from #397.

Labeled `run-integration-tests` so the job runs on this PR rather than only after merge.

Independent of #397: this was already red on the last runs before uv was pinned, and invisible in between only because the file would not parse.
