### PR TITLE
feat(api): let an installed extension contribute routes

### DIFF
--- a/agentarea-platform/apps/api/agentarea_api/main.py
+++ b/agentarea-platform/apps/api/agentarea_api/main.py
@@ -335,6 +335,31 @@ def create_app() -> FastAPI:
     app.include_router(public_v1_router, tags=["v1"])
     app.include_router(protected_v1_router, tags=["v1"])
 
+    # Routes contributed by installed extensions.
+    #
+    # The registry already lets a distribution replace a service implementation; this lets
+    # one add endpoints, which is the other half of the same seam. It exists so a
+    # deployment can serve routes this repository does not ship without forking the app
+    # factory — the alternative being a fork whose only diff is one include_router call,
+    # which then has to be rebased forever.
+    #
+    # Mounted last so an extension cannot shadow a core route by registering the same
+    # path: FastAPI matches in insertion order, and the routes above are the contract this
+    # project is responsible for.
+    #
+    # A failing extension must not take the API down with it. The registry is populated by
+    # scanning installed packages, so a broken one is a deployment problem, and refusing
+    # to start turns "one feature is unavailable" into "nothing is".
+    from agentarea_common.extensions.registry import ExtensionRegistry
+
+    extension_router_factory = ExtensionRegistry.get_factory("api_router")
+    if extension_router_factory is not None:
+        try:
+            app.include_router(extension_router_factory())
+            logger.info("Mounted routes from the api_router extension")
+        except Exception:
+            logger.exception("api_router extension failed to mount; continuing without it")
+
     # Mount native MCP server at /mcp — exposes platform tools via MCP protocol.
     # Auth: Hydra OAuth tokens (Cursor/Claude Desktop), API keys, Kratos JWT.
     # Session manager lifespan is run in _lifespan (above) so the task group


### PR DESCRIPTION
Two halves of one seam: extensions can contribute routes, and the billing page can show a prepaid balance and take a top-up.

### Extensions can add endpoints

`ExtensionRegistry` already lets a distribution swap a service implementation. Adding endpoints is the other half of the same idea, and without it a deployment that serves an endpoint this repo does not ship has to fork the app factory — a fork whose only diff is one `include_router` call, which then gets rebased forever.

Mounted **last**, so an extension cannot shadow a core route by claiming the same path: FastAPI matches in insertion order, and the routes above are the contract this project owns. A failing extension is logged and skipped rather than fatal — the registry is filled by scanning installed packages, so a broken one is a deployment problem, and refusing to boot turns "one feature is unavailable" into "nothing is".

### The billing page grows a balance

The page already called `/v1/billing/overview` and treated 404 as "this deployment does not sell anything". That shape was right and is kept: `balance` is **optional**, so an install with no billing service renders exactly as it does today and no wallet appears.

Things here that are not cosmetic:

| | |
|---|---|
| Client sends only an amount | The account credited is resolved from the session. A client-supplied id would let anyone top up — or name — someone else's balance |
| Spendable = balance + credit limit | A postpaid account sitting at zero is not shown as empty |
| Action returns a URL, does not redirect | A server action that redirects offsite cannot tell the customer why the provider declined |
| 400 for a missing contact is a prompt | Fiscal receipts (54-FZ) need an address; the field appears and the customer retries |

### `/billing/return` does not claim success

This is the part worth reviewing carefully. The provider redirects there **as soon as the customer leaves its page** — before, and independently of, the notification that actually credits the balance. Treating arrival as success would tell someone whose card was declined that their money arrived.

So the page says the payment is being confirmed and points at the balance, which is the only honest source.

### Verification

- `tsc --noEmit` clean across the app
- `eslint` clean on the changed files
- `prettier` formatted
- `en` and `ru` translations both added
