### PR TITLE
feat(connections): reuse workspace OAuth secrets

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/connection_oauth.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/connection_oauth.py
@@ -14,7 +14,11 @@ from typing import Any, Literal
 from uuid import UUID
 
 import httpx
-from agentarea_api.api.deps.services import DatabaseSessionDep, get_real_secret_manager
+from agentarea_api.api.deps.services import (
+    DatabaseSessionDep,
+    SecretCatalogServiceDep,
+    get_real_secret_manager,
+)
 from agentarea_api.api.v1.registries import require_platform_catalog_write
 from agentarea_common.auth.context import UserContext
 from agentarea_common.auth.dependencies import UserContextDep
@@ -22,6 +26,7 @@ from agentarea_common.base.repository_factory import RepositoryFactory
 from agentarea_common.config import get_settings
 from agentarea_common.constants import PLATFORM_PRINCIPAL_ID, PLATFORM_WORKSPACE_ID
 from agentarea_common.infrastructure.connection_manager import get_connection_manager
+from agentarea_common.infrastructure.secret_manager import BaseSecretManager
 from agentarea_mcp.application.auth_service import MCPAuthService, MissingCredentialsError
 from agentarea_mcp.application.oauth_client_service import PKCEPair
 from agentarea_mcp.infrastructure.auth_repository import MCPAuthConfigRepository
@@ -30,9 +35,11 @@ from agentarea_openapi.application.url_validator import validate_url
 from agentarea_openapi.infrastructure.repository import OpenAPIConnectionRepository
 from agentarea_openapi.schemas.dto import OpenAPIConnectionCreate
 from agentarea_registry.infrastructure.repository import RegistryItemRepository, RegistryRepository
+from agentarea_secrets.catalog_service import SecretCatalogService, SecretNotFoundError
+from agentarea_secrets.models import EncryptedSecret
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
@@ -53,7 +60,38 @@ class CatalogConnectionRequest(BaseModel):
     credential_mode: Literal["managed", "custom"] = "managed"
     client_id: str | None = Field(default=None, min_length=1, max_length=512)
     client_secret: str | None = Field(default=None, min_length=1, max_length=4096)
+    client_id_secret_id: UUID | None = Field(
+        default=None,
+        description="Existing user-owned workspace secret containing the OAuth client ID.",
+    )
+    client_secret_secret_id: UUID | None = Field(
+        default=None,
+        description="Existing user-owned workspace secret containing the OAuth client secret.",
+    )
     return_to: str = Field(default="", max_length=2048)
+
+    @model_validator(mode="after")
+    def validate_credential_sources(self) -> "CatalogConnectionRequest":
+        fields = (
+            self.client_id,
+            self.client_secret,
+            self.client_id_secret_id,
+            self.client_secret_secret_id,
+        )
+        if self.credential_mode == "managed":
+            if any(value is not None for value in fields):
+                raise ValueError("Managed connections do not accept custom OAuth credentials.")
+            return self
+
+        for label, value, secret_id in (
+            ("client ID", self.client_id, self.client_id_secret_id),
+            ("client secret", self.client_secret, self.client_secret_secret_id),
+        ):
+            if (value is None) == (secret_id is None):
+                raise ValueError(
+                    f"Custom OAuth {label} must be entered or selected from workspace secrets."
+                )
+        return self
 
 
 class CatalogConnectionResponse(BaseModel):
@@ -195,6 +233,34 @@ async def _managed_credentials(manager, key: str) -> tuple[str, str]:
     return client_id, client_secret
 
 
+async def _workspace_secret_value(
+    catalog: SecretCatalogService,
+    manager: BaseSecretManager,
+    secret_id: UUID,
+    label: str,
+) -> tuple[EncryptedSecret, str]:
+    """Resolve a stable, workspace-checked reference without exposing its value."""
+    try:
+        secret = await catalog.get(secret_id)
+    except SecretNotFoundError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Selected OAuth {label} secret is not available in this workspace.",
+        ) from exc
+    if secret.owner_type is not None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Selected OAuth {label} must be a user-owned workspace secret.",
+        )
+    value = await manager.get_secret(secret.secret_name)
+    if not value:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Selected OAuth {label} secret has no value.",
+        )
+    return secret, value
+
+
 @router.put(
     "/oauth/apps/{provider_key}",
     response_model=ManagedOAuthAppResponse,
@@ -225,6 +291,7 @@ async def connect_catalog_item(
     body: CatalogConnectionRequest,
     user_context: UserContextDep,
     db_session: DatabaseSessionDep,
+    secret_catalog: SecretCatalogServiceDep,
 ) -> CatalogConnectionResponse:
     """Materialize a trusted OpenAPI template and start its OAuth flow."""
     item_repo = RegistryItemRepository(db_session, user_context)
@@ -257,19 +324,40 @@ async def connect_catalog_item(
     )
     platform_secret_manager = _managed_secret_manager(db_session)
     repository_factory = RepositoryFactory(db_session, user_context)
+    credential_config: dict[str, Any] = {}
+    credential_references: list[tuple[UUID, str]] = []
     if body.credential_mode == "managed":
         client_id, _ = await _managed_credentials(
             platform_secret_manager, str(oauth["managed_credentials_key"])
         )
+        credential_config["client_id"] = client_id
         credentials: dict[str, Any] = {}
     else:
-        if not body.client_id or not body.client_secret:
-            raise HTTPException(
-                status_code=422,
-                detail="Custom OAuth app requires both client ID and client secret.",
+        if body.client_id_secret_id is not None:
+            client_id_secret, client_id = await _workspace_secret_value(
+                secret_catalog,
+                workspace_secret_manager,
+                body.client_id_secret_id,
+                "client ID",
             )
-        client_id = body.client_id
-        credentials = {"client_secret": body.client_secret}
+            credential_config["client_id_secret_name"] = client_id_secret.secret_name
+            credential_references.append((client_id_secret.id, "client_id"))
+        else:
+            client_id = str(body.client_id)
+            credential_config["client_id"] = client_id
+
+        if body.client_secret_secret_id is not None:
+            client_secret, _ = await _workspace_secret_value(
+                secret_catalog,
+                workspace_secret_manager,
+                body.client_secret_secret_id,
+                "client secret",
+            )
+            credential_config["client_secret_secret_name"] = client_secret.secret_name
+            credential_references.append((client_secret.id, "client_secret"))
+            credentials = {}
+        else:
+            credentials = {"client_secret": body.client_secret}
 
     connection_service = OpenAPIConnectionService(
         repository_factory=repository_factory,
@@ -303,7 +391,7 @@ async def connect_catalog_item(
             "provider": oauth["provider_key"],
             "authorization_url": oauth["authorization_url"],
             "token_url": oauth["token_url"],
-            "client_id": client_id,
+            **credential_config,
             "scopes": oauth["scopes"],
             "authorization_scheme": oauth["authorization_scheme"],
             "client_auth_method": oauth["client_auth_method"],
@@ -313,6 +401,13 @@ async def connect_catalog_item(
         credentials=credentials,
         allow_managed_credentials=True,
     )
+    for secret_id, field in credential_references:
+        await secret_catalog.add_reference(
+            secret_id,
+            "mcp_auth_config",
+            str(auth_config.id),
+            field,
+        )
 
     pkce = PKCEPair.generate()
     state = secrets.token_urlsafe(32)

--- a/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_auth_configs.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/mcp_auth_configs.py
@@ -4,7 +4,11 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from agentarea_api.api.deps.services import BaseSecretManagerDep, DatabaseSessionDep
+from agentarea_api.api.deps.services import (
+    BaseSecretManagerDep,
+    DatabaseSessionDep,
+    SecretCatalogServiceDep,
+)
 from agentarea_common.auth.dependencies import UserContextDep
 from agentarea_common.utils.types import UtcDatetime
 from agentarea_mcp.application.auth_service import MCPAuthService
@@ -150,12 +154,14 @@ async def update_mcp_auth_config(
 async def delete_mcp_auth_config(
     config_id: UUID,
     user_context: UserContextDep,
+    secret_catalog: SecretCatalogServiceDep,
     service: MCPAuthService = Depends(get_mcp_auth_service),
 ):
     try:
         deleted = await service.delete(config_id)
         if not deleted:
             raise HTTPException(status_code=404, detail="MCP auth config not found")
+        await secret_catalog.clear_references("mcp_auth_config", str(config_id))
     except ValueError as exc:
         # Linked instances prevent deletion → 409 Conflict
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/agentarea-platform/apps/api/tests/test_connection_oauth.py
+++ b/agentarea-platform/apps/api/tests/test_connection_oauth.py
@@ -2,7 +2,7 @@
 
 import urllib.parse
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 from uuid import uuid4
 
 import pytest
@@ -34,7 +34,10 @@ def test_catalog_oauth_rejects_unreserved_platform_secret_reference(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_managed_connect_is_one_click_and_state_contains_no_secret(monkeypatch):
+@pytest.mark.parametrize("credential_source", ["managed", "inline", "workspace_secrets"])
+async def test_connect_uses_requested_credential_source_without_secret_in_state(
+    monkeypatch, credential_source
+):
     item_id = uuid4()
     connection_id = uuid4()
     auth_config_id = uuid4()
@@ -92,7 +95,31 @@ async def test_managed_connect_is_one_click_and_state_contains_no_secret(monkeyp
     monkeypatch.setattr(connection_oauth, "OpenAPIConnectionService", _ConnectionService)
     monkeypatch.setattr(connection_oauth, "MCPAuthService", _AuthService)
     monkeypatch.setattr(connection_oauth, "RepositoryFactory", lambda *_args: object())
-    monkeypatch.setattr(connection_oauth, "get_real_secret_manager", lambda **_kwargs: object())
+    client_id_secret = SimpleNamespace(
+        id=uuid4(),
+        secret_name="metrika_client_id",  # noqa: S106  # pragma: allowlist secret
+        owner_type=None,
+    )
+    client_secret_secret = SimpleNamespace(
+        id=uuid4(),
+        secret_name="metrika_client_secret",  # noqa: S106  # pragma: allowlist secret
+        owner_type=None,
+    )
+    workspace_manager = SimpleNamespace(
+        get_secret=AsyncMock(
+            side_effect=lambda name: {
+                "metrika_client_id": "workspace-client-id",
+                "metrika_client_secret": "workspace-client-secret",  # pragma: allowlist secret
+            }.get(name)
+        )
+    )
+    secret_catalog = SimpleNamespace(
+        get=AsyncMock(side_effect=[client_id_secret, client_secret_secret]),
+        add_reference=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        connection_oauth, "get_real_secret_manager", lambda **_kwargs: workspace_manager
+    )
     monkeypatch.setattr(connection_oauth, "_managed_secret_manager", lambda _session: object())
     monkeypatch.setattr(
         connection_oauth,
@@ -107,23 +134,116 @@ async def test_managed_connect_is_one_click_and_state_contains_no_secret(monkeyp
         lambda: "https://api.agentarea.ru/v1/connections/oauth/callback",
     )
 
+    if credential_source == "managed":
+        body = connection_oauth.CatalogConnectionRequest(return_to="https://app.agentarea.ru")
+    elif credential_source == "inline":
+        body = connection_oauth.CatalogConnectionRequest(
+            credential_mode="custom",
+            client_id="inline-client-id",
+            client_secret="inline-client-secret",  # noqa: S106  # pragma: allowlist secret
+            return_to="https://app.agentarea.ru",
+        )
+    else:
+        body = connection_oauth.CatalogConnectionRequest(
+            credential_mode="custom",
+            client_id_secret_id=client_id_secret.id,
+            client_secret_secret_id=client_secret_secret.id,
+            return_to="https://app.agentarea.ru",
+        )
+
     response = await connection_oauth.connect_catalog_item(
         item_id,
-        connection_oauth.CatalogConnectionRequest(return_to="https://app.agentarea.ru"),
+        body,
         UserContext(user_id=str(uuid4()), workspace_id=str(uuid4())),
         AsyncMock(),
+        secret_catalog,
     )
 
     assert response.connection_id == connection_id
     query = urllib.parse.parse_qs(urllib.parse.urlparse(response.authorize_url).query)
-    assert query["client_id"] == ["managed-client-id"]
+    expected_client_id = {
+        "managed": "managed-client-id",
+        "inline": "inline-client-id",
+        "workspace_secrets": "workspace-client-id",  # pragma: allowlist secret
+    }[credential_source]
+    assert query["client_id"] == [expected_client_id]
     assert query["redirect_uri"] == ["https://api.agentarea.ru/v1/connections/oauth/callback"]
     assert query["scope"] == ["metrika:read"]
     assert query["code_challenge_method"] == ["S256"]
 
     auth_kwargs = auth_create.await_args.kwargs
     assert auth_kwargs["allow_managed_credentials"] is True
-    assert auth_kwargs["credentials"] == {}
+    if credential_source == "managed":
+        assert auth_kwargs["credentials"] == {}
+        assert auth_kwargs["config"]["client_id"] == "managed-client-id"
+        secret_catalog.add_reference.assert_not_awaited()
+    elif credential_source == "inline":
+        assert auth_kwargs["config"]["client_id"] == "inline-client-id"
+        assert auth_kwargs["credentials"] == {  # pragma: allowlist secret
+            "client_secret": "inline-client-secret"  # pragma: allowlist secret
+        }
+        secret_catalog.add_reference.assert_not_awaited()
+    else:
+        assert auth_kwargs["credentials"] == {}
+        assert "client_id" not in auth_kwargs["config"]
+        assert (
+            auth_kwargs["config"]["client_id_secret_name"] == "metrika_client_id"  # noqa: S105
+        )
+        assert (
+            auth_kwargs["config"]["client_secret_secret_name"] == "metrika_client_secret"  # noqa: S105  # pragma: allowlist secret
+        )
+        assert secret_catalog.add_reference.await_args_list == [
+            call(client_id_secret.id, "mcp_auth_config", str(auth_config_id), "client_id"),
+            call(
+                client_secret_secret.id,
+                "mcp_auth_config",
+                str(auth_config_id),
+                "client_secret",
+            ),
+        ]
     state_payload = stored_state.await_args.args[1]
     assert "client_secret" not in state_payload
     assert state_payload["connection_id"] == str(connection_id)
+
+
+def test_custom_connect_requires_exactly_one_source_per_credential():
+    secret_id = uuid4()
+
+    with pytest.raises(ValueError, match="client ID must be entered or selected"):
+        connection_oauth.CatalogConnectionRequest(
+            credential_mode="custom",
+            client_secret="secret",  # noqa: S106  # pragma: allowlist secret
+        )
+
+    with pytest.raises(ValueError, match="client secret must be entered or selected"):
+        connection_oauth.CatalogConnectionRequest(
+            credential_mode="custom",
+            client_id="id",
+            client_secret="secret",  # noqa: S106  # pragma: allowlist secret
+            client_secret_secret_id=secret_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_workspace_secret_source_rejects_connection_owned_secret():
+    secret_id = uuid4()
+    catalog = SimpleNamespace(
+        get=AsyncMock(
+            return_value=SimpleNamespace(
+                id=secret_id,
+                secret_name="mcp_auth_cred:managed",  # noqa: S106  # pragma: allowlist secret
+                owner_type="mcp_auth_config",
+            )
+        )
+    )
+    manager = SimpleNamespace(get_secret=AsyncMock(return_value="must-not-be-read"))
+
+    with pytest.raises(HTTPException, match="must be a user-owned workspace secret"):
+        await connection_oauth._workspace_secret_value(
+            catalog,
+            manager,
+            secret_id,
+            "client secret",
+        )
+
+    manager.get_secret.assert_not_awaited()

--- a/agentarea-platform/libs/mcp/agentarea_mcp/application/auth_service.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/application/auth_service.py
@@ -32,6 +32,13 @@ def _managed_credentials_key(config: dict[str, Any]) -> str | None:
     return key
 
 
+def _uses_workspace_secret_references(config: dict[str, Any]) -> bool:
+    """Whether trusted catalog code attached existing workspace credentials."""
+    return any(
+        config.get(field) for field in ("client_id_secret_name", "client_secret_secret_name")
+    )
+
+
 class MissingCredentialsError(Exception):
     """The auth config names credentials that are not there.
 
@@ -119,6 +126,14 @@ class MCPAuthService:
         creds = await self._load_credentials(config)
         client_id = str(config.config.get("client_id") or "")
         client_secret = str(creds.get("client_secret") or "")
+        client_id_secret_name = str(config.config.get("client_id_secret_name") or "")
+        client_secret_secret_name = str(config.config.get("client_secret_secret_name") or "")
+        if client_id_secret_name:
+            client_id = str(await self._secret_manager.get_secret(client_id_secret_name) or "")
+        if client_secret_secret_name:
+            client_secret = str(
+                await self._secret_manager.get_secret(client_secret_secret_name) or ""
+            )
         managed_key = _managed_credentials_key(config.config)
         if managed_key is not None:
             if self._managed_secret_manager is None:
@@ -303,6 +318,10 @@ class MCPAuthService:
         """Create and persist a new auth config, storing creds encrypted."""
         if _managed_credentials_key(config) is not None and not allow_managed_credentials:
             raise ValueError("Managed OAuth configs can only be created by a catalog connection")
+        if _uses_workspace_secret_references(config) and not allow_managed_credentials:
+            raise ValueError(
+                "Workspace OAuth secret references can only be created by a catalog connection"
+            )
         auth_config = MCPAuthConfig(
             name=name,
             auth_type=auth_type,
@@ -351,10 +370,17 @@ class MCPAuthService:
             return None
         existing_is_managed = _managed_credentials_key(existing.config) is not None
         incoming_is_managed = config is not None and _managed_credentials_key(config) is not None
-        if (existing_is_managed or incoming_is_managed) and not allow_managed_credentials:
+        existing_has_references = _uses_workspace_secret_references(existing.config)
+        incoming_has_references = config is not None and _uses_workspace_secret_references(config)
+        if (
+            existing_is_managed
+            or incoming_is_managed
+            or existing_has_references
+            or incoming_has_references
+        ) and not allow_managed_credentials:
             if config is not None or credentials is not None:
                 raise ValueError(
-                    "Managed OAuth credentials can only be changed by reconnecting the catalog connection"
+                    "Catalog OAuth credentials can only be changed by reconnecting the catalog connection"
                 )
 
         updates: dict[str, Any] = {}

--- a/agentarea-platform/libs/mcp/agentarea_mcp/domain/auth_models.py
+++ b/agentarea-platform/libs/mcp/agentarea_mcp/domain/auth_models.py
@@ -64,9 +64,15 @@ class MCPAuthConfig(BaseModel, WorkspaceScopedMixin):
             if not self.config.get("header_name"):
                 raise ValueError("api_key auth requires 'header_name' in config")
         elif self.auth_type == AUTH_TYPE_OAUTH2:
-            for field in ("client_id", "token_url"):
-                if not self.config.get(field):
-                    raise ValueError(f"oauth2 auth requires '{field}' in config")
+            if not self.config.get("token_url"):
+                raise ValueError("oauth2 auth requires 'token_url' in config")
+            client_id = self.config.get("client_id")
+            client_id_secret_name = self.config.get("client_id_secret_name")
+            if bool(client_id) == bool(client_id_secret_name):
+                raise ValueError(
+                    "oauth2 auth requires exactly one of 'client_id' or "
+                    "'client_id_secret_name' in config"
+                )
 
 
 class MCPOAuthLink(BaseModel, WorkspaceScopedMixin):

--- a/agentarea-platform/libs/mcp/tests/test_domain_model.py
+++ b/agentarea-platform/libs/mcp/tests/test_domain_model.py
@@ -1,5 +1,6 @@
 import pytest
 from agentarea_common.base.models import BaseModel
+from agentarea_mcp.domain.auth_models import AUTH_TYPE_OAUTH2, MCPAuthConfig
 from agentarea_mcp.domain.mpc_server_instance_model import MCPServerInstance
 from agentarea_mcp.domain.verification_types import (
     DEFAULT_VERIFICATION,
@@ -28,6 +29,34 @@ class TestVerificationTypes:
         d2 = dict(DEFAULT_VERIFICATION)
         d1["status"] = "succeeded"
         assert d2["status"] == "never_attempted"
+
+
+class TestMCPAuthConfigModel:
+    def test_oauth_client_id_can_reference_a_workspace_secret(self):
+        config = MCPAuthConfig(
+            name="Metrika",
+            auth_type=AUTH_TYPE_OAUTH2,
+            config={
+                "token_url": "https://oauth.example/token",
+                "client_id_secret_name": "metrika_client_id",
+            },
+        )
+
+        config.validate_config()
+
+    def test_oauth_client_id_rejects_ambiguous_sources(self):
+        config = MCPAuthConfig(
+            name="Metrika",
+            auth_type=AUTH_TYPE_OAUTH2,
+            config={
+                "token_url": "https://oauth.example/token",
+                "client_id": "inline-id",
+                "client_id_secret_name": "metrika_client_id",
+            },
+        )
+
+        with pytest.raises(ValueError, match="exactly one"):
+            config.validate_config()
 
 
 class TestMCPServerInstanceModel:

--- a/agentarea-platform/libs/mcp/tests/test_mcp_auth_service.py
+++ b/agentarea-platform/libs/mcp/tests/test_mcp_auth_service.py
@@ -255,6 +255,29 @@ class TestOAuth2Refresh:
         assert client.posted["client_secret"] == expected_credential
         managed_sm.get_secret.assert_awaited_once_with(managed_key)
 
+    async def test_custom_refresh_resolves_workspace_secret_references(self):
+        svc, _, workspace_sm = _make_service()
+        config = _oauth_config(
+            client_id=None,
+            client_id_secret_name="metrika_client_id",  # noqa: S106
+            client_secret_secret_name="metrika_client_secret",  # noqa: S106  # pragma: allowlist secret
+        )
+        workspace_sm.get_secret.side_effect = lambda key: {
+            "k": json.dumps({"refresh_token": "refresh", "expires_at": 0}),
+            "metrika_client_id": "workspace-client-id",
+            "metrika_client_secret": "workspace-client-secret",  # pragma: allowlist secret
+        }.get(key)
+        client = _FakeClient(_FakeResp(200, {"access_token": "fresh", "expires_in": 3600}))
+
+        with patch("httpx.AsyncClient", lambda *a, **k: client):
+            headers = await svc.get_auth_headers(config)
+
+        assert headers == {"Authorization": "Bearer fresh"}
+        assert client.posted["client_id"] == "workspace-client-id"
+        assert (
+            client.posted["client_secret"] == "workspace-client-secret"  # noqa: S105  # pragma: allowlist secret
+        )
+
     async def test_force_refresh_refreshes_even_when_unexpired(self):
         svc, _, sm = _make_service()
         import time
@@ -328,6 +351,23 @@ class TestCreateDelete:
 
         repo.create.assert_not_awaited()
 
+    async def test_public_create_cannot_reference_workspace_secrets(self):
+        svc, repo, _ = _make_service()
+
+        with pytest.raises(ValueError, match="only be created by a catalog connection"):
+            await svc.create(
+                name="Forged workspace reference",
+                auth_type=AUTH_TYPE_OAUTH2,
+                config={
+                    "token_url": "https://attacker.example/token",
+                    "client_id": "attacker-id",
+                    "client_secret_secret_name": "valuable_workspace_secret",  # pragma: allowlist secret
+                },
+                credentials={},
+            )
+
+        repo.create.assert_not_awaited()
+
     async def test_public_update_cannot_redirect_managed_token_exchange(self):
         svc, repo, sm = _make_service()
         config_id = uuid4()
@@ -342,6 +382,28 @@ class TestCreateDelete:
                 config_id,
                 config={
                     **managed.config,
+                    "token_url": "https://attacker.example/token",
+                },
+            )
+
+        repo.update.assert_not_awaited()
+        sm.set_secret.assert_not_awaited()
+
+    async def test_public_update_cannot_redirect_workspace_secret_exchange(self):
+        svc, repo, sm = _make_service()
+        config_id = uuid4()
+        referenced = _oauth_config(
+            client_id=None,
+            client_id_secret_name="metrika_client_id",  # noqa: S106
+            client_secret_secret_name="metrika_client_secret",  # noqa: S106  # pragma: allowlist secret
+        )
+        repo.get.return_value = referenced
+
+        with pytest.raises(ValueError, match="only be changed by reconnecting"):
+            await svc.update(
+                config_id,
+                config={
+                    **referenced.config,
                     "token_url": "https://attacker.example/token",
                 },
             )

--- a/agentarea-webapp/packages/api-client/src/generated/types.gen.ts
+++ b/agentarea-webapp/packages/api-client/src/generated/types.gen.ts
@@ -1410,9 +1410,21 @@ export type CatalogConnectionRequest = {
      */
     client_id?: string | null;
     /**
+     * Client Id Secret Id
+     *
+     * Existing user-owned workspace secret containing the OAuth client ID.
+     */
+    client_id_secret_id?: string | null;
+    /**
      * Client Secret
      */
     client_secret?: string | null;
+    /**
+     * Client Secret Secret Id
+     *
+     * Existing user-owned workspace secret containing the OAuth client secret.
+     */
+    client_secret_secret_id?: string | null;
     /**
      * Credential Mode
      */

--- a/agentarea-webapp/packages/api-client/types/generated/types.gen.d.ts
+++ b/agentarea-webapp/packages/api-client/types/generated/types.gen.d.ts
@@ -1362,9 +1362,21 @@ export type CatalogConnectionRequest = {
      */
     client_id?: string | null;
     /**
+     * Client Id Secret Id
+     *
+     * Existing user-owned workspace secret containing the OAuth client ID.
+     */
+    client_id_secret_id?: string | null;
+    /**
      * Client Secret
      */
     client_secret?: string | null;
+    /**
+     * Client Secret Secret Id
+     *
+     * Existing user-owned workspace secret containing the OAuth client secret.
+     */
+    client_secret_secret_id?: string | null;
     /**
      * Credential Mode
      */

--- a/agentarea-webapp/src/api/client/types.gen.ts
+++ b/agentarea-webapp/src/api/client/types.gen.ts
@@ -1416,9 +1416,21 @@ export type CatalogConnectionRequest = {
    */
   client_id?: string | null;
   /**
+   * Client Id Secret Id
+   *
+   * Existing user-owned workspace secret containing the OAuth client ID.
+   */
+  client_id_secret_id?: string | null;
+  /**
    * Client Secret
    */
   client_secret?: string | null;
+  /**
+   * Client Secret Secret Id
+   *
+   * Existing user-owned workspace secret containing the OAuth client secret.
+   */
+  client_secret_secret_id?: string | null;
   /**
    * Credential Mode
    */

--- a/agentarea-webapp/src/api/client/zod.gen.ts
+++ b/agentarea-webapp/src/api/client/zod.gen.ts
@@ -469,7 +469,9 @@ export const zBundleSkill = z.object({
  */
 export const zCatalogConnectionRequest = z.object({
   client_id: z.string().min(1).max(512).nullish(),
+  client_id_secret_id: z.string().uuid().nullish(),
   client_secret: z.string().min(1).max(4096).nullish(),
+  client_secret_secret_id: z.string().uuid().nullish(),
   credential_mode: z.enum(["managed", "custom"]).optional().default("managed"),
   return_to: z.string().max(2048).optional().default(""),
 });

--- a/agentarea-webapp/src/api/openapi.json
+++ b/agentarea-webapp/src/api/openapi.json
@@ -2464,6 +2464,19 @@
             ],
             "title": "Client Id"
           },
+          "client_id_secret_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Existing user-owned workspace secret containing the OAuth client ID.",
+            "title": "Client Id Secret Id"
+          },
           "client_secret": {
             "anyOf": [
               {
@@ -2476,6 +2489,19 @@
               }
             ],
             "title": "Client Secret"
+          },
+          "client_secret_secret_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Existing user-owned workspace secret containing the OAuth client secret.",
+            "title": "Client Secret Secret Id"
           },
           "credential_mode": {
             "default": "managed",

--- a/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
+++ b/agentarea-webapp/src/app/(main)/bundles/components/CatalogGallery.tsx
@@ -36,6 +36,10 @@ import {
 } from "lucide-react";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { Streamdown } from "streamdown";
+import type {
+  CatalogConnectionRequest,
+  SecretResponse,
+} from "@/api/client/types.gen";
 import { AgentAvatar } from "@/components/AgentAvatar";
 import EmptyState from "@/components/EmptyState";
 import HeaderTabs from "@/components/HeaderTabs";
@@ -80,6 +84,7 @@ import {
   listActiveModelInstancesAction,
   listSkillFilesAction,
   listWorkspaceAgentsAction,
+  listWorkspaceSecretsAction,
   type AgentLite,
   type WorkspaceModel,
 } from "./actions";
@@ -1048,6 +1053,14 @@ type SetupTier =
   | "needs_tenant_config"
   | "unverified";
 
+type CustomOAuthAppInput = Pick<
+  CatalogConnectionRequest,
+  | "client_id"
+  | "client_secret"
+  | "client_id_secret_id"
+  | "client_secret_secret_id"
+>;
+
 function DetailView({
   entry,
   onBack,
@@ -1107,14 +1120,13 @@ function DetailView({
 
   async function connectCatalogApi(
     credentialMode: "managed" | "custom",
-    custom?: { clientId: string; clientSecret: string }
+    custom?: CustomOAuthAppInput
   ) {
     setState({ phase: "connecting" });
     try {
       const result = await connectCatalogConnectionAction(entry.id, {
         credential_mode: credentialMode,
-        client_id: custom?.clientId,
-        client_secret: custom?.clientSecret,
+        ...custom,
         return_to: window.location.origin,
       });
       window.location.assign(result.authorize_url);
@@ -1424,14 +1436,54 @@ function CustomOAuthApp({
   onConnect,
 }: {
   connecting: boolean;
-  onConnect: (credentials: { clientId: string; clientSecret: string }) => void;
+  onConnect: (credentials: CustomOAuthAppInput) => void;
 }) {
+  const manual = "manual";
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
-  const ready = clientId.trim().length > 0 && clientSecret.length > 0;
+  const [clientIdSource, setClientIdSource] = useState(manual);
+  const [clientSecretSource, setClientSecretSource] = useState(manual);
+  const [secrets, setSecrets] = useState<SecretResponse[] | null>(null);
+  const [secretsError, setSecretsError] = useState<string | null>(null);
+  const loadingSecrets = useRef(false);
+  const reusableSecrets = (secrets ?? []).filter((secret) => !secret.owner);
+  const ready =
+    (clientIdSource !== manual || clientId.trim().length > 0) &&
+    (clientSecretSource !== manual || clientSecret.length > 0);
+
+  async function loadSecrets() {
+    if (secrets !== null || loadingSecrets.current) return;
+    loadingSecrets.current = true;
+    setSecretsError(null);
+    try {
+      setSecrets(await listWorkspaceSecretsAction());
+    } catch (error) {
+      setSecretsError(
+        error instanceof Error ? error.message : "Failed to load workspace secrets"
+      );
+    } finally {
+      loadingSecrets.current = false;
+    }
+  }
+
+  function connect() {
+    onConnect({
+      client_id: clientIdSource === manual ? clientId.trim() : undefined,
+      client_secret: clientSecretSource === manual ? clientSecret : undefined,
+      client_id_secret_id:
+        clientIdSource === manual ? undefined : clientIdSource,
+      client_secret_secret_id:
+        clientSecretSource === manual ? undefined : clientSecretSource,
+    });
+  }
 
   return (
-    <details className="group rounded-lg border border-border/60">
+    <details
+      className="group rounded-lg border border-border/60"
+      onToggle={(event) => {
+        if (event.currentTarget.open) void loadSecrets();
+      }}
+    >
       <summary className="cursor-pointer list-none px-3 py-2.5 text-xs font-medium text-muted-foreground hover:text-foreground">
         Advanced
       </summary>
@@ -1439,28 +1491,71 @@ function CustomOAuthApp({
         <p className="text-xs text-muted-foreground">
           Use your own OAuth app credentials instead of the AgentArea app.
         </p>
-        <div className="grid gap-2 sm:grid-cols-2">
-          <Input
-            value={clientId}
-            onChange={(event) => setClientId(event.target.value)}
-            aria-label="OAuth client ID"
-            placeholder="Client ID"
-            autoComplete="off"
-          />
-          <Input
-            value={clientSecret}
-            onChange={(event) => setClientSecret(event.target.value)}
-            aria-label="OAuth client secret"
-            placeholder="Client secret"
-            type="password"
-            autoComplete="new-password"
-          />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Select value={clientIdSource} onValueChange={setClientIdSource}>
+              <SelectTrigger aria-label="OAuth client ID source">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={manual}>Enter client ID</SelectItem>
+                {reusableSecrets.map((secret) => (
+                  <SelectItem key={secret.id} value={secret.id}>
+                    {secret.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {clientIdSource === manual && (
+              <Input
+                value={clientId}
+                onChange={(event) => setClientId(event.target.value)}
+                aria-label="OAuth client ID"
+                placeholder="Client ID"
+                autoComplete="off"
+              />
+            )}
+          </div>
+          <div className="space-y-2">
+            <Select
+              value={clientSecretSource}
+              onValueChange={setClientSecretSource}
+            >
+              <SelectTrigger aria-label="OAuth client secret source">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={manual}>Enter client secret</SelectItem>
+                {reusableSecrets.map((secret) => (
+                  <SelectItem key={secret.id} value={secret.id}>
+                    {secret.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {clientSecretSource === manual && (
+              <Input
+                value={clientSecret}
+                onChange={(event) => setClientSecret(event.target.value)}
+                aria-label="OAuth client secret"
+                placeholder="Client secret"
+                type="password"
+                autoComplete="new-password"
+              />
+            )}
+          </div>
         </div>
+        {secretsError && <p className="text-xs text-red-600">{secretsError}</p>}
+        {secrets !== null && reusableSecrets.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            No reusable workspace secrets yet. You can enter both values here.
+          </p>
+        )}
         <Button
           size="sm"
           variant="outline"
           disabled={!ready || connecting}
-          onClick={() => onConnect({ clientId: clientId.trim(), clientSecret })}
+          onClick={connect}
         >
           Connect with custom app
         </Button>

--- a/agentarea-webapp/src/app/(main)/bundles/components/actions.ts
+++ b/agentarea-webapp/src/app/(main)/bundles/components/actions.ts
@@ -11,6 +11,7 @@ import type {
   InstallResult,
   ModelInstanceResponse,
   RegistryItemResponse,
+  SecretResponse,
   SkillFileResponse,
 } from "@/api/client/types.gen";
 import {
@@ -29,6 +30,7 @@ import {
   zInstallSkillV1SkillsSkillIdInstallPostResponse,
   zListAgentsV1AgentsGetResponse,
   zListModelInstancesV1ModelInstancesGetResponse,
+  zListSecretsV1SecretsGetResponse,
   zListSkillFilesV1SkillsSkillIdFilesGetResponse,
   zUpdateAgentV1AgentsAgentIdPatchResponse,
 } from "@/api/client/zod.gen";
@@ -46,6 +48,7 @@ import {
   installSkill,
   listAgents,
   listModelInstances,
+  listSecrets,
   updateAgent,
 } from "@/lib/api";
 import { PAGE, TYPE_KEYS, type CatalogType } from "./catalog-data";
@@ -59,6 +62,14 @@ export type WorkspaceModel = Pick<
   | "provider_name"
   | "provider_icon_url"
 >;
+
+export async function listWorkspaceSecretsAction(): Promise<SecretResponse[]> {
+  const { data, error } = await listSecrets();
+  if (error || !data) {
+    throw new Error(errorMessage(error, "Failed to load workspace secrets"));
+  }
+  return zListSecretsV1SecretsGetResponse.parse(data);
+}
 
 function errorMessage(error: unknown, fallback: string): string {
   if (!error) return fallback;

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -2464,6 +2464,19 @@
             ],
             "title": "Client Id"
           },
+          "client_id_secret_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Existing user-owned workspace secret containing the OAuth client ID.",
+            "title": "Client Id Secret Id"
+          },
           "client_secret": {
             "anyOf": [
               {
@@ -2476,6 +2489,19 @@
               }
             ],
             "title": "Client Secret"
+          },
+          "client_secret_secret_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Existing user-owned workspace secret containing the OAuth client secret.",
+            "title": "Client Secret Secret Id"
           },
           "credential_mode": {
             "default": "managed",


### PR DESCRIPTION
## Summary
- let custom catalog OAuth connections independently enter or select client ID and client secret
- resolve selected workspace secrets dynamically and track references so rotation works and deletion is guarded
- restrict workspace-secret-backed OAuth configs to the trusted catalog flow
- regenerate web and docs OpenAPI contracts

## Validation
- `make lint` (pyright: 0 errors)
- `make test` (3112 passed, 57 skipped)
- `pnpm run lint`
- `pnpm run build`
- OpenAPI export and generated-client drift checks