### PR TITLE
fix(connections): allow multiple catalog accounts

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/api/v1/connection_oauth.py
+++ b/agentarea-platform/apps/api/agentarea_api/api/v1/connection_oauth.py
@@ -130,10 +130,11 @@ async def _store_state(state: str, payload: dict[str, Any]) -> None:
 async def _pop_state(state: str) -> dict[str, Any] | None:
     redis = await _redis()
     key = f"{_STATE_PREFIX}:{state}"
-    raw = await redis.get(key)
+    # Consume state in one operation so concurrent/replayed callbacks cannot
+    # both exchange the same authorization code.
+    raw = await redis.getdel(key)
     if raw is None:
         return None
-    await redis.delete(key)
     return json.loads(raw)
 
 
@@ -364,20 +365,20 @@ async def connect_catalog_item(
         secret_manager=workspace_secret_manager,
         allow_private_urls=get_settings().mcp.ALLOW_PRIVATE_URLS,
     )
-    connection = await connection_service.get_by_registry_item_id(item_id)
-    if connection is None:
-        connection = await connection_service.create_connection(
-            OpenAPIConnectionCreate(
-                name=item.name,
-                description=item.description,
-                base_url=base_url,
-                spec_url=spec.get("spec_url"),
-                spec_content=spec.get("spec_content"),
-            ),
-            registry_item_id=item_id,
-            allowed_auth_origins=[str(origin) for origin in allowed_origins],
-            status="pending",
-        )
+    # A catalog item is a reusable connection definition, not a singleton.
+    # Each authorization creates an independently governable account instance.
+    connection = await connection_service.create_connection(
+        OpenAPIConnectionCreate(
+            name=item.name,
+            description=item.description,
+            base_url=base_url,
+            spec_url=spec.get("spec_url"),
+            spec_content=spec.get("spec_content"),
+        ),
+        registry_item_id=item_id,
+        allowed_auth_origins=[str(origin) for origin in allowed_origins],
+        status="pending",
+    )
 
     auth_service = MCPAuthService(
         MCPAuthConfigRepository(db_session, user_context),

--- a/agentarea-platform/apps/api/alembic/versions/20260908_1000_allow_multiple_catalog_connections.py
+++ b/agentarea-platform/apps/api/alembic/versions/20260908_1000_allow_multiple_catalog_connections.py
@@ -1,0 +1,35 @@
+"""Allow multiple connection instances from one catalog item.
+
+Revision ID: 20260908_1000_multi_catalog_conn
+Revises: 20260907_1300_openapi_registry
+Create Date: 2026-09-08 10:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260908_1000_multi_catalog_conn"
+down_revision: str | None = "20260907_1300_openapi_registry"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # registry_item_id identifies the reusable catalog definition. It must not
+    # make that definition a singleton within a workspace.
+    op.drop_constraint(
+        "uq_openapi_conn_workspace_registry",
+        "openapi_connections",
+        type_="unique",
+    )
+
+
+def downgrade() -> None:
+    # Downgrade is intentionally strict: if a workspace created multiple
+    # instances, PostgreSQL will refuse to discard that valid data implicitly.
+    op.create_unique_constraint(
+        "uq_openapi_conn_workspace_registry",
+        "openapi_connections",
+        ["workspace_id", "registry_item_id"],
+    )

--- a/agentarea-platform/apps/api/tests/test_connection_oauth.py
+++ b/agentarea-platform/apps/api/tests/test_connection_oauth.py
@@ -1,5 +1,6 @@
 """Contract and trust-boundary tests for one-click connection OAuth."""
 
+import json
 import urllib.parse
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
@@ -74,10 +75,6 @@ async def test_connect_uses_requested_credential_source_without_secret_in_state(
     class _ConnectionService:
         def __init__(self, *_args, **_kwargs):
             pass
-
-        async def get_by_registry_item_id(self, requested_id):
-            assert requested_id == item_id
-            return None
 
         create_connection = connection_create
 
@@ -160,6 +157,8 @@ async def test_connect_uses_requested_credential_source_without_secret_in_state(
     )
 
     assert response.connection_id == connection_id
+    connection_create.assert_awaited_once()
+    assert connection_create.await_args.kwargs["registry_item_id"] == item_id
     query = urllib.parse.parse_qs(urllib.parse.urlparse(response.authorize_url).query)
     expected_client_id = {
         "managed": "managed-client-id",
@@ -204,6 +203,16 @@ async def test_connect_uses_requested_credential_source_without_secret_in_state(
     state_payload = stored_state.await_args.args[1]
     assert "client_secret" not in state_payload
     assert state_payload["connection_id"] == str(connection_id)
+
+
+@pytest.mark.asyncio
+async def test_oauth_state_is_consumed_atomically(monkeypatch):
+    payload = {"connection_id": str(uuid4())}
+    redis = SimpleNamespace(getdel=AsyncMock(return_value=json.dumps(payload)))
+    monkeypatch.setattr(connection_oauth, "_redis", AsyncMock(return_value=redis))
+
+    assert await connection_oauth._pop_state("one-time-state") == payload
+    redis.getdel.assert_awaited_once_with("connection_oauth_state:one-time-state")
 
 
 def test_custom_connect_requires_exactly_one_source_per_credential():

--- a/agentarea-platform/libs/openapi/agentarea_openapi/application/service.py
+++ b/agentarea-platform/libs/openapi/agentarea_openapi/application/service.py
@@ -313,9 +313,6 @@ class OpenAPIConnectionService:
             )
         return headers
 
-    async def get_by_registry_item_id(self, registry_item_id: UUID) -> OpenAPIConnection | None:
-        return await self._repo.get_by_registry_item_id(registry_item_id)
-
     async def get_connection(self, connection_id: UUID) -> OpenAPIConnection | None:
         return await self._repo.get_by_id(str(connection_id))
 

--- a/agentarea-platform/libs/openapi/agentarea_openapi/domain/models.py
+++ b/agentarea-platform/libs/openapi/agentarea_openapi/domain/models.py
@@ -4,7 +4,7 @@ from typing import Any
 from uuid import UUID
 
 from agentarea_common.base.models import BaseModel, WorkspaceScopedMixin
-from sqlalchemy import JSON, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import JSON, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -17,14 +17,6 @@ class OpenAPIConnection(BaseModel, WorkspaceScopedMixin):
     """
 
     __tablename__ = "openapi_connections"
-    __table_args__ = (
-        UniqueConstraint(
-            "workspace_id",
-            "registry_item_id",
-            name="uq_openapi_conn_workspace_registry",
-        ),
-    )
-
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     spec_url: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/agentarea-platform/libs/openapi/agentarea_openapi/infrastructure/repository.py
+++ b/agentarea-platform/libs/openapi/agentarea_openapi/infrastructure/repository.py
@@ -1,7 +1,5 @@
 """Repository for OpenAPIConnection CRUD operations."""
 
-from uuid import UUID
-
 from agentarea_common.auth.context import UserContext
 from agentarea_common.base.workspace_scoped_repository import WorkspaceScopedRepository
 from sqlalchemy import func, or_, select
@@ -13,13 +11,6 @@ from agentarea_openapi.domain.models import OpenAPIConnection
 class OpenAPIConnectionRepository(WorkspaceScopedRepository[OpenAPIConnection]):
     def __init__(self, session: AsyncSession, user_context: UserContext):
         super().__init__(session, OpenAPIConnection, user_context)
-
-    async def get_by_registry_item_id(self, registry_item_id: UUID) -> OpenAPIConnection | None:
-        query = select(self.model_class).where(
-            self._get_workspace_filter(),
-            self.model_class.registry_item_id == registry_item_id,
-        )
-        return (await self.session.execute(query)).scalar_one_or_none()
 
     async def list_connections(
         self,

--- a/agentarea-platform/libs/openapi/tests/test_models.py
+++ b/agentarea-platform/libs/openapi/tests/test_models.py
@@ -1,9 +1,19 @@
 """Tests for OpenAPIConnection domain model."""
 
 from agentarea_openapi.domain.models import OpenAPIConnection
+from sqlalchemy import UniqueConstraint
 
 
 class TestOpenAPIConnectionModel:
+    def test_catalog_item_can_have_multiple_workspace_connections(self):
+        unique_column_sets = {
+            tuple(column.name for column in constraint.columns)
+            for constraint in OpenAPIConnection.__table__.constraints
+            if isinstance(constraint, UniqueConstraint)
+        }
+
+        assert ("workspace_id", "registry_item_id") not in unique_column_sets
+
     def test_create_with_spec_url(self):
         conn = OpenAPIConnection(
             name="Stripe API",


### PR DESCRIPTION
## What changed
- treat catalog entries as reusable connection definitions rather than workspace singletons
- create a separate OpenAPI connection and OAuth config on every Connect
- remove the workspace/catalog uniqueness constraint with an Alembic migration
- consume OAuth state atomically to prevent callback replay races

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `make test` (3168 selected tests passed)
- PostgreSQL 15: fresh `alembic upgrade head`, `downgrade -1`, `upgrade head`