### PR TITLE
fix(connections): polish managed OAuth setup

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/connection_oauth.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/connection_oauth.py
@@ -143,7 +143,10 @@ def _oauth_profile(spec: dict[str, Any]) -> dict[str, Any]:
         )
     managed_key = str(oauth["managed_credentials_key"])
     if not managed_key.startswith(_MANAGED_CREDENTIALS_PREFIX):
-        raise HTTPException(status_code=500, detail="Invalid managed OAuth secret key")
+        raise HTTPException(
+            status_code=500,
+            detail="Invalid managed OAuth credential reference",
+        )
 
     for url_field in ("authorization_url", "token_url"):
         url = str(oauth[url_field])

--- a/agentarea-platform/apps/api/tests/test_connection_oauth.py
+++ b/agentarea-platform/apps/api/tests/test_connection_oauth.py
@@ -29,7 +29,7 @@ def test_catalog_oauth_rejects_unreserved_platform_secret_reference(monkeypatch)
     profile = _oauth_profile()
     profile["managed_credentials_key"] = "unrelated-platform-key"
 
-    with pytest.raises(HTTPException, match="Invalid managed OAuth secret key"):
+    with pytest.raises(HTTPException, match="Invalid managed OAuth credential reference"):
         connection_oauth._oauth_profile({"oauth": profile})
 
 

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -1443,12 +1443,14 @@ function CustomOAuthApp({
           <Input
             value={clientId}
             onChange={(event) => setClientId(event.target.value)}
+            aria-label="OAuth client ID"
             placeholder="Client ID"
             autoComplete="off"
           />
           <Input
             value={clientSecret}
             onChange={(event) => setClientSecret(event.target.value)}
+            aria-label="OAuth client secret"
             placeholder="Client secret"
             type="password"
             autoComplete="new-password"


### PR DESCRIPTION
## What
- use credential-reference terminology for managed OAuth validation errors
- give the Advanced OAuth client fields explicit accessible names

## Rollout context
The original Connections merge landed while the main image workflow was not parseable. This app-level follow-up also causes the repaired pipeline to build the backend and frontend images through the normal release path.

## Validation
- focused OAuth tests: 2 passed
- Ruff check and format
- ESLint on CatalogGallery
- git diff --check